### PR TITLE
Add a test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c
 sudo: required
 dist: trusty
-script: make
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq qemu-system-x86
+script: make && sudo tests/setup-tests.sh && sudo tests/run-tests.sh

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ target you selected.
 These examples show how to run Mirage/Solo5 unikernels directly.  If
 you'd like to use Docker instead, skip to the next section.
 
-**Setting up networking**
+**Setting up**
 
 The following examples assume you have successfully built the MirageOS
 `stackv4` application, and use the default networking configuration for
@@ -91,8 +91,11 @@ To set up the `tap100` interface on Linux, run (as root):
     ip addr add 10.0.0.1/24 dev tap100
     ip link set dev tap100 up
 
-To set up the `tap100` interface on FreeBSD, run (as root):
+To set up Bhyve and the `tap100` interface on FreeBSD, run (as root):
 
+    kldload vmm
+    kldload if_tap
+    kldload nmdm
     sysctl -w net.link.tap.up_on_open=1
     ifconfig tap100 create 10.0.0.1/24 link0 up
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,22 @@
+# Automated tests
+
+This is an automated test suite for Solo5.
+
+To run the test suite, first ensure your host environment is set up by running
+(as root):
+
+    ./setup-tests.sh
+
+Then, run the test suite with:
+
+    ./run-tests.sh
+
+Some tests / hypervisors require root privileges. For best results, run the
+test suite as root.
+
+When adding tests, please use the following conventions:
+
+1. Each test goes in its own subdirectory.
+2. On success the test should print `SUCCESS` on the console and return from
+   `solo5_app_main()`. This will halt the unikernel.
+3. Add your tests to `run-tests.sh` for automatic invocation.

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,9 @@ Then, run the test suite with:
 Some tests / hypervisors require root privileges. For best results, run the
 test suite as root.
 
+To see full output from all tests (not just the failures), run the test suite
+with the `-v` option.
+
 When adding tests, please use the following conventions:
 
 1. Each test goes in its own subdirectory.

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+#
+# Test harness for running Solo5 automated tests.
+#
+# Tries to run as many tests as are available. Skips tests which cannot be run
+# due to lack of privilege or hypervisor on the host.
+#
+# For best (most complete) results run as root.
+#
+# TODO This should probably be rewritten in something other than shell.
+
+die ()
+{
+    echo $0: "$@" 1>&2
+    exit 1
+}
+
+nuketmpdir ()
+{
+    [ -n "${PRESERVE_TMPDIR}" ] && return
+    [ -z "${TMPDIR}" ] && return
+    [ ! -d "${TMPDIR}" ] && return
+    rm -rf ${TMPDIR}
+}
+
+trap nuketmpdir 0 INT TERM
+TMPDIR=$(mktemp -d)
+if [ $? -ne 0 ]; then
+    echo "error creating temporary directory" 1>&2
+    exit 1
+fi
+
+# Usage:
+#     run_test [ OPTIONS ] TEST
+# Returns:
+#     0: Success
+#     98: Skipped
+#     99: Failed (ran to completion but no SUCCESS in logs)
+#     124: Timeout
+#     (anything else): Other error
+run_test ()
+{
+    logto ()
+    {
+        LOG=${TMPDIR}/$1
+        exec >>${LOG} 2>&1 </dev/null
+    }
+
+    local ARGS
+    local DISK
+    local NET
+    local NAME
+    local UNIKERNEL
+    local TEST_DIR
+    local STATUS
+
+    ARGS=$(getopt dn $*)
+    [ $? -ne 0 ] && return 1
+    set -- ${ARGS}
+    DISK=
+    NET=
+    while true; do
+        case "$1" in
+        -d)
+            DISK=${TMPDIR}/disk.img
+            shift
+            ;;
+        -n)
+            NET=tap100
+            NET_IP=10.0.0.2
+            shift
+            ;;
+        --)
+            shift; break
+            ;;
+        esac
+    done
+    [ $# -ne 1 ] && return 1
+    UNIKERNEL=${SCRIPT_DIR}/${1%%.*}/$1
+    TEST_DIR=${SCRIPT_DIR}/${1%%.*}
+    NAME=$1
+    [ ! -d ${TEST_DIR} ] && return 1
+    [ ! -x ${UNIKERNEL} ] && return 1
+
+    # Test requires a block device. Create a fresh disk image for it.
+    if [ -n "${DISK}" ]; then
+        (
+            logto ${NAME}.log.1
+            set -x; dd if=/dev/zero of=${TMPDIR}/disk.img bs=4k count=1024
+        )
+    fi
+
+    # Network test. Run flood ping as the "client".
+    # XXX This is pretty hacky, and needs improvement. Should also check for
+    # no packet loss on the ping side.
+    if [ -n "${NET}" ]; then
+        # Need root to run this test (for ping -f)
+        [ $(id -u) -ne 0 ] && return 98
+        NET=tap100
+        (
+            logto ${NAME}.log.2
+            sleep 1
+            set -x; timeout 30s ping -fq -c 100000 ${NET_IP}
+        ) &
+        PID_PING=$!
+    fi
+
+    # Run the unikernel under test.
+    (
+        logto ${NAME}.log.0
+
+        echo "-------- ${NAME} START --------"
+
+        case ${NAME} in
+        *.ukvm)
+            [ -c /dev/kvm -a -w /dev/kvm ] || exit 98
+            UKVM=${TEST_DIR}/ukvm-bin
+            [ -n "${DISK}" ] && UKVM="${UKVM} --disk=${DISK}"
+            [ -n "${NET}" ] && UKVM="${UKVM} --net=${NET}"
+            (set -x; timeout 30s ${UKVM} ${UNIKERNEL})
+            STATUS=$?
+            ;;
+        *.virtio)
+            VIRTIO=${SCRIPT_DIR}/../tools/run/solo5-run-virtio.sh
+            [ -n "${DISK}" ] && VIRTIO="${VIRTIO} -d ${DISK}"
+            [ -n "${NET}" ] && VIRTIO="${VIRTIO} -n ${NET}"
+            (set -x; timeout 30s ${VIRTIO} ${UNIKERNEL})
+            STATUS=$?
+            ;;
+        esac
+        
+        echo "-------- ${NAME} END (status ${STATUS}) --------"
+        exit ${STATUS}
+    )
+
+    STATUS=$?
+    case ${STATUS} in
+    # XXX Should this be abstracted out in solo5-run-virtio.sh?
+    0|2|83) 
+        LOGS=$(find ${TMPDIR} -type f -name ${NAME}.log.\*)
+        STATUS=99
+        [ -n "${LOGS}" ] && grep -q SUCCESS ${LOGS} && STATUS=0
+        ;;
+    esac
+
+    wait
+
+    return ${STATUS}
+}
+
+dumplogs ()
+{
+    LOGS=$(find ${TMPDIR} -type f -name $1.log.\*)
+    for F in ${LOGS}; do
+        echo "$2${F}: $3"
+        cat ${F} | sed "s/^/$2>$3 /"
+    done
+}
+
+ARGS=$(getopt v $*)
+[ $? -ne 0 ] && exit 1
+set -- $ARGS
+VERBOSE=
+while true; do
+    case "$1" in
+    -v)
+        VERBOSE=1
+        shift
+        ;;
+    --)
+        shift; break
+        ;;
+    esac
+done
+
+if [ -t 1 ]; then
+    TRED=$(tput setaf 1)
+    TGREEN=$(tput setaf 2)
+    TYELL=$(tput setaf 3)
+    TOFF=$(tput sgr0)
+else
+    TRED=
+    TGREEN=
+    TYELL=
+    TOFF=
+fi
+
+SCRIPT_DIR=$(readlink -f $(dirname $0))
+
+# Grab variables from Makeconf to determine which targets have been built.
+MAKECONF=${SCRIPT_DIR}/../Makeconf
+[ ! -f ${MAKECONF} ] && die "Can't find Makeconf, looked in ${MAKECONF}"
+. ${MAKECONF}
+
+#
+# List of tests to run is defined here.
+#
+# Format: test_foo.TARGET[:OPTIONS]
+#
+TESTS=
+if [ -n "${BUILD_UKVM}" ]; then
+    TESTS="${TESTS} test_hello.ukvm test_blk.ukvm:-d test_ping_serve.ukvm:-n"
+fi
+if [ -n "${BUILD_VIRTIO}" ]; then
+    TESTS="${TESTS} test_hello.virtio test_blk.virtio:-d test_ping_serve.virtio:-n"
+fi
+
+echo "--------------------------------------------------------------------------------"
+echo "Starting tests at $(date)"
+
+FAILED=
+SKIPPED=
+for T in ${TESTS}; do
+    NAME=${T%:*}
+    OPTS=${T#*:}
+    [ "${OPTS}" = "${NAME}" ] && OPTS=
+    printf "%-32s: " "${NAME}"
+    run_test ${OPTS} ${NAME}
+    case $? in
+    0)
+        STATUS=0
+        echo "${TGREEN}PASSED${TOFF}"
+        [ -n "${VERBOSE}" ] && dumplogs ${NAME} ${TGREEN} ${TOFF}
+        ;;
+    99)
+        STATUS=1
+        echo "${TRED}FAILED${TOFF}"
+        ;;
+    98)
+        STATUS=0
+        SKIPPED=1
+        echo "${TYELL}SKIPPED${TOFF}"
+        ;;
+    124)
+        STATUS=1
+        echo "${TRED}TIMEOUT${TOFF}"
+        ;;
+    *)
+        STATUS=1
+        echo "${TRED}ERROR${TOFF}"
+        ;;
+    esac
+    if [ ${STATUS} -ne 0 ]; then
+        FAILED=1
+        dumplogs ${NAME} ${TRED} ${TOFF}
+    fi
+done
+
+echo "Finished tests at $(date)"
+echo "--------------------------------------------------------------------------------"
+
+if [ -n "${FAILED}" ]; then
+    RESULT="${TRED}FAILURE${TOFF}"
+    STATUS=1
+else
+    # Anything skipped gives a yellow "mostly SUCCESS".
+    if [ -n "${SKIPPED}" ]; then
+        RESULT="${TYELL}SUCCESS${TOFF}"
+    else
+        RESULT="${TGREEN}SUCCESS${TOFF}"
+    fi
+    STATUS=0
+fi
+printf "%-32s: %s\n" "Result" "${RESULT}"
+exit ${STATUS}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -125,7 +125,7 @@ run_test ()
             VIRTIO=${SCRIPT_DIR}/../tools/run/solo5-run-virtio.sh
             [ -n "${DISK}" ] && VIRTIO="${VIRTIO} -d ${DISK}"
             [ -n "${NET}" ] && VIRTIO="${VIRTIO} -n ${NET}"
-            (set -x; timeout 30s ${VIRTIO} ${UNIKERNEL} -- "$@")
+            (set -x; timeout 30s ${VIRTIO} -- ${UNIKERNEL} "$@")
             STATUS=$?
             ;;
         esac

--- a/tests/setup-tests.sh
+++ b/tests/setup-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Set up test environment.
+#
+# Convention is: tap interface named 'tap100', host address of 10.0.0.1/24.
+#
+
+if [ $(id -u) -ne 0 ]; then
+    echo "$0: must be root" 1>&2
+    exit 1
+fi
+
+case `uname -s` in
+Linux)
+    set -xe
+    ip tuntap add tap100 mode tap
+    ip addr add 10.0.0.1/24 dev tap100
+    ip link set dev tap100 up
+    ;;
+FreeBSD)
+    kldload vmm
+    kldload if_tap
+    kldload nmdm
+    sysctl -w net.link.tap.up_on_open=1
+    ifconfig tap100 create 10.0.0.1/24 link0 up
+    ;;
+*)
+    exit 1
+    ;;
+esac

--- a/tests/test_blk/test_blk.c
+++ b/tests/test_blk/test_blk.c
@@ -1,5 +1,19 @@
 #include "solo5.h"
 
+static size_t strlen(const char *s)
+{
+    size_t len = 0;
+
+    while (*s++)
+        len += 1;
+    return len;
+}
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
 #define SECTOR_SIZE	512
 
 static uint8_t sector_write[SECTOR_SIZE];
@@ -30,10 +44,11 @@ int check_sector_write(uint64_t sector)
     return 0;
 }
 
-/* Returns 0 if the tests pass, 1 otherwise. */
 int solo5_app_main(char *cmdline __attribute__((unused)))
 {
     uint64_t i;
+
+    puts("\n**** Solo5 standalone test_blk ****\n\n");
 
     /* Write and read/check one tenth of the disk. */
     for (i = 0; i < solo5_blk_sectors(); i += 10) {
@@ -41,6 +56,8 @@ int solo5_app_main(char *cmdline __attribute__((unused)))
             /* Check failed */
             return 1;
     }
+
+    puts("SUCCESS\n");
 
     return 0;
 }

--- a/tests/test_hello/test_hello.c
+++ b/tests/test_hello/test_hello.c
@@ -17,6 +17,8 @@ static void puts(const char *s)
 int solo5_app_main(char *cmdline)
 {
     puts("\n**** Solo5 standalone test_hello ****\n\n");
+
+    /* "SUCCESS" will be passed in via the command line */
     puts("Hello, World\nCommand line is: '");
 
     size_t len = 0;
@@ -27,7 +29,6 @@ int solo5_app_main(char *cmdline)
     solo5_console_write(cmdline, len);
 
     puts("'\n");
-    puts("SUCCESS\n");
 
     return 0;
 }

--- a/tests/test_hello/test_hello.c
+++ b/tests/test_hello/test_hello.c
@@ -1,10 +1,23 @@
 #include "solo5.h"
 
+static size_t strlen(const char *s)
+{
+    size_t len = 0;
+
+    while (*s++)
+        len += 1;
+    return len;
+}
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
 int solo5_app_main(char *cmdline)
 {
-    const char s[] = "Hello, World\nCommand line is: '";
-
-    solo5_console_write(s, sizeof(s));
+    puts("\n**** Solo5 standalone test_hello ****\n\n");
+    puts("Hello, World\nCommand line is: '");
 
     size_t len = 0;
     char *p = cmdline;
@@ -12,8 +25,9 @@ int solo5_app_main(char *cmdline)
     while (*p++)
         len++;
     solo5_console_write(cmdline, len);
-    solo5_console_write("'", 1);
-    solo5_console_write("\n", 1);
+
+    puts("'\n");
+    puts("SUCCESS\n");
 
     return 0;
 }

--- a/tests/test_ping_serve/test_ping_serve.c
+++ b/tests/test_ping_serve/test_ping_serve.c
@@ -263,6 +263,8 @@ static void send_garp(void)
 
 static void ping_serve(int verbose)
 {
+    unsigned long received = 0;
+
     /* XXX this interface should really not return a string */
     char *smac = solo5_net_mac_str();
     for (int i = 0; i < HLEN_ETHER; i++) {
@@ -317,6 +319,10 @@ static void ping_serve(int verbose)
         if (solo5_net_write_sync(buf, len) == -1)
             puts("Write error\n");
 
+        received++;
+        if (received == 100000)
+            break;
+
         continue;
 
 out:
@@ -326,10 +332,12 @@ out:
 
 int solo5_app_main(char *cmdline)
 {
-    puts("Hello, World\n");
+    puts("\n**** Solo5 standalone test_ping_serve ****\n\n");
 
     /* anything passed on the command line means "verbose" */
     ping_serve(strlen(cmdline));
+
+    puts("SUCCESS\n");
 
     return 0;
 }

--- a/tests/test_ping_serve/test_ping_serve.c
+++ b/tests/test_ping_serve/test_ping_serve.c
@@ -261,7 +261,7 @@ static void send_garp(void)
         puts("Could not send GARP packet\n");
 }
 
-static void ping_serve(int verbose)
+static void ping_serve(int verbose, int limit)
 {
     unsigned long received = 0;
 
@@ -320,8 +320,10 @@ static void ping_serve(int verbose)
             puts("Write error\n");
 
         received++;
-        if (received == 100000)
+        if (limit && received == 100000) {
+            puts("Limit reached, exiting\n");
             break;
+        }
 
         continue;
 
@@ -332,10 +334,27 @@ out:
 
 int solo5_app_main(char *cmdline)
 {
+    int verbose = 0;
+    int limit = 0;
+
     puts("\n**** Solo5 standalone test_ping_serve ****\n\n");
 
-    /* anything passed on the command line means "verbose" */
-    ping_serve(strlen(cmdline));
+    if (strlen(cmdline) >= 1) {
+        switch (cmdline[0]) {
+        case 'v':
+            verbose = 1;
+            break;
+        case 'l':
+            limit = 1;
+            break;
+        default:
+            puts("Error in command line.\n");
+            puts("Usage: test_ping_serve [ verbose | limit ]\n");
+            return 1;
+        }
+    }
+
+    ping_serve(verbose, limit);
 
     puts("SUCCESS\n");
 

--- a/tools/run/solo5-run-virtio.sh
+++ b/tools/run/solo5-run-virtio.sh
@@ -81,8 +81,8 @@ done
 [ $# -lt 1 ] && usage
 
 UNIKERNEL=$(readlink -f $1)
+[ -n "${UNIKERNEL}" -a -f "${UNIKERNEL}" ] || die "not found: $1}"
 shift
-[ ! -f ${UNIKERNEL} ] && die "not found: ${UNIKERNEL}"
 VMNAME=$(basename ${UNIKERNEL})
 
 if [ "${HV}" = "best" ]; then


### PR DESCRIPTION
TL;DR: `sudo tests/setup-tests.sh && sudo tests/run-tests.sh`.

Finally, a test suite that runs end to end tests using the standalone test programs in `tests/`. See tests/README.md for usage.

The test harness is a rather gnarly shell script, this is the simplest I could get to that has the basic functionality we need. There are more interesting things that can be done with automated tests, but those will probably need a test harness written in something better than shell.

Please review. 

@hannesm There is a race condition _somewhere_ in the innards of `solo5-run-virtio.sh` for Bhyve which may cause random hard hangs (not sure why `timeout` is not doing the right thing in this case). Will debug in due course.

Part of #82, (1) "end to end CI".