### PR TITLE
Test ping serve fix checksum

### DIFF
--- a/kernel/virtio/virtio_net.c
+++ b/kernel/virtio/virtio_net.c
@@ -103,8 +103,6 @@ int virtio_net_xmit_packet(void *data, int len)
     struct io_buffer *head_buf, *data_buf;
     int r;
 
-    assert(xmitq.used->idx <= xmitq.avail->idx);
-
     /* Consume used descriptors from all the previous tx'es. */
     for (; xmitq.last_used != xmitq.used->idx; xmitq.last_used++)
         xmitq.num_avail += 2; /* 2 descriptors per chain */


### PR DESCRIPTION
There was an issue in the checksum function in test_ping_serve, where many packets had incorrect checksums and were reported by `ping -f` as missed.

Other changes are:
1. reverse the quiet/verbose behavior of test_ping_serve, now any arg passed means verbose mode.
2. there was an assert in virtio_net.c that can legitimately fail when the 16 bit indexes wrap over. 