### PR TITLE
Getting rid of virtio interrupt handling

### DIFF
--- a/kernel/virtio/virtio_blk.c
+++ b/kernel/virtio/virtio_blk.c
@@ -96,27 +96,41 @@ static uint16_t virtio_blk_op(uint32_t type,
     return head;
 }
 
-/* Returns the status (0 is OK, -1 is not) */
+/*
+ * Returns the status (0 is OK, -1 is not)
+ *
+ * This function assumes that no other pending IO is submitted at the same
+ * time.  That is true as long as we use only synchronous IO calls, and if
+ * there is just a sync call at a time (which is true for solo5).
+ */
 static int virtio_blk_op_sync(uint32_t type,
                               uint64_t sector,
                               void *data, int *len)
 {
     uint16_t mask = blkq.num - 1;
     uint16_t head;
-    struct io_buffer *head_buf, *data_buf, *status_buf;
+    struct io_buffer *data_buf, *status_buf;
     uint8_t status;
 
     head = virtio_blk_op(type, sector, data, *len);
-
-    head_buf = &blkq.bufs[head];
     data_buf = &blkq.bufs[(head + 1) & mask];
     status_buf = &blkq.bufs[(head + 2) & mask];
 
-    /* XXX need timeout or something, because this can hang... sync
-     * should probably go away anyway
-     */
-    while (!head_buf->completed)
+    /* Loop until the device used all of our descriptors. */
+    while (blkq.used->idx != blkq.avail->idx)
         ;
+
+    /* Consume all the recently used descriptors. */
+    for (; blkq.used->idx != blkq.last_used; blkq.last_used++) {
+        struct virtq_used_elem *e;
+
+	/* Assert that the used descriptor matches the descriptor of the
+         * IO we started at the start of this function. */
+        e = &(blkq.used->ring[blkq.last_used & mask]);
+        assert(head == e->id);
+
+        blkq.num_avail += 3; /* 3 descriptors per chain */
+    }
 
     status = (*(uint8_t *)status_buf);
     if (status != VIRTIO_BLK_S_OK)
@@ -168,6 +182,14 @@ void virtio_config_block(uint16_t base, unsigned irq)
     virtio_blk_pci_base = base;
     blk_configured = 1;
     intr_register_irq(irq, handle_virtio_blk_interrupt, NULL);
+
+    /*
+     * We don't need to get interrupts every time the device uses our
+     * descriptors.
+     */
+
+    blkq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
+
     outb(base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
 }
 
@@ -178,7 +200,6 @@ int handle_virtio_blk_interrupt(void *arg __attribute__((unused)))
     if (blk_configured) {
         isr_status = inb(virtio_blk_pci_base + VIRTIO_PCI_ISR);
         if (isr_status & VIRTIO_PCI_ISR_HAS_INTR) {
-            virtq_handle_interrupt(&blkq);
             return 1;
         }
     }

--- a/kernel/virtio/virtio_net.c
+++ b/kernel/virtio/virtio_net.c
@@ -71,6 +71,8 @@ int handle_virtio_net_interrupt(void *arg __attribute__((unused)))
     if (net_configured) {
         isr_status = inb(virtio_net_pci_base + VIRTIO_PCI_ISR);
         if (isr_status & VIRTIO_PCI_ISR_HAS_INTR) {
+	    /* This interrupt is just to kick the application out of any
+             * solo5_poll() that may be running. */
             return 1;
         }
     }

--- a/kernel/virtio/virtio_ring.h
+++ b/kernel/virtio/virtio_ring.h
@@ -103,7 +103,7 @@ struct virtq_used_elem {
 
 struct virtq_used {
         le16 flags;
-        le16 idx;
+        volatile le16 idx;
         struct virtq_used_elem ring[];
         /* Only if VIRTIO_F_EVENT_IDX: le16 avail_event; */
 };
@@ -122,10 +122,6 @@ struct io_buffer {
      * by the device on a rx/read on interrupt handling (do not remove the
      * volatile). */
     volatile uint32_t len;
-
-    /* The driver sets this field to 0 before submitting an IO, and it is set
-     * to 1 at completion on interrupt handling (hence the volatile). */
-    volatile uint8_t completed;
 
     /* Extra flags to be added to the corresponding descriptor. */
     uint16_t extra_flags;
@@ -164,8 +160,6 @@ static inline le16 *virtq_avail_event(struct virtq *vq)
         /* For backwards compat, avail event index is at *end* of used ring. */
         return (le16 *)&vq->used->ring[vq->num];
 }
-
-void virtq_handle_interrupt(struct virtq *vq);
 
 /*
  * Create a descriptor chain starting at index head, using vq->bufs also

--- a/tests/test_ping_serve/test_ping_serve.c
+++ b/tests/test_ping_serve/test_ping_serve.c
@@ -146,6 +146,7 @@ static void ping_serve(int quiet)
     for (;;) {
         struct pingpkt *p = (struct pingpkt *)&buf;
         int len = sizeof(buf);
+        uint64_t t1;
 
         /* wait for packet */
         /* XXX doing the below produces an assert in ukvm, look into it */
@@ -158,6 +159,11 @@ static void ping_serve(int quiet)
             ;
         }
         assert(solo5_net_read_sync(buf, &len) == 0);
+
+        t1 = solo5_clock_monotonic();
+        while ((solo5_clock_monotonic() - t1) < 1e7) {
+            solo5_poll(solo5_clock_monotonic() + 1000000000ULL);
+        }
 
         if (memcmp(p->ether.target, macaddr, HLEN_ETHER) &&
             memcmp(p->ether.target, macaddr_brd, HLEN_ETHER))
@@ -226,7 +232,7 @@ int solo5_app_main(char *cmdline)
     puts("Hello, World\n");
 
     /* anything passed on the command line means "quiet" */
-    ping_serve(strlen(cmdline));
+    ping_serve(strlen(cmdline) + 1);
 
     return 0;
 }


### PR DESCRIPTION
This change removes all the interrupt handling code from virtio-net and virtio-blk. It's mainly done for simplicity purposes. We can do this at the moment because our IO calls are synchronous, and we poll for receiving network packets anyway. Nothing was previously done on interrupt handling besides advancing our index of used descriptors (i.e. last_used). To know that the device used a descriptor (e.g. it put a packet on the ring), we can just check the ring's used->idx index that gets incremented by the device whenever it uses a descriptor chain.

Tests:
- test_ping_serve and test_blk locally on kvm
- static_website on GCE

Quick perf test (`ping -f` against test_ping_serve on kvm):
- current master: `round-trip min/avg/max/stddev = 0.094/0.285/2.296/0.111 ms`
- after change: `round-trip min/avg/max/stddev = 0.086/0.256/6.012/0.160 ms`