### PR TITLE
Validate image passed to ukvm is in ELF format

### DIFF
--- a/ukvm/ukvm-core.c
+++ b/ukvm/ukvm-core.c
@@ -247,6 +247,19 @@ static void load_code(const char *file, uint8_t *mem,     /* IN */
     if (numb < 0 || (size_t) numb != sizeof(Elf64_Ehdr))
         err(1, "unable to read ELF64 hdr");
 
+    /*
+     * Validate program is in ELF64 format:
+     * 1. EI_MAG fields 0, 1, 2, 3 spell ELFMAG('0x7f', 'E', 'L', 'F'),
+     * 2. File contains 64-bit objects,
+     * 3. Objects are Executable,
+     * 4. Target instruction set architecture is set to x86_64.
+     */
+    if (hdr.e_ident[EI_MAG0] != ELFMAG0 || hdr.e_ident[EI_MAG1] != ELFMAG1 || \
+        hdr.e_ident[EI_MAG2] != ELFMAG2 || hdr.e_ident[EI_MAG3] != ELFMAG3 || \
+        hdr.e_ident[EI_CLASS] != ELFCLASS64 || hdr.e_type != ET_EXEC || \
+        hdr.e_machine != EM_X86_64)
+        errx(1, "%s is in invalid ELF64 format.", file);
+
     ph_off = hdr.e_phoff;
     ph_entsz = hdr.e_phentsize;
     ph_cnt = hdr.e_phnum;


### PR DESCRIPTION
Since ukvm expects its payload to be in ELF format, validate that the ELF header has expected magic characters. Without the validation, any image format (ex: qcow2, which is the default OSv image format) is loaded successfully, and ``vcpu_loop`` execution fails with ``KVM_EXIT_SHUTDOWN`` ([Issue 13](https://github.com/Solo5/solo5/issues/88)).

This PR attempts to validate ELF magic characters in the loaded code so that -
a) user is informed of mismatched image format
b) ukvm does not attempt to get into ``vcpu_loop`` with a corrupt guest
___________
Testing Done:

Invalid image without validation:
```
root@ubuntu:~/solo5/tests/test_hello# ./ukvm-bin /tmp/osv-images/ukvm.img 
Setting the CPUID.
ukvm-bin: exit_reason = 0x8
root@ubuntu:~/solo5/tests/test_hello# 
```

Invalid image with ELF validation:
```
root@ubuntu:~/solo5/tests/test_hello# ./ukvm-bin /tmp/osv-images/ukvm.img 
ukvm-bin: /tmp/osv-images/ukvm.img is not in ELF format
: Success
root@ubuntu:~/solo5/tests/test_hello# file /tmp/osv-images/ukvm.img 
/tmp/osv-images/ukvm.img: QEMU QCOW Image (v3), 10737418240 bytes
```

Valid image:
```
root@ubuntu:~/solo5/tests/test_hello# ./ukvm-bin test_hello.ukvm 
Setting the CPUID.
            |      ___|
  __|  _ \  |  _ \ __ \
\__ \ (   | | (   |  ) |
____/\___/ _|\___/____/
mem_size=20000000, kernel_end=10e000
Initializing the KVM Paravirtualized clock.
Hello, World
Command line is: 
solo5_app_main() returned with 0
Kernel done.
Goodbye!
KVM_EXIT_HLT
root@ubuntu:~/solo5/tests/test_hello# file test_hello.ukvm 
test_hello.ukvm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```