### PR TITLE
Memory layout fixes

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -83,7 +83,7 @@ virtio/solo5.o: $(VIRTIO_COBJS) $(SOBJS) virtio/solo5.lds
 
 ukvm/solo5.o: $(UKVM_COBJS) $(SOBJS) ukvm/solo5.lds
 	$(LD) -r $(LDFLAGS) -o $@ $(UKVM_COBJS) $(SOBJS) 
-	$(OBJCOPY) -w -G solo5_\* -G kernel_main $@ $@
+	$(OBJCOPY) -w -G solo5_\* -G _start $@ $@
 
 .PHONY: clean
 clean:

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -26,21 +26,20 @@ stubs.o \
 pvclock.o
 
 UKVM_COBJS=\
-$(COMMON_COBJS) \
+ukvm/kernel.o \
 ukvm/gdt.o \
 ukvm/io.o \
-ukvm/kernel.o \
 ukvm/low_level.o \
 ukvm/low_level_interrupts.o \
 ukvm/mem.o \
-ukvm/time.o
+ukvm/time.o \
+$(COMMON_COBJS)
 
 VIRTIO_COBJS=\
-$(COMMON_COBJS) \
 virtio/boot.o \
+virtio/kernel.o \
 virtio/low_level.o \
 virtio/low_level_interrupts.o \
-virtio/kernel.o \
 virtio/mem.o \
 virtio/net.o \
 virtio/pci.o \
@@ -48,9 +47,9 @@ virtio/serial.o \
 virtio/time.o \
 virtio/virtio.o \
 virtio/tscclock.o \
-virtio/clock_subr.o
+virtio/clock_subr.o \
+$(COMMON_COBJS)
 
-COBJS=$(COMMON_COBJS) $(VIRTIO_COBJS)
 SOBJS=\
 kernel_s.o \
 mem_s.o \

--- a/kernel/ukvm/kernel.c
+++ b/kernel/ukvm/kernel.c
@@ -26,7 +26,7 @@ static void banner(void)
     printf("____/\\___/ _|\\___/____/\n");
 }
 
-void kernel_main(struct ukvm_boot_info *bi)
+void _start(struct ukvm_boot_info *bi)
 {
     int ret;
 

--- a/kernel/ukvm/solo5.lds
+++ b/kernel/ukvm/solo5.lds
@@ -1,36 +1,57 @@
-ENTRY(kernel_main)
+ENTRY(_start)
 
 SECTIONS {
-
-    /* kernel at 1MB */
     . = 0x100000;
 
-	.text BLOCK(4K) : ALIGN(4K)
-	{
-		*(.text)
-	}
+    /* Code */
+    _stext = .;
 
-	/* Read-only data. */
-	.rodata BLOCK(4K) : ALIGN(4K)
-	{
-		*(.rodata)
-	}
+    .text :
+    {
+        *(.text)
+        *(.text.*)
+    }
 
-	/* Read-write data (initialized) */
-	.data BLOCK(4K) : ALIGN(4K)
-	{
-		*(.data)
-	}
+    . = ALIGN(0x1000);
+    _etext = .;
 
-	/* Read-write data (uninitialized) */
-    bss_start = .;
-	.bss BLOCK(4K) : ALIGN(4K)
-	{
-		*(COMMON)
-		*(.bss)
-	}
-    bss_end = .;
+    /* Read-only data */
+    .rodata :
+    {
+        *(.rodata)
+        *(.rodata.*)
+    }
+    .eh_frame :
+    {
+        *(.eh_frame)
+    }
 
-	/* The compiler may produce other sections, by default it will put them in
-	   a segment with the same name. Simply add stuff here as needed. */
+    . = ALIGN(0x1000);
+    _erodata = .;
+
+    /* Read-write data (initialized) */
+    .got :
+    {
+        *(.got.plt)
+        *(.got)
+    }
+    .data :
+    {
+        *(.data)
+        *(.data.*)
+    }
+
+    . = ALIGN(0x1000);
+    _edata = .;
+
+    /* Read-write data (uninitialized) */
+    .bss :
+    {
+        *(.bss)
+        *(COMMON)
+    }
+
+    . = ALIGN(0x1000);
+    _ebss = .;
+    _end = .;
 }

--- a/kernel/virtio/boot.S
+++ b/kernel/virtio/boot.S
@@ -49,6 +49,8 @@ bootstrap:
 .long _ebss
 .long _start
 
+.data
+
 .space 4096
 bootstack:
 

--- a/kernel/virtio/solo5.lds
+++ b/kernel/virtio/solo5.lds
@@ -2,36 +2,64 @@ ENTRY(_start)
 
 SECTIONS {
     . = 0x100000;
-    
+
+    /* Multiboot header */
     .bootstrap :
     {
         *(.bootstrap)
     }
 
-    .text BLOCK(4K) : ALIGN(4K)
+    . = ALIGN(0x1000);
+
+    /* Code */
+    _stext = .;
+
+    .text :
     {
         *(.text)
+        *(.text.*)
     }
 
-    /* Read-only data. */
-    .rodata BLOCK(4K) : ALIGN(4K)
+    . = ALIGN(0x1000);
+    _etext = .;
+
+    /* Read-only data */
+    .rodata :
     {
         *(.rodata)
+        *(.rodata.*)
+    }
+    .eh_frame :
+    {
+        *(.eh_frame)
     }
 
+    . = ALIGN(0x1000);
+    _erodata = .;
+
     /* Read-write data (initialized) */
-    .data BLOCK(4K) : ALIGN(4K)
+    .got :
+    {
+        *(.got.plt)
+        *(.got)
+    }
+    .data :
     {
         *(.data)
+        *(.data.*)
     }
+
+    . = ALIGN(0x1000);
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .bss BLOCK(4K) : ALIGN(4K)
+    .bss :
     {
-        *(COMMON)
         *(.bss)
+        *(COMMON)
     }
+
+    . = ALIGN(0x1000);
     _ebss = .;
     _end = .;
 }


### PR DESCRIPTION
Summary of changes:
- New, unified, linker scripts for ukvm and virtio. Addresses #73.
- Mainly cosmetic changes to link order and bootstrap stack placement. Makes eyeballing the symbol table for correctness easier.