### PR TITLE
test-blk is using byte offsets and virtio_blk not cleaning up IO bufs before using them

### DIFF
--- a/kernel/virtio/virtio_blk.c
+++ b/kernel/virtio/virtio_blk.c
@@ -78,9 +78,10 @@ static uint16_t virtio_blk_op(uint32_t type,
     head_buf->extra_flags = 0;
 
     /* The data buf */
-    if (type == VIRTIO_BLK_T_OUT) /* write */
+    if (type == VIRTIO_BLK_T_OUT) /* write */ {
         memcpy(data_buf->data, data, len);
-    else
+        data_buf->extra_flags = 0;
+    } else
         data_buf->extra_flags = VIRTQ_DESC_F_WRITE;
     data_buf->len = len;
 

--- a/tests/test_blk/test_blk.c
+++ b/tests/test_blk/test_blk.c
@@ -2,18 +2,21 @@
 
 #define SECTOR_SIZE	512
 
-int check_sector_write(uint64_t offset)
+static uint8_t sector_write[SECTOR_SIZE];
+static uint8_t sector_read[SECTOR_SIZE];
+
+int check_sector_write(uint64_t sector)
 {
-    uint8_t sector_write[SECTOR_SIZE];
-    uint8_t sector_read[SECTOR_SIZE];
     int n = SECTOR_SIZE;
     int i;
 
-    for (i = 0; i < SECTOR_SIZE; i++)
+    for (i = 0; i < SECTOR_SIZE; i++) {
         sector_write[i] = '0' + i % 10;
+        sector_read[i] = 0;
+    }
 
-    solo5_blk_write_sync(offset, sector_write, SECTOR_SIZE);
-    solo5_blk_read_sync(offset, sector_read, &n);
+    solo5_blk_write_sync(sector, sector_write, SECTOR_SIZE);
+    solo5_blk_read_sync(sector, sector_read, &n);
 
     if (n != SECTOR_SIZE)
         return 1;
@@ -34,7 +37,7 @@ int solo5_app_main(char *cmdline __attribute__((unused)))
 
     /* Write and read/check one tenth of the disk. */
     for (i = 0; i < solo5_blk_sectors(); i += 10) {
-        if (check_sector_write(i * SECTOR_SIZE))
+        if (check_sector_write(i))
             /* Check failed */
             return 1;
     }


### PR DESCRIPTION
This PR is for two issues:
- `test_blk` is using `solo5_blk_*_sync` incorrectly, as these use sector numbers and not byte offsets.
- `virtio_blk_op` is not cleaning up the IO bufs completely before reusing them. The consequence is that IO bufs can reuse the flags of previous IOs, which happens when wrapping over the ring.