### PR TITLE
Use qemu "isa-debug-exit" device to shutdown on virtio

### DIFF
--- a/kernel/abort.c
+++ b/kernel/abort.c
@@ -18,8 +18,8 @@ void _assert_fail(const char *file, const char *line, const char *e)
     puts(line);
     puts(": Assertion `");
     puts(e);
-    puts("' failed\nSolo5: Halted\n");
-    cpu_halt();
+    puts("' failed\n");
+    platform_exit();
 }
 
 void _abort(const char *file, const char *line, const char *s)
@@ -30,6 +30,5 @@ void _abort(const char *file, const char *line, const char *s)
     puts(line);
     puts(": ");
     puts(s);
-    puts("\nSolo5: Halted\n");
-    cpu_halt();
+    platform_exit();
 }

--- a/kernel/virtio/platform.c
+++ b/kernel/virtio/platform.c
@@ -21,8 +21,15 @@
 void platform_exit(void)
 {
     /*
-     * There is no way to initiate "shutdown" on virtio without ACPI, so just
-     * halt.
+     * Poke the QEMU "isa-debug-exit" device to "shutdown". Should be harmless
+     * if it is not present. This is used to enable automated tests on virtio.
+     * Note that the actual QEMU exit() status will be 83 ('S', 41 << 1 | 1).
+     */
+    outw(0x501, 41);
+
+    /*
+     * If we got here, there is no way to initiate "shutdown" on virtio without
+     * ACPI, so just halt.
      */
     platform_puts("Solo5: Halted\n", 15);
     cpu_halt();

--- a/tools/run/solo5-run-virtio.sh
+++ b/tools/run/solo5-run-virtio.sh
@@ -139,6 +139,9 @@ kvm|qemu)
         hv_addargs -drive file=${BLKIMG},if=virtio,format=raw
     fi
 
+    # Used by automated tests on QEMU (see kernel/virtio/platform.c).
+    hv_addargs -device isa-debug-exit
+
     hv_addargs -kernel ${UNIKERNEL}
 
     # QEMU command line parsing is just stupid.


### PR DESCRIPTION
This is a hack, but it's the cleanest hack I could find that does the
job without doing anything which could be considered destructive on
other hypervisors.