### PR TITLE
Add a UKVM_STATIC=1 option to generated Makefile.ukvm

### DIFF
--- a/ukvm/ukvm-configure
+++ b/ukvm/ukvm-configure
@@ -25,6 +25,9 @@ UKVM_CC?=cc
 UKVM_FLAGS=-D__UKVM_HOST__ \$(UKVM_MODULE_FLAGS)
 UKVM_CFLAGS=-Wall -Werror -std=c99 -O2 -g \$(UKVM_FLAGS)
 UKVM_OBJS=_build-ukvm/ukvm-core.o \$(UKVM_MODULE_OBJS)
+ifdef UKVM_STATIC
+UKVM_LDFLAGS=-static
+endif
 UKVM_HEADERS= \\
 $UKVM_SRC/ukvm.h \\
 $UKVM_SRC/misc.h \\
@@ -37,7 +40,7 @@ _build-ukvm/ukvm-%.o: $UKVM_SRC/ukvm-%.c _build-ukvm
 	\$(UKVM_CC) \$(UKVM_CFLAGS) -c \$< -o \$@
 
 ukvm-bin: \$(UKVM_OBJS) \$(UKVM_HEADERS)
-	\$(UKVM_CC) -o \$@ \$(UKVM_CFLAGS) \$(UKVM_OBJS) -lpthread -lrt
+	\$(UKVM_CC) \$(UKVM_LDFLAGS) -o \$@ \$(UKVM_CFLAGS) \$(UKVM_OBJS) -lpthread -lrt
 
 .PHONY: ukvm-clean
 ukvm-clean:


### PR DESCRIPTION
Allows building `ukvm-bin` statically.