### PR TITLE
virtio: Handle irq 5.

### DIFF
--- a/kernel/virtio/low_level_interrupts.c
+++ b/kernel/virtio/low_level_interrupts.c
@@ -120,6 +120,7 @@ void low_level_handle_irq(int irq)
     switch (irq) {
     case 0x0a:
     case 0x0b:
+    case 0x05:
         handle_virtio_interrupt();
         break;
     case 0: /* PIT */


### PR DESCRIPTION
Bhyve assigns irq 5 to the virtio device, so add another workaround
until #32 is fixed.