### PR TITLE
fix make virtio and make clean

### DIFF
--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -13,11 +13,11 @@ CFLAGS+=-I$(SOLO5_DIR)
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-ifdef UKVM_TARGETS
 Makefile.ukvm: $(UKVM_SRC)/ukvm-configure
 	$(UKVM_SRC)/ukvm-configure $(UKVM_SRC) $(UKVM_MODULES)
 
-include Makefile.ukvm
+.PHONY: ukvm-clean
+-include Makefile.ukvm
 
 %.ukvm: %.o $(SOLO5_DIR)/ukvm/solo5.lds $(SOLO5_DIR)/ukvm/solo5.o
 	$(LD) -T $(SOLO5_DIR)/ukvm/solo5.lds \
@@ -25,18 +25,13 @@ include Makefile.ukvm
 
 $(SOLO5_DIR)/ukvm/solo5.o: 
 	$(MAKE) -C $(SOLO5_DIR) ukvm
-else
-.PHONY: ukvm-clean
-endif
 
-ifdef VIRTIO_TARGETS
 %.virtio: %.o $(SOLO5_DIR)/virtio/solo5.lds $(SOLO5_DIR)/virtio/solo5.o
 	$(LD) -T $(SOLO5_DIR)/virtio/solo5.lds \
 			 $(LDFLAGS) -o $@ $(SOLO5_DIR)/virtio/solo5.o $< $(LDLIBS)
 
 $(SOLO5_DIR)/virtio/solo5.o: 
 	$(MAKE) -C $(SOLO5_DIR) virtio
-endif
 
 .PHONY: clean
 clean: ukvm-clean


### PR DESCRIPTION
the `test_hello` defines both UKVM_TARGETS and VIRTIO_TARGETS, but there's no Makefile.ukvm generated when virtio tests are run: ignore failing to load it (and provide a phony ukvm-clean)