### PR TITLE
Audit ukvm-blk, improve test_blk, plus minor virtio_blk "fix"

### DIFF
--- a/kernel/virtio/virtio_blk.c
+++ b/kernel/virtio/virtio_blk.c
@@ -181,6 +181,11 @@ void virtio_config_block(struct pci_config_info *pci)
 int solo5_blk_write_sync(uint64_t sector, uint8_t *data, int n)
 {
     assert(blk_configured);
+    /*
+     * XXX: virtio_blk_op_sync does not support >1 sectors per operation.
+     */
+    if (n > VIRTIO_BLK_SECTOR_SIZE)
+        return -1;
 
     return virtio_blk_op_sync(VIRTIO_BLK_T_OUT, sector, data, &n);
 }
@@ -188,6 +193,11 @@ int solo5_blk_write_sync(uint64_t sector, uint8_t *data, int n)
 int solo5_blk_read_sync(uint64_t sector, uint8_t *data, int *n)
 {
     assert(blk_configured);
+    /*
+     * XXX: virtio_blk_op_sync does not support >1 sectors per operation.
+     */
+    if (*n > VIRTIO_BLK_SECTOR_SIZE)
+        return -1;
 
     return virtio_blk_op_sync(VIRTIO_BLK_T_IN, sector, data, n);
 }


### PR DESCRIPTION
- ukvm-blk: guard against read/write beyond "end of device"
- ukvm-blk: switch to pread()/pwrite()
- test_blk: clean up, test for edge cases
- virtio_blk: does not support >1 sector per operation, but make it
return -1 rather than asserting so that the new test_blk passes