### PR TITLE
virtio: Refactoring and cleanup

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -47,6 +47,7 @@ virtio/mem.o \
 virtio/pci.o \
 virtio/serial.o \
 virtio/time.o \
+virtio/virtio_ring.o \
 virtio/virtio_net.o \
 virtio/virtio_blk.o \
 virtio/tscclock.o \

--- a/kernel/virtio/virtio_net.c
+++ b/kernel/virtio/virtio_net.c
@@ -21,27 +21,11 @@
 #include "virtio_pci.h"
 
 /* The feature bitmap for virtio net */
-#define VIRTIO_NET_F_CSUM	0     /* Host handles pkts w/ partial csum */
+#define VIRTIO_NET_F_CSUM       0 /* Host handles pkts w/ partial csum */
 #define VIRTIO_NET_F_GUEST_CSUM	1 /* Guest handles pkts w/ partial csum */
 #define VIRTIO_NET_F_MAC (1 << 5) /* Host has given MAC address. */
 
 #define PKT_BUFFER_LEN 1526
-struct pkt_buffer {
-    uint8_t data[PKT_BUFFER_LEN];
-    uint32_t len;
-};
-
-/*
- * There is no official max queue size. But we've seen 4096, so let's use the
- * double of that.
- */
-#define VIRTQ_NET_MAX_QUEUE_SIZE 8192
-
-static struct pkt_buffer *xmit_bufs;
-static struct pkt_buffer *recv_bufs;
-
-static uint8_t *recv_data;
-static uint8_t *xmit_data;
 
 static struct virtq recvq;
 static struct virtq xmitq;
@@ -55,113 +39,29 @@ static struct virtq xmitq;
  * specify GSO or CSUM features, you can simply ignore the header.
  */
 struct __attribute__((__packed__)) virtio_net_hdr {
-#define VIRTIO_NET_HDR_F_NEEDS_CSUM	1   /* Use csum_start, csum_offset */
-#define VIRTIO_NET_HDR_F_DATA_VALID	2	/* Csum is valid */
+#define VIRTIO_NET_HDR_F_NEEDS_CSUM     1   /* Use csum_start, csum_offset */
+#define VIRTIO_NET_HDR_F_DATA_VALID     2        /* Csum is valid */
     uint8_t flags;
-#define VIRTIO_NET_HDR_GSO_NONE		0	/* Not a GSO frame */
-#define VIRTIO_NET_HDR_GSO_TCPV4	1	/* GSO frame, IPv4 TCP (TSO) */
-#define VIRTIO_NET_HDR_GSO_UDP		3	/* GSO frame, IPv4 UDP (UFO) */
-#define VIRTIO_NET_HDR_GSO_TCPV6	4	/* GSO frame, IPv6 TCP */
-#define VIRTIO_NET_HDR_GSO_ECN		0x80	/* TCP has ECN set */
+#define VIRTIO_NET_HDR_GSO_NONE         0        /* Not a GSO frame */
+#define VIRTIO_NET_HDR_GSO_TCPV4        1        /* GSO frame, IPv4 TCP (TSO) */
+#define VIRTIO_NET_HDR_GSO_UDP          3        /* GSO frame, IPv4 UDP (UFO) */
+#define VIRTIO_NET_HDR_GSO_TCPV6        4        /* GSO frame, IPv6 TCP */
+#define VIRTIO_NET_HDR_GSO_ECN       0x80        /* TCP has ECN set */
     uint8_t gso_type;
-    uint16_t hdr_len;		/* Ethernet + IP + tcp/udp hdrs */
-    uint16_t gso_size;		/* Bytes to append to hdr_len per frame */
-    uint16_t csum_start;	/* Position to start checksumming from */
-    uint16_t csum_offset;	/* Offset after that to place checksum */
+    uint16_t hdr_len;                /* Ethernet + IP + tcp/udp hdrs */
+    uint16_t gso_size;                /* Bytes to append to hdr_len per frame */
+    uint16_t csum_start;        /* Position to start checksumming from */
+    uint16_t csum_offset;        /* Offset after that to place checksum */
 };
 
