### PR TITLE
Prefix all messages with 'Solo5: '

### DIFF
--- a/kernel/abort.c
+++ b/kernel/abort.c
@@ -12,24 +12,24 @@ static void puts(const char *s)
 
 void _assert_fail(const char *file, const char *line, const char *e)
 {
-    puts("ABORT: ");
+    puts("Solo5: ABORT: ");
     puts(file);
     puts(":");
     puts(line);
     puts(": Assertion `");
     puts(e);
-    puts("' failed\nHalted\n");
+    puts("' failed\nSolo5: Halted\n");
     cpu_halt();
 }
 
 void _abort(const char *file, const char *line, const char *s)
 {
-    puts("ABORT: ");
+    puts("Solo5: ABORT: ");
     puts(file);
     puts(":");
     puts(line);
     puts(": ");
     puts(s);
-    puts("\nHalted\n");
+    puts("\nSolo5: Halted\n");
     cpu_halt();
 }

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -20,6 +20,6 @@
 
 void solo5_exit(void)
 {
-    printf("solo5_exit() called\n");
+    printf("Solo5: solo5_exit() called\n");
     platform_exit();
 }

--- a/kernel/intr.c
+++ b/kernel/intr.c
@@ -190,10 +190,10 @@ static char *traps[32] = {
 
 void trap_handler(uint64_t num, struct trap_regs *regs)
 {
-    printf("trap: type=%s ec=0x%lx rip=0x%lx rsp=0x%lx rflags=0x%lx\n",
+    printf("Solo5: trap: type=%s ec=0x%lx rip=0x%lx rsp=0x%lx rflags=0x%lx\n",
         traps[num], regs->ec, regs->rip, regs->rsp, regs->rflags);
     if (num == 14)
-        printf("trap: cr2=0x%lx\n", regs->cr2);
+        printf("Solo5: trap: cr2=0x%lx\n", regs->cr2);
     PANIC("Fatal trap");
 }
 
@@ -234,7 +234,7 @@ void irq_handler(uint64_t irq)
     }
 
     if (!handled)
-        printf("unhandled irq %d\n", irq);
+        printf("Solo5: unhandled irq %d\n", irq);
     else
         /* Only ACK the IRQ if handled; we only need to know about an unhandled
          * IRQ the first time round. */

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -120,18 +120,6 @@ int memcmp(const void *s1, const void *s2, size_t n);
 char *strcpy(char *dst, const char *src);
 size_t strlen(const char *s);
 
-/* pci.c: only enumerate for now */
-void pci_enumerate(void);
-
-/* virtio.c: mostly net for now */
-void virtio_config_network(uint16_t base, unsigned irq);
-void virtio_config_block(uint16_t base, unsigned irq);
-
-uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
-void virtio_net_pkt_put(void);      /* we're done with recv'd data */
-int virtio_net_xmit_packet(void *data, int len);
-int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
-
 /* platform.c: specifics for ukvm or virito platform */
 void platform_exit(void) __attribute__((noreturn));
 int platform_puts(const char *buf, int n);

--- a/kernel/pvclock.c
+++ b/kernel/pvclock.c
@@ -134,7 +134,7 @@ int pvclock_init(void) {
         return 1;
     }
 
-    printf("Initializing the KVM Paravirtualized clock.\n");
+    printf("Solo5: Clock source: KVM paravirtualized clock\n");
 
     __asm__ __volatile("wrmsr" ::
         "c" (msr_kvm_system_time),

--- a/kernel/ukvm/kernel.c
+++ b/kernel/ukvm/kernel.c
@@ -18,19 +18,14 @@
 
 #include "kernel.h"
 
-static void banner(void)
-{
-    printf("            |      ___|\n");
-    printf("  __|  _ \\  |  _ \\ __ \\\n");
-    printf("\\__ \\ (   | | (   |  ) |\n");
-    printf("____/\\___/ _|\\___/____/\n");
-}
-
 void _start(struct ukvm_boot_info *bi)
 {
     int ret;
 
-    banner();
+    printf("            |      ___|\n");
+    printf("  __|  _ \\  |  _ \\ __ \\\n");
+    printf("\\__ \\ (   | | (   |  ) |\n");
+    printf("____/\\___/ _|\\___/____/\n");
 
     gdt_init();
     mem_init(bi->mem_size, bi->kernel_end);
@@ -43,7 +38,7 @@ void _start(struct ukvm_boot_info *bi)
     intr_enable();
 
     ret = solo5_app_main((char *)bi->cmdline);
-    printf("solo5_app_main() returned with %d\n", ret);
+    printf("Solo5: solo5_app_main() returned with %d\n", ret);
 
     platform_exit();
 }

--- a/kernel/virtio/kernel.c
+++ b/kernel/virtio/kernel.c
@@ -35,7 +35,7 @@ void kernel_main(uint32_t arg)
     printf("____/\\___/ _|\\___/____/\n");
 
     if (!gdb)
-        printf("looping for gdb\n");
+        printf("Solo5: Waiting for gdb...\n");
     while (gdb == 0)
         ;
 
@@ -63,7 +63,7 @@ void kernel_main(uint32_t arg)
 
         if (cmdline_len >= sizeof(cmdline)) {
             cmdline_len = sizeof(cmdline) - 1;
-            printf("kernel_main: warning: command line too long, truncated\n");
+            printf("Solo5: warning: command line too long, truncated\n");
         }
         memcpy(cmdline, mi_cmdline, cmdline_len);
     } else {
@@ -92,7 +92,7 @@ static void kernel_main2(void)
     intr_enable();
 
     ret = solo5_app_main(cmdline);
-    printf("solo5_app_main() returned with %d\n", ret);
+    printf("Solo5: solo5_app_main() returned with %d\n", ret);
 
     platform_exit();
 }

--- a/kernel/virtio/kernel.h
+++ b/kernel/virtio/kernel.h
@@ -16,4 +16,25 @@ uint64_t tscclock_monotonic(void);
 uint64_t tscclock_epochoffset(void);
 void cpu_block(uint64_t until);
 
+/* pci.c: only enumerate for now */
+struct pci_config_info {
+    uint8_t bus;
+    uint8_t dev;
+    uint16_t vendor_id;
+    uint16_t subsys_id;
+    uint16_t base;
+    uint8_t irq;
+};
+
+void pci_enumerate(void);
+
+/* virtio.c: mostly net for now */
+void virtio_config_network(struct pci_config_info *);
+void virtio_config_block(struct pci_config_info *);
+
+uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
+void virtio_net_pkt_put(void);      /* we're done with recv'd data */
+int virtio_net_xmit_packet(void *data, int len);
+int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
+
 #endif

--- a/kernel/virtio/platform.c
+++ b/kernel/virtio/platform.c
@@ -24,7 +24,7 @@ void platform_exit(void)
      * There is no way to initiate "shutdown" on virtio without ACPI, so just
      * halt.
      */
-    printf("Halted\n");
+    platform_puts("Solo5: Halted\n", 15);
     cpu_halt();
 }
 

