### PR TITLE
Fully independent virtio and ukvm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,8 @@
 *.pcap
 cscope.*
 iso/boot/kernel
-kernel.iso
 kernel/kernel
 kernel/interrupt_vectors.s
-kernel/test_*.ukvm
-kernel/test_*.virtio
-ukvm/ukvm
-disk.img
-test.iso
+tests/*/*.ukvm
+tests/*/*.virtio
+tests/*/ukvm-bin

--- a/solo5-kernel-ukvm.opam
+++ b/solo5-kernel-ukvm.opam
@@ -6,7 +6,7 @@ dev-repo:     "https://github.com/solo5/solo5.git"
 authors:      [ "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" "Ricardo Koller <kollerr@us.ibm.com>"]
 license:      "ISC"
 
-build:  [make "ukvm_target"]
+build:  [make "ukvm"]
 install:[make "opam-ukvm-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-ukvm-uninstall" "PREFIX=%{prefix}%"]
 

--- a/solo5-kernel-virtio.opam
+++ b/solo5-kernel-virtio.opam
@@ -6,7 +6,7 @@ dev-repo:     "https://github.com/solo5/solo5.git"
 authors:      [ "Dan Williams <djwillia@us.ibm.com>" "Martin Lucina <martin@lucina.net>" "Ricardo Koller <kollerr@us.ibm.com>"]
 license:      "ISC"
 
-build:  [make "virtio_target"]
+build:  [make "virtio"]
 install:[make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,17 +1,24 @@
 TESTDIRS=test_hello test_ping_serve
 
-TESTS=$(subst test, _test, $(TESTDIRS))
+UKVM_TESTS=$(subst test, _test_ukvm, $(TESTDIRS))
+VIRTIO_TESTS=$(subst test, _test_virtio, $(TESTDIRS))
 CLEANS=$(subst test, _clean, $(TESTDIRS))
 
-all: $(TESTS)
+all: $(UKVM_TESTS) $(VIRTIO_TESTS)
+
+ukvm: $(UKVM_TESTS)
+
+virtio: $(VIRTIO_TESTS)
+
 clean: $(CLEANS)
 
 .PHONY: force_it
 
-_test_%: force_it
-	make -C $(subst _test, test, $@)
+_test_ukvm%: force_it
+	$(MAKE) -C $(subst _test_ukvm, test, $@) ukvm
+
+_test_virtio%: force_it
+	$(MAKE) -C $(subst _test_virtio, test, $@) virtio
 
 _clean_%: force_it
-	make -C $(subst _clean, test, $@) clean
-
-
+	$(MAKE) -C $(subst _clean, test, $@) clean

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -1,4 +1,8 @@
-all: $(UKVM_TARGETS) $(VIRTIO_TARGETS)
+.PHONY: ukvm
+ukvm: $(UKVM_TARGETS)
+
+.PHONY: virtio
+virtio:	$(VIRTIO_TARGETS)
 
 SOLO5_DIR=../../kernel
 UKVM_SRC=../../ukvm
@@ -8,7 +12,6 @@ CFLAGS+=-I$(SOLO5_DIR)
 
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c $< -o $@
-
 
 ifdef UKVM_TARGETS
 Makefile.ukvm: $(UKVM_SRC)/ukvm-configure
@@ -26,8 +29,6 @@ else
 .PHONY: ukvm-clean
 endif
 
-
-
 ifdef VIRTIO_TARGETS
 %.virtio: %.o $(SOLO5_DIR)/virtio/solo5.lds $(SOLO5_DIR)/virtio/solo5.o
 	$(LD) -T $(SOLO5_DIR)/virtio/solo5.lds \
@@ -36,7 +37,6 @@ ifdef VIRTIO_TARGETS
 $(SOLO5_DIR)/virtio/solo5.o: 
 	$(MAKE) -C $(SOLO5_DIR) virtio
 endif
-
 
 .PHONY: clean
 clean: ukvm-clean


### PR DESCRIPTION
In #64 the tests are split out into their own subdirectories, however it
is no longer possible to build only for ukvm or virtio. As the ukvm
target is Linux-specific, this is not ideal.

Summary of changes:

- Allow independent build of ukvm or virtio. The default make target is
  still "everything".
- Rename top-level targets to just "ukvm" and "virtio", to be consistent
  with sub-Makefiles.
- Ensure that the tests are always built. This is important since now
  the ukvm binary is no longer built at Solo5 build time but rather
  at unikernel build time (#64) we need to be sure that all components
  build correctly at any given point.
- The rest is just cosmetics and cleanups, removal of unused top-level
  Makefile targets and fixes for parallel make.