### PR TITLE
Print memory map on boot, add stack guard space

### DIFF
--- a/kernel/ukvm/kernel.c
+++ b/kernel/ukvm/kernel.c
@@ -31,7 +31,6 @@ void _start(struct ukvm_boot_info *bi)
     int ret;
 
     banner();
-    printf("mem_size=%lx, kernel_end=%lx\n", bi->mem_size, bi->kernel_end);
 
     gdt_init();
     mem_init(bi->mem_size, bi->kernel_end);


### PR DESCRIPTION
This is useful to be able to quickly eyeball that the memory layout
looks sane and will also aid in debugging addresses in traps / other
crashes.

STACK_GUARD_SIZE is a primitive way of ensuring that (at least) heap
allocation does not overflow into the stack. Ideally we'd want to check
the converse also (stack does not overflow into heap) but the
infrastructure for that is not there yet.