### PR TITLE
ukvm: Clean up error messages

### DIFF
--- a/ukvm/ukvm-blk.c
+++ b/ukvm/ukvm-blk.c
@@ -108,15 +108,11 @@ static int setup(int vcpufd, uint8_t *mem)
     /* set up virtual disk */
     diskfd = open(diskfile, O_RDWR);
     if (diskfd == -1)
-        err(1, "couldn't open disk %s", diskfile);
+        err(1, "Could not open disk: %s", diskfile);
 
     blkinfo.sector_size = 512;
     blkinfo.num_sectors = lseek(diskfd, 0, SEEK_END) / 512;
     blkinfo.rw = 1;
-
-    printf("Providing disk: %zd sectors @ %zd = %zd bytes\n",
-           blkinfo.num_sectors, blkinfo.sector_size,
-           blkinfo.num_sectors * blkinfo.sector_size);
 
     return 0;
 }
@@ -136,6 +132,7 @@ struct ukvm_module ukvm_blk = {
     .handle_exit = handle_exit,
     .handle_cmdarg = handle_cmdarg,
     .setup = setup,
-    .usage = usage
+    .usage = usage,
+    .name = "blk"
 };
 

--- a/ukvm/ukvm-gdb.c
+++ b/ukvm/ukvm-gdb.c
@@ -682,5 +682,6 @@ struct ukvm_module ukvm_gdb = {
     .handle_exit = handle_exit,
     .handle_cmdarg = handle_cmdarg,
     .setup = setup,
-    .usage = usage
+    .usage = usage,
+    .name = "gdb"
 };

--- a/ukvm/ukvm-modules.h
+++ b/ukvm/ukvm-modules.h
@@ -9,6 +9,7 @@ struct ukvm_module {
     int (*handle_cmdarg)(char *cmdarg);
     int (*setup)(int vcpufd, uint8_t *mem);
     char *(*usage)(void);
+    const char *name;
 };
 
 extern struct ukvm_module ukvm_blk;

--- a/ukvm/ukvm-net.c
+++ b/ukvm/ukvm-net.c
@@ -165,7 +165,7 @@ static int setup(int vcpufd, uint8_t *mem)
     strcpy(tun_name, netiface);
     netfd = tun_alloc(tun_name, IFF_TAP | IFF_NO_PI);	/* TAP interface */
     if (netfd < 0) {
-        perror("Allocating interface");
+        err(1, "Could not open interface: %s", netiface);
         exit(1);
     }
     /* generate a random, locally-administered and unicast MAC address */
@@ -187,9 +187,6 @@ static int setup(int vcpufd, uint8_t *mem)
             guest_mac[0], guest_mac[1], guest_mac[2],
             guest_mac[3], guest_mac[4], guest_mac[5]);
 
-    printf("Providing network: %s, guest address %s\n", tun_name,
-            netinfo.mac_str);
-
     return 0;
 }
 
@@ -208,5 +205,6 @@ struct ukvm_module ukvm_net = {
     .handle_exit = handle_exit,
     .handle_cmdarg = handle_cmdarg,
     .setup = setup,
-    .usage = usage
+    .usage = usage,
+    .name = "net"
 };


### PR DESCRIPTION
- Ensure all error messages go to stderr.
- Consistently use err()/errx()/warn()/warnx() everywhere.
- Slightly less terse error messages for users.
- Cosmetic cleanups for usage errors.
- Remove some more commented out/debug code.
- Remove "useless" success messages (CPUID, blk/net setup).

No functional change intended with the exception of the last point (silent operation).

@djwillia I think this addresses "ukvm host feature detection" in #82. #9 talks about a few other things:
- TSC stability: that's a guest issue, I may add some detection to Solo5 for this if needed
- guest page size support which is moot for the moment since 2MB pages are supported on all x86_64 processors)