### PR TITLE
ukvm-configure fixes

### DIFF
--- a/ukvm/ukvm-configure
+++ b/ukvm/ukvm-configure
@@ -4,10 +4,14 @@ if [ "$#" -lt 1 ]; then
     echo "Usage: ukvm-configure UKVM_SRC [MODULES]"
     echo "    UKVM_SRC is /path/to/ukvm"
     echo "    MODULES can be any combination of: net blk gdb"
-    exit
+    exit 1
 fi
 
-UKVM_SRC=`readlink -e $1`
+UKVM_SRC=`readlink -f $1`
+if [ ! -d ${UKVM_SRC} -o ! -f ${UKVM_SRC}/ukvm-core.c ]; then
+    echo "Error: Not a ukvm source directory: ${UKVM_SRC}" 1>&2
+    exit 1
+fi
 shift
 UKVM_MODULES=$@
 


### PR DESCRIPTION
- Fails to build on alpine due to busybox readlink not supporting '-e'.
- Add extra error checks to ensure UKVM_SRC looks like a ukvm source
  directory.