-static struct virtio_net_hdr virtio_net_hdr = {0, 0, 0, 0, 0, 0};
 static uint16_t virtio_net_pci_base; /* base in PCI config space */
 
 static uint8_t virtio_net_mac[6];
 static char virtio_net_mac_str[18];
 
 static int net_configured;
-static uint32_t xmit_next_avail;
-static uint32_t recv_next_avail;
-static uint32_t xmit_last_used;
-static uint32_t recv_last_used;
 
 static int handle_virtio_net_interrupt(void *);
-
-/* WARNING: called in interrupt context */
-static void check_xmit(void)
-{
-    volatile struct virtq_used_elem e;
-    struct virtq_desc desc;
-    int dbg = 0;
-
-    for (;;) {
-        if ((xmitq.used->idx % xmitq.num) == xmit_last_used)
-            break;
-
-        e = xmitq.used->ring[xmit_last_used % xmitq.num];
-        desc = xmitq.desc[e.id];
-
-        if (dbg)
-            printf("REAP: 0x%p next_avail %d last_used %d\n",
-                   desc.addr, xmit_next_avail, xmit_last_used);
-
-        xmit_last_used = (xmit_last_used + 1) % xmitq.num;
-    }
-}
-
-static void recv_load_desc(void)
-{
-    struct virtq_desc *desc;
-    struct virtq_avail *avail;
-
-    desc = &(recvq.desc[recv_next_avail]);
-    desc->addr = (uint64_t)recv_bufs[recv_next_avail].data;
-    desc->len = PKT_BUFFER_LEN;
-    desc->flags = VIRTQ_DESC_F_WRITE;
-    avail = recvq.avail;
-    /* Memory barriers should be unnecessary with one processor */
-    recvq.avail->ring[avail->idx % recvq.num] = recv_next_avail;
-    avail->idx++;
-    recv_next_avail = (recv_next_avail + 1) % recvq.num;
-}
-
-/* WARNING: called in interrupt context */
-static void check_recv(void)
-{
-    volatile struct virtq_used_elem *e;
-    struct virtq_desc *desc;
-    int i;
-
-    for (;;) {
-        if ((recvq.used->idx % recvq.num) == recv_last_used)
-            break;
-
-        e = &(recvq.used->ring[recv_last_used % recvq.num]);
-        desc = &(recvq.desc[e->id]);
-
-        /* Everything should be in a single descriptor. */
-        assert(desc->next == 0);
-
-	if (0)
-            printf("RECV: 0x%p next_avail %d last_used %d\n",
-                   desc->addr, recv_next_avail, recv_last_used);
-
-        ((struct pkt_buffer *)desc->addr)->len = e->len;
-
-        assert(e->len <= PKT_BUFFER_LEN);
-        assert(e->len >= sizeof(struct virtio_net_hdr));
-
-        if (0) {
-            printf("recv pkt:\n");
-            for (i = 0; i < 64; i++) {
-                printf("%02x ", ((uint8_t *)desc->addr)[i]);
-                if ((i % 8) == 7)
-                    printf(" ");
-                if ((i % 16) == 15)
-                    printf("\n");
-            }
-        }
-
-        recv_last_used = (recv_last_used + 1) % recvq.num;
-    }
-}
 
 /* WARNING: called in interrupt context */
 int handle_virtio_net_interrupt(void *arg __attribute__((unused)))
@@ -171,8 +71,8 @@ int handle_virtio_net_interrupt(void *arg __attribute__((unused)))
     if (net_configured) {
         isr_status = inb(virtio_net_pci_base + VIRTIO_PCI_ISR);
         if (isr_status & VIRTIO_PCI_ISR_HAS_INTR) {
-            check_xmit();
-            check_recv();
+            virtq_handle_interrupt(&xmitq);
+            virtq_handle_interrupt(&recvq);
             return 1;
         }
     }
