### PR TITLE
Adding a blk test kernel for the solo5 interface

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-TESTDIRS=test_hello test_ping_serve
+TESTDIRS=test_hello test_ping_serve test_blk
 
 UKVM_TESTS=$(subst test, _test_ukvm, $(TESTDIRS))
 VIRTIO_TESTS=$(subst test, _test_virtio, $(TESTDIRS))

--- a/tests/test_blk/Makefile
+++ b/tests/test_blk/Makefile
@@ -1,0 +1,5 @@
+UKVM_TARGETS=test_blk.ukvm ukvm-bin
+VIRTIO_TARGETS=test_blk.virtio
+UKVM_MODULES=blk
+
+include ../Makefile.tests

--- a/tests/test_blk/test_blk.c
+++ b/tests/test_blk/test_blk.c
@@ -1,0 +1,43 @@
+#include "solo5.h"
+
+#define SECTOR_SIZE	512
+
+int check_sector_write(uint64_t offset)
+{
+    uint8_t sector_write[SECTOR_SIZE];
+    uint8_t sector_read[SECTOR_SIZE];
+    int n = SECTOR_SIZE;
+    int i;
+
+    for (i = 0; i < SECTOR_SIZE; i++)
+        sector_write[i] = '0' + i % 10;
+
+    solo5_blk_write_sync(offset, sector_write, SECTOR_SIZE);
+    solo5_blk_read_sync(offset, sector_read, &n);
+
+    if (n != SECTOR_SIZE)
+        return 1;
+    
+    for (i = 0; i < SECTOR_SIZE; i++) {
+        if (sector_write[i] != '0' + i % 10)
+            /* Check failed */
+            return 1;
+    }
+
+    return 0;
+}
+
+/* Returns 0 if the tests pass, 1 otherwise. */
+int solo5_app_main(char *cmdline __attribute__((unused)))
+{
+    uint64_t i;
+
+    /* Write and read/check one tenth of the disk. */
+    for (i = 0; i < solo5_blk_sectors(); i += 10) {
+        if (check_sector_write(i * SECTOR_SIZE))
+            /* Check failed */
+            return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This is a small test for the solo5 blk IO interface. It just writes some sectors and checks that the read content matches.

```
./ukvm-bin --disk=/home/opam/disk.img ./test_blk.ukvm

qemu-system-x86_64 -s -nographic -name foo -m 1024 -kernel test_blk.virtio -device virtio-net,netdev=n0 -netdev tap,id=n0,ifname=tap100,script=no,downscript=no -drive file=/home/opam/disk.img,if=virtio
```