--- a/kernel/virtio/tscclock.c
+++ b/kernel/virtio/tscclock.c
@@ -190,7 +190,7 @@ int tscclock_init(void) {
     tsc_base = cpu_rdtsc();
     i8254_delay(100000);
     tsc_freq = (cpu_rdtsc() - tsc_base) * 10;
-    printf("TSC frequency estimate is %lu Hz\n",
+    printf("Solo5: Clock source: TSC, frequency estimate is %lu Hz\n",
         (unsigned long long)tsc_freq);
 
     /*

--- a/kernel/virtio/virtio_ring.c
+++ b/kernel/virtio/virtio_ring.c
@@ -43,7 +43,7 @@ int virtq_add_descriptor_chain(struct virtq *vq,
     uint16_t used_descs = num;
 
     if (vq->num_avail < used_descs) {
-        printf("buffer full! next_avail:%d last_used:%d\n",
+        printf("Solo5: virtq full! next_avail:%d last_used:%d\n",
                vq->next_avail, vq->last_used);
             return -1;
     }


### PR DESCRIPTION
- Prefix all messages with 'Solo5 ', allowing for easy eyeballing of
"who printed what" in logs.
- Print more / structured information during PCI enumeration and config.
- No functional change intended, but I had to revamp the data structures
passed around in the PCI code, mostly to get the bus/dev numbers out.