@@ -181,20 +81,14 @@ int handle_virtio_net_interrupt(void *arg __attribute__((unused)))
 
 static void recv_setup(void)
 {
-    struct virtq_desc *desc;
-    struct virtq_avail *avail;
     do {
-        desc = &(recvq.desc[recv_next_avail]);
-        desc->addr = (uint64_t)recv_bufs[recv_next_avail].data;
-        desc->len = PKT_BUFFER_LEN;
-        desc->flags = VIRTQ_DESC_F_WRITE;
-
-        avail = recvq.avail;
-        /* Memory barriers should be unnecessary with one processor */
-        recvq.avail->ring[avail->idx % recvq.num] = recv_next_avail;
-        avail->idx++;
-        recv_next_avail = (recv_next_avail + 1) % recvq.num;
-    } while (recv_next_avail != 0);
+        struct io_buffer *buf; /* header and data in a single descriptor */
+        buf = &recvq.bufs[recvq.next_avail];
+        memset(buf->data, 0, PKT_BUFFER_LEN);
+        buf->len = PKT_BUFFER_LEN;
+        buf->extra_flags = VIRTQ_DESC_F_WRITE;
+        assert(virtq_add_descriptor_chain(&recvq, recvq.next_avail, 1) == 0);
+    } while (recvq.next_avail != 0);
 
     outw(virtio_net_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_RECV);
 }
@@ -202,53 +96,52 @@ static void recv_setup(void)
 /* performance note: we perform a copy into the xmit buffer */
 int virtio_net_xmit_packet(void *data, int len)
 {
-    struct virtq_desc *desc;
-    struct virtq_avail *avail;
-    int dbg = 0;
+    uint16_t head = xmitq.next_avail;
+    struct io_buffer *head_buf, *data_buf;
+    int r;
 
-    if (((xmit_next_avail + 1) % xmitq.num) ==
-        (xmit_last_used % xmitq.num)) {
-        printf("xmit buffer full! next_avail:%d last_used:%d\n",
-               xmit_next_avail, xmit_last_used);
-            return -1;
-    }
+    head_buf = &xmitq.bufs[head];
+    data_buf = &xmitq.bufs[(head + 1) % xmitq.num];
 
-    /* we perform a copy into the xmit buffer to make reclaiming easy */
-    assert((len + sizeof(virtio_net_hdr)) <= PKT_BUFFER_LEN);
-    memcpy(xmit_bufs[xmit_next_avail].data,
-           &virtio_net_hdr, sizeof(virtio_net_hdr));
-    memcpy(xmit_bufs[xmit_next_avail].data + sizeof(virtio_net_hdr),
-           data, len);
+    /* The header buf */
+    memset(head_buf->data, 0, sizeof(struct virtio_net_hdr));
+    head_buf->len = sizeof(struct virtio_net_hdr);
+    head_buf->extra_flags = 0;
 
-    desc = &(xmitq.desc[xmit_next_avail]);
-    desc->addr = (uint64_t) xmit_bufs[xmit_next_avail].data;
-    desc->len = sizeof(virtio_net_hdr) + len;
-    desc->flags = 0;
+    /* The data buf */
+    assert(len <= PKT_BUFFER_LEN);
+    memcpy(data_buf->data, data, len);
+    data_buf->len = len;
+    data_buf->extra_flags = 0;
 
-    if (dbg)
-        atomic_printf("XMIT: 0x%p next_avail %d last_used %d\n",
-                      desc->addr, xmit_next_avail, xmit_last_used);
+    r = virtq_add_descriptor_chain(&xmitq, head, 2);
 
-    avail = xmitq.avail;
-    /* Memory barriers should be unnecessary with one processor */
-    xmitq.avail->ring[avail->idx % xmitq.num] = xmit_next_avail;
-
-    avail->idx++;
-    xmit_next_avail = (xmit_next_avail + 1) % xmitq.num;
     outw(virtio_net_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_XMIT);
 
-    return 0;
+    return r;
 }
 
 
 void virtio_config_network(uint16_t base, unsigned irq)
 {
-    uint8_t ready_for_init = VIRTIO_PCI_STATUS_ACK | VIRTIO_PCI_STATUS_DRIVER;
     uint32_t host_features, guest_features;
     int i;
     int dbg = 0;
 
-    outb(base + VIRTIO_PCI_STATUS, ready_for_init);
+    /*
+     * 2. Set the ACKNOWLEDGE status bit: the guest OS has notice the device.
+     * 3. Set the DRIVER status bit: the guest OS knows how to drive the device. 
+     */
+
+    outb(base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_ACK);
+    outb(base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER);
+
+    /*
+     * 4. Read device feature bits, and write the subset of feature bits
+     * understood by the OS and driver to the device. During this step the
+     * driver MAY read (but MUST NOT write) the device-specific configuration
+     * fields to check that it can support the device before accepting it. 
+     */
 
     host_features = inl(base + VIRTIO_PCI_HOST_FEATURES);
 
@@ -286,48 +179,30 @@ void virtio_config_network(uint16_t base, unsigned irq)
              virtio_net_mac[4],
              virtio_net_mac[5]);
 
