### PR TITLE
Kill all global variables

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -41,7 +41,6 @@ virtio/kernel.o \
 virtio/low_level.o \
 virtio/low_level_interrupts.o \
 virtio/mem.o \
-virtio/net.o \
 virtio/pci.o \
 virtio/serial.o \
 virtio/time.o \

--- a/kernel/interrupts.c
+++ b/kernel/interrupts.c
@@ -48,7 +48,7 @@ struct __attribute__((__packed__)) idtptr {
 extern void idt_load(uint64_t idtptr);
 
 /* The actual memory for the IDT is here */
-struct qw idt[IDT_NUM_ENTRIES] ALIGN_64_BIT;
+static struct qw idt[IDT_NUM_ENTRIES] ALIGN_64_BIT;
 
 #define SET_IDT_ENTRY(n, a) do {                                        \
         idt[n].hi2 = 0;                                                 \
@@ -125,7 +125,9 @@ struct tss {
     uint64_t reserved3;
     uint16_t reserved4;
     uint16_t iomap_base;
-} __attribute__((packed)) cpu_tss;
+} __attribute__((packed));
+
+static struct tss cpu_tss;
 
 struct tss_desc {
     uint64_t limit_lo:16;

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -113,7 +113,6 @@ void pci_enumerate(void);
 void virtio_config_network(uint16_t base);
 void virtio_config_block(uint16_t base);
 
-extern uint8_t virtio_net_mac[];
 uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
 void virtio_net_pkt_put(void);      /* we're done with recv'd data */
 int virtio_net_xmit_packet(void *data, int len);

--- a/kernel/pvclock.c
+++ b/kernel/pvclock.c
@@ -54,8 +54,8 @@ struct pvclock_wall_clock {
  * TODO: These should be pointers (for Xen HVM support), but we can't use
  * bmk_pgalloc() here.
  */
-volatile struct pvclock_vcpu_time_info pvclock_ti;
-volatile struct pvclock_wall_clock pvclock_wc;
+static volatile struct pvclock_vcpu_time_info pvclock_ti;
+static volatile struct pvclock_wall_clock pvclock_wc;
 
 static inline void
 x86_cpuid(uint32_t level, uint32_t *eax_out, uint32_t *ebx_out,

--- a/kernel/virtio/pci.c
+++ b/kernel/virtio/pci.c
@@ -57,8 +57,8 @@ struct pci_config_info {
     uint8_t interrupt_line;
 };
 
-uint32_t net_devices_found;
-uint32_t blk_devices_found;
+static uint32_t net_devices_found;
+static uint32_t blk_devices_found;
 
 #define PCI_CONF_SUBSYS_NET 1
 #define PCI_CONF_SUBSYS_BLK 2

--- a/kernel/virtio/virtio.c
+++ b/kernel/virtio/virtio.c
@@ -105,7 +105,7 @@ struct virtio_blk_req {
     volatile uint8_t status;
     volatile uint8_t hw_used;
 };
-struct virtio_blk_req blk_bufs[128];
+static struct virtio_blk_req blk_bufs[128];
 
 struct __attribute__((__packed__)) vring_desc {
     uint64_t addr;   /* Address (guest-physical). */
@@ -193,8 +193,8 @@ struct vring_used_elem *vring_used_elem_get(struct vring *vring, int i)
  */
 #define VRING_NET_MAX_QUEUE_SIZE 8192
 
-struct pkt_buffer xmit_bufs[VRING_NET_MAX_QUEUE_SIZE];
-struct pkt_buffer recv_bufs[VRING_NET_MAX_QUEUE_SIZE];
+static struct pkt_buffer xmit_bufs[VRING_NET_MAX_QUEUE_SIZE];
+static struct pkt_buffer recv_bufs[VRING_NET_MAX_QUEUE_SIZE];
 
 static uint8_t recv_data[VRING_SIZE(VRING_NET_MAX_QUEUE_SIZE)] ALIGN_4K;
 static uint8_t xmit_data[VRING_SIZE(VRING_NET_MAX_QUEUE_SIZE)] ALIGN_4K;
@@ -244,7 +244,7 @@ static struct virtio_net_hdr virtio_net_hdr = {0, 0, 0, 0, 0, 0};
 static uint16_t virtio_net_pci_base; /* base in PCI config space */
 static uint16_t virtio_blk_pci_base; /* base in PCI config space */
 
-uint8_t virtio_net_mac[6];
+static uint8_t virtio_net_mac[6];
 static char virtio_net_mac_str[18];
 
 static uint32_t xmit_next_avail;

--- a/tests/test_ping_serve/Makefile
+++ b/tests/test_ping_serve/Makefile
@@ -1,5 +1,5 @@
-UKVM_TARGETS=
+UKVM_TARGETS=test_ping_serve.ukvm ukvm-bin
 VIRTIO_TARGETS=test_ping_serve.virtio
-UKVM_MODULES=
+UKVM_MODULES=net
 
 include ../Makefile.tests

--- a/tests/test_ping_serve/test_ping_serve.c
+++ b/tests/test_ping_serve/test_ping_serve.c
@@ -1,15 +1,232 @@
 #include "solo5.h"
 
-extern void solo5_ping_serve(void); /* XXX */
+/* Liberally copied / reinvented libc bits */
 
-int solo5_app_main(char *cmdline __attribute__((unused)))
+static void *memcpy(void *dst, const void *src, size_t size)
 {
-    const char s[] = "Hello, World\n";
+    size_t i;
 
-    solo5_console_write(s, sizeof(s));
+    for (i = 0; i < size; i++)
+        ((uint8_t *)dst)[i] = ((uint8_t *)src)[i];
+    return dst;
+}
 
-    for (;;)
-        solo5_ping_serve();  /* does things if network packet comes in */
+static int memcmp(const void *s1, const void *s2, size_t n)
+{
+    size_t i;
+
+    for (i = 0; i < n; i++) {
+        if (((uint8_t *)s1)[i] < ((uint8_t *)s2)[i])
+            return -1;
+        if (((uint8_t *)s1)[i] > ((uint8_t *)s2)[i])
+            return 1;
+    }
+    return 0;
+}
+
+static size_t strlen(const char *s)
+{
+    size_t len = 0;
+
+    while (*s++)
+        len += 1;
+    return len;
+}
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
+#define assert(e) do {                              \
+        if (!(e)) {                                 \
+            puts("assertion failed: ");             \
+            puts(#e);                               \
+            puts("\n");                             \
+            solo5_exit();                           \
+        }                                           \
+    } while (0)
+
+#define ETHERTYPE_IP  0x0800
+#define HLEN_ETHER  6
+#define PLEN_IPV4  4
+
+struct ether {
+    uint8_t target[HLEN_ETHER];
+    uint8_t source[HLEN_ETHER];
+    uint16_t type;
+};
+
+struct ip {
+    uint8_t version_ihl;
+    uint8_t type;
+    uint16_t length;
+    uint16_t id;
+    uint16_t flags_offset;
+    uint8_t ttl;
+    uint8_t proto;
+    uint16_t checksum;
+    uint8_t src_ip[PLEN_IPV4];
+    uint8_t dst_ip[PLEN_IPV4];
+};
+
+struct ping {
+    uint8_t type;
+    uint8_t code;
+    uint16_t checksum;
+    uint16_t id;
+    uint16_t seqnum;
+    uint8_t data[0];
+};
+
+struct pingpkt {
+    struct ether ether;
+    struct ip ip;
+    struct ping ping;
+};
+
+static uint16_t checksum(void *ptr, size_t len)
+{
+    uint32_t sum = 0;
+    size_t i;
+
+    assert((len % 2) == 0);
+
+    for (i = 0; i < len; i += 2)
+        sum += *(uint16_t *)(ptr + i);
+
+    return ~(((uint16_t)(sum & 0xffff)) + ((uint16_t)(sum >> 16)));
+};
+
+static uint16_t htons(uint16_t x)
+{
+    uint16_t val;
+    uint8_t *v = (uint8_t *)&val;
+
+    v[0] = (x >> 8) & 0xff;
+    v[1] = x & 0xff;
+    return val;
+}
+
+static uint8_t dehex(char c)
+{
+    if (c >= '0' && c <= '9')
+        return (c - '0');
+    else if (c >= 'a' && c <= 'f')
+        return (c - 'a');
+    else if (c >= 'A' && c <= 'F')
+        return (c - 'A');
+    else
+        return 0;
+}
+
+static uint8_t buf[1526];
+
+static void ping_serve(int quiet)
+{
+    uint8_t ipaddr[4] = { 0x0a, 0x00, 0x00, 0x02 }; /* 10.0.0.2 */
+    uint8_t ipaddr_brdnet[4] = { 0x0a, 0x00, 0x00, 0xff }; /* 10.0.0.255 */
+    uint8_t ipaddr_brdall[4] = { 0xff, 0xff, 0xff, 0xff }; /* 255.255.255.255 */
+    uint8_t macaddr[HLEN_ETHER];
+    uint8_t macaddr_brd[HLEN_ETHER] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+
+    /* XXX this interface should really not return a string */
+    char *smac = solo5_net_mac_str();
+    for (int i = 0; i < HLEN_ETHER; i++) {
+        macaddr[i] = dehex(*smac++) << 4;
+        macaddr[i] |= dehex(*smac++);
+        smac++;
+    }
+
+    puts("Serving ping on 10.0.0.2 / 10.0.0.255 / 255.255.255.255\n");
+    puts("With MAC: ");
+    puts(solo5_net_mac_str());
+    puts(" (no ARP!)\n");
+
+    for (;;) {
+        struct pingpkt *p = (struct pingpkt *)&buf;
+        int len = sizeof(buf);
+
+        /* wait for packet */
+        /* XXX doing the below produces an assert in ukvm, look into it */
+        /*
+        while (solo5_net_read_sync(buf, &len) != 0) {
+            solo5_poll(solo5_clock_monotonic() + 1000000000ULL);
+        }
+        */
+        while (solo5_poll(solo5_clock_monotonic() + 1000000000ULL) == 0) {
+            ;
+        }
+        assert(solo5_net_read_sync(buf, &len) == 0);
+
+        if (memcmp(p->ether.target, macaddr, HLEN_ETHER) &&
+            memcmp(p->ether.target, macaddr_brd, HLEN_ETHER))
+            goto out; /* not ether addressed to us */
+
+        if (p->ether.type != htons(ETHERTYPE_IP))
+            goto out; /* not an IP packet */
+
+        if (p->ip.version_ihl != 0x45)
+            goto out; /* we don't support IPv6, yet :-) */
+
+        if (p->ip.type != 0x00)
+            goto out;
+
+        if (p->ip.proto != 0x01)
+            goto out; /* not ICMP */
+
+        if (memcmp(p->ip.dst_ip, ipaddr, PLEN_IPV4) &&
+            memcmp(p->ip.dst_ip, ipaddr_brdnet, PLEN_IPV4) &&
+            memcmp(p->ip.dst_ip, ipaddr_brdall, PLEN_IPV4))
+            goto out; /* not ip addressed to us */
+
+        if (p->ping.type != 0x08)
+            goto out; /* not an echo request */
+
+        if (p->ping.code != 0x00)
+            goto out;
+
+        /* reorder ether net header addresses */
+        memcpy(p->ether.target, p->ether.source, HLEN_ETHER);
+        memcpy(p->ether.source, macaddr, HLEN_ETHER);
+
+        p->ip.id = 0;
+        p->ip.flags_offset = 0;
+
+        /* reorder ip net header addresses */
+        memcpy(p->ip.dst_ip, p->ip.src_ip, PLEN_IPV4);
+        memcpy(p->ip.src_ip, ipaddr, PLEN_IPV4);
+
+        /* recalculate ip checksum for return pkt */
+        p->ip.checksum = 0;
+        p->ip.checksum = checksum(&p->ip, sizeof(struct ip));
+
+        p->ping.type = 0x0; /* change into reply */
+
+        /* recalculate ICMP checksum */
+        p->ping.checksum = 0;
+        p->ping.checksum = checksum(&p->ping,
+                htons(p->ip.length) - sizeof(struct ip));
+
+        if (!quiet)
+            puts("Received ping, sending reply\n");
+
+        if (solo5_net_write_sync(buf, len) == -1)
+            puts("Write error\n");
+
+        continue;
+
+out:
+        puts("Received non-ping or unsupported packet, dropped\n");
+    }
+}
+
+int solo5_app_main(char *cmdline)
+{
+    puts("Hello, World\n");
+
+    /* anything passed on the command line means "quiet" */
+    ping_serve(strlen(cmdline));
 
     return 0;
 }


### PR DESCRIPTION
Rather than fighting the toolchain to understand why globals are getting allocated as COMMON, I've changed all global variables to `static`.

~~A casualty of this process is `test_ping_serve`, since that was relying on poking around in variables declared in `virtio.c`.~~

~~@djwillia @ricarkol Please confirm you're ok with removing `test_ping_serve` -- I think we discussed this and concluded it's not worth keeping in it's current form?~~