### PR TITLE
ukvm-configure: Correct dependencies in generated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ include Makefile.common
 .PHONY: all
 all: ukvm virtio
 .DEFAULT_GOAL := all
+.NOTPARALLEL: ukvm virtio
 
 .PHONY: virtio
 virtio:

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -1,3 +1,4 @@
+TOP?=../..
 include $(TOP)/Makefile.common
 
 .PHONY: ukvm
@@ -13,6 +14,7 @@ CFLAGS+=-I$(SOLO5_DIR)
 
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c $< -o $@
+.PRECIOUS: %.o
 
 ifeq ($(BUILD_UKVM), yes)
 Makefile.ukvm: $(UKVM_SRC)/ukvm-configure

--- a/ukvm/ukvm-configure
+++ b/ukvm/ukvm-configure
@@ -37,10 +37,10 @@ $UKVM_SRC/ukvm.h
 _build-ukvm:
 	mkdir -p _build-ukvm
 
-_build-ukvm/ukvm-%.o: $UKVM_SRC/ukvm-%.c _build-ukvm 
+_build-ukvm/ukvm-%.o: $UKVM_SRC/ukvm-%.c \$(MAKEFILE_LIST) | _build-ukvm
 	\$(UKVM_CC) \$(UKVM_CFLAGS) -c \$< -o \$@
 
-ukvm-bin: \$(UKVM_OBJS) \$(UKVM_HEADERS)
+ukvm-bin: \$(UKVM_OBJS) \$(UKVM_HEADERS) \$(MAKEFILE_LIST)
 	\$(UKVM_CC) \$(UKVM_LDFLAGS) -o \$@ \$(UKVM_CFLAGS) \$(UKVM_OBJS) -lpthread -lrt
 
 .PHONY: ukvm-clean


### PR DESCRIPTION
1. Make _build_ukvm/ an order-only prerequisite, thus not rebuilding
bits of ukvm every time due to the timestamp on the directory changing.

2. Add $(MAKEFILE_LIST) to ukvm dependencies, forcing a rebuild of ukvm
if the generated Makefile has changed (e.g. from re-running of
ukvm-configure).