-    /* get the size of the virt queues */
-    outw(base + VIRTIO_PCI_QUEUE_SEL, VIRTQ_RECV);
-    recvq.num = inw(base + VIRTIO_PCI_QUEUE_SIZE);
-    outw(base + VIRTIO_PCI_QUEUE_SEL, VIRTQ_XMIT);
-    xmitq.num = inw(base + VIRTIO_PCI_QUEUE_SIZE);
-    assert(recvq.num <= VIRTQ_NET_MAX_QUEUE_SIZE);
-    assert(xmitq.num <= VIRTQ_NET_MAX_QUEUE_SIZE);
-    printf("net queue size is %d/%d\n", recvq.num, xmitq.num);
+    /*
+     * 7. Perform device-specific setup, including discovery of virtqueues for
+     * the device, optional per-bus setup, reading and possibly writing the
+     * device's virtio configuration space, and population of virtqueues.
+     */
 
-    recv_data = memalign(4096, VIRTQ_SIZE(recvq.num));
-    assert(recv_data);
-    memset(recv_data, 0, VIRTQ_SIZE(recvq.num));
-    recv_bufs = calloc(recvq.num, sizeof (struct pkt_buffer));
-    assert(recv_bufs);
+    virtq_init_rings(base, &recvq, VIRTQ_RECV);
+    virtq_init_rings(base, &xmitq, VIRTQ_XMIT);
 
-    recvq.desc = (struct virtq_desc *)(recv_data + VIRTQ_OFF_DESC(recvq.num));
-    recvq.avail = (struct virtq_avail *)(recv_data + VIRTQ_OFF_AVAIL(recvq.num));
-    recvq.used = (struct virtq_used *)(recv_data + VIRTQ_OFF_USED(recvq.num));
-
-    xmit_data = memalign(4096, VIRTQ_SIZE(xmitq.num));
-    assert(xmit_data);
-    memset(xmit_data, 0, VIRTQ_SIZE(xmitq.num));
-    xmit_bufs = calloc(xmitq.num, sizeof (struct pkt_buffer));
-    assert(xmit_bufs);
-
-    xmitq.desc = (struct virtq_desc *)(xmit_data + VIRTQ_OFF_DESC(xmitq.num));
-    xmitq.avail = (struct virtq_avail *)(xmit_data + VIRTQ_OFF_AVAIL(xmitq.num));
-    xmitq.used = (struct virtq_used *)(xmit_data + VIRTQ_OFF_USED(xmitq.num));
+    recvq.bufs = calloc(recvq.num, sizeof (struct io_buffer));
+    assert(recvq.bufs);
+    xmitq.bufs = calloc(xmitq.num, sizeof (struct io_buffer));
+    assert(xmitq.bufs);
 
     virtio_net_pci_base = base;
     net_configured = 1;
     intr_register_irq(irq, handle_virtio_net_interrupt, NULL);
-    outb(base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
-
-    outw(base + VIRTIO_PCI_QUEUE_SEL, VIRTQ_RECV);
-    outl(base + VIRTIO_PCI_QUEUE_PFN, (uint64_t) recv_data
-         >> VIRTIO_PCI_QUEUE_ADDR_SHIFT);
-    outw(base + VIRTIO_PCI_QUEUE_SEL, VIRTQ_XMIT);
-    outl(base + VIRTIO_PCI_QUEUE_PFN, (uint64_t) xmit_data
-         >> VIRTIO_PCI_QUEUE_ADDR_SHIFT);
-
     recv_setup();
+
+    /*
+     * 8. Set the DRIVER_OK status bit. At this point the device is "live".
+     */
+
+    outb(base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
 }
 
 int virtio_net_pkt_poll(void)
@@ -335,29 +210,39 @@ int virtio_net_pkt_poll(void)
     if (!net_configured)
         return 0;
 
-    if (recv_next_avail == (recv_last_used % recvq.num))
+    if (recvq.next_avail == recvq.last_used)
         return 0;
     else
         return 1;
 }
 
-uint8_t *virtio_net_pkt_get(int *size)
+/* Get the data from the next_avail (top-most) receive buffer/descriptpr in
+ * the available ring. */
+uint8_t *virtio_net_recv_pkt_get(int *size)
 {
-    struct pkt_buffer *buf;
+    struct io_buffer *buf;
 
-    if (recv_next_avail == (recv_last_used % recvq.num))
+    /* last_used advances whenever we receive a packet, and if it's ahead of
+     * next_avail it means that we have a pending packet. */
+    if (recvq.next_avail == recvq.last_used)
         return NULL;
 
-    buf = &recv_bufs[recv_next_avail];
+    buf = &recvq.bufs[recvq.next_avail];
 
     /* Remove the virtio_net_hdr */
-    *size = buf->len - sizeof(virtio_net_hdr);
-    return buf->data + sizeof(virtio_net_hdr);
+    *size = buf->len - sizeof(struct virtio_net_hdr);
+    return buf->data + sizeof(struct virtio_net_hdr);
 }
 
-void virtio_net_pkt_put(void)
+/* Return the next_avail (top-most) receive buffer/descriptor to the available
+ * ring. */
+void virtio_net_recv_pkt_put(void)
 {
-    recv_load_desc();
+    recvq.bufs[recvq.next_avail].len = PKT_BUFFER_LEN;
+    recvq.bufs[recvq.next_avail].extra_flags = VIRTQ_DESC_F_WRITE;
+    /* This sets the returned descriptor to be ready for incoming packets, and
+     * advances the next_avail index. */
+    assert(virtq_add_descriptor_chain(&recvq, recvq.next_avail, 1) == 0);
 }
 
 int solo5_net_write_sync(uint8_t *data, int n)
@@ -374,7 +259,7 @@ int solo5_net_read_sync(uint8_t *data, int *n)
 
     assert(net_configured);
 
-    pkt = virtio_net_pkt_get(&len);
+    pkt = virtio_net_recv_pkt_get(&len);
     if (!pkt)
         return -1;
 
@@ -385,7 +270,7 @@ int solo5_net_read_sync(uint8_t *data, int *n)
     /* also, it's clearly not zero copy */
     memcpy(data, pkt, len);
 
-    virtio_net_pkt_put();
+    virtio_net_recv_pkt_put();
 
     return 0;
 }

--- a/kernel/virtio/virtio_ring.c
+++ b/kernel/virtio/virtio_ring.c
@@ -1,0 +1,144 @@
+/* Copyright (c) 2015, IBM
+ * Author(s): Dan Williams <djwillia@us.ibm.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "kernel.h"
+#include "virtio_ring.h"
+#include "virtio_pci.h"
+
+/*
+ * There is no official max queue size. But we've seen 4096, so let's use the
+ * double of that.
+ */
+#define VIRTQ_MAX_QUEUE_SIZE 8192
+
+/* WARNING: called in interrupt context */
+void virtq_handle_interrupt(struct virtq *vq)
+{
+    struct virtq_used_elem *e;
+
+    for (;;) {
+        uint16_t desc_idx;
+        struct io_buffer *head_buf;
+
+        if ((vq->used->idx % vq->num) == vq->last_used)
+            break;
+
+        e = &(vq->used->ring[vq->last_used % vq->num]);
+        desc_idx = e->id;
+
+        head_buf = (struct io_buffer *) vq->desc[desc_idx].addr;
+
+        /* Overwrite buf->len with the number of bytes written by the device.
+         * This will be 0 for the tx/blk_write case. */
+        head_buf->len = e->len;
+        head_buf->completed = 1;
+        assert(e->len <= MAX_BUFFER_LEN);
+
+        vq->num_avail++;
+        while (vq->desc[desc_idx].flags & VIRTQ_DESC_F_NEXT) {
+            vq->num_avail++;
+            desc_idx = vq->desc[desc_idx].next;
+        }
+
+        vq->last_used = (vq->last_used + 1) % vq->num;
+    }
+}
+
+/*
+ * Create a descriptor chain starting at index head, using vq->bufs also
+ * starting at index head.
+ * Make sure the vq-bufs are cleaned before using them again.
+ */
+int virtq_add_descriptor_chain(struct virtq *vq,
+                               uint32_t head,
+                               uint32_t num)
+{
+    struct virtq_desc *desc;
+    uint32_t i;
+    int dbg = 0;
+    uint32_t used_descs = num;
+
+    if (vq->num_avail < used_descs) {
+        printf("buffer full! next_avail:%d last_used:%d\n",
+               vq->next_avail, vq->last_used);
+            return -1;
+    }
+
+    assert(used_descs > 0);
+
+    for (i = head; used_descs > 0; used_descs--) {
+        desc = &(vq->desc[i]);
+
+        assert(vq->bufs[i].len <= MAX_BUFFER_LEN);
+
+        /*
+         * The first field of a "struct io_buffer" is the "data" field, so in
+         * the interrupt handler we can just cast this pointer back into a
+         * 'struct io_buffer'.
+         */
+        assert(vq->bufs[i].data == (uint8_t *) &vq->bufs[i]);
+        vq->bufs[i].completed = 0;
+        desc->addr = (uint64_t) vq->bufs[i].data;
+        desc->len = vq->bufs[i].len;
+        desc->flags = VIRTQ_DESC_F_NEXT | vq->bufs[i].extra_flags;
+
+        i = (i + 1) % vq->num;
+        desc->next = i;
+    }
+
+    /* The last descriptor in the chain does not have a next */
+    desc->next = 0;
+    desc->flags &= ~VIRTQ_DESC_F_NEXT;
+
+    if (dbg)
+        atomic_printf("0x%p next_avail %d last_used %d\n",
+                      desc->addr, vq->next_avail,
+                      (vq->last_used * num) % vq->num);
+
+    vq->num_avail -= num;
+    /* Memory barriers should be unnecessary with one processor */
+    vq->avail->ring[vq->avail->idx % vq->num] = head;
+    /* avail->idx always increments and wraps naturally at 65536 */
+    vq->avail->idx++;
+    vq->next_avail = (vq->next_avail + num) % vq->num;
+
+    return 0;
+}
+
+void virtq_init_rings(uint16_t pci_base, struct virtq *vq, int selector)
+{
+    uint8_t *data;
+
+    outw(pci_base + VIRTIO_PCI_QUEUE_SEL, selector);
+    vq->last_used = vq->next_avail = 0;
+    vq->num = vq->num_avail = inw(pci_base + VIRTIO_PCI_QUEUE_SIZE);
+
+    data = memalign(4096, VIRTQ_SIZE(vq->num));
+    assert(data);
+    memset(data, 0, VIRTQ_SIZE(vq->num));
+
+    assert(vq->num <= VIRTQ_MAX_QUEUE_SIZE);
+
+    vq->desc = (struct virtq_desc *)(data + VIRTQ_OFF_DESC(vq->num));
+    vq->avail = (struct virtq_avail *)(data + VIRTQ_OFF_AVAIL(vq->num));
+    vq->used = (struct virtq_used *)(data + VIRTQ_OFF_USED(vq->num));
+
+    outw(pci_base + VIRTIO_PCI_QUEUE_SEL, selector);
+    outl(pci_base + VIRTIO_PCI_QUEUE_PFN, (uint64_t) data
+         >> VIRTIO_PCI_QUEUE_ADDR_SHIFT);
+}

--- a/kernel/virtio/virtio_ring.h
+++ b/kernel/virtio/virtio_ring.h
@@ -140,11 +140,11 @@ struct virtq {
         struct io_buffer *bufs;
 
         /* Keep track of available (free) descriptors */
-        uint32_t num_avail;
+        uint16_t num_avail;
 
         /* Indexes in the descriptors array */
-        uint32_t last_used;
-        uint32_t next_avail;
+        uint16_t last_used;
+        uint16_t next_avail;
 };
 
 static inline int virtq_need_event(uint16_t event_idx, uint16_t new_idx, uint16_t old_idx)
@@ -174,8 +174,8 @@ void virtq_handle_interrupt(struct virtq *vq);
  * Returns 0 on success.
  */
 int virtq_add_descriptor_chain(struct virtq *vq,
-                               uint32_t head,
-                               uint32_t num);
+                               uint16_t head,
+                               uint16_t num);
 
 void virtq_init_rings(uint16_t pci_base, struct virtq *vq, int selector);
 

--- a/tests/test_blk/test_blk.c
+++ b/tests/test_blk/test_blk.c
@@ -19,7 +19,7 @@ int check_sector_write(uint64_t offset)
         return 1;
     
     for (i = 0; i < SECTOR_SIZE; i++) {
-        if (sector_write[i] != '0' + i % 10)
+        if (sector_read[i] != '0' + i % 10)
             /* Check failed */
             return 1;
     }


### PR DESCRIPTION
This PR is for two changes:

1. The network header in bhyve's virtio-net implementation is hard coded to use the extra `num_buffers` field (or `vrh_bufs` in freebsd code) even when the `VIRTIO_NET_F_MRG_RXBUF` feature is not negotiated. This proposed change uses the extended network header, asserts the host feature `VIRTIO_NET_F_MRG_RXBUF`, and negotiates it with the host (always). Here is the freebsd code with the hardcoded struct for reference: https://github.com/freebsd/freebsd/blob/master/usr.sbin/bhyve/pci_virtio_net.c#L120

2. The Tx path in bhyve's virtio-net assumes that all Tx'es will have a first descriptor with the header alone. Here is the code. https://github.com/freebsd/freebsd/blob/master/usr.sbin/bhyve/pci_virtio_net.c#L617 has an interesting comment, and https://github.com/freebsd/freebsd/blob/master/usr.sbin/bhyve/pci_virtio_net.c#L631 only copies data for tx after the first descriptor. The proposed change uses two descriptors per Tx operation. All I could find in the virtio 1.0 spec is this:

> "Most common is to begin the data with a header (containing little-endian ﬁelds) for the device to read, and postﬁx it with a status tailer for the device to write.".

Tested this changes with the static_website unikernel locally and in GCE. Also tested the ping_test_serve unikernel in freebsd (after applying @hannesm change to Makefile.common and following the instructions).