### PR TITLE
ukvm: Fix argument parsing

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -118,7 +118,7 @@ run_test ()
             UKVM=${TEST_DIR}/ukvm-bin
             [ -n "${DISK}" ] && UKVM="${UKVM} --disk=${DISK}"
             [ -n "${NET}" ] && UKVM="${UKVM} --net=${NET}"
-            (set -x; timeout 30s ${UKVM} ${UNIKERNEL} -- "$@")
+            (set -x; timeout 30s ${UKVM} -- ${UNIKERNEL} "$@")
             STATUS=$?
             ;;
         *.virtio)


### PR DESCRIPTION
User-visible change: "--" now comes before first non-option argument to
ukvm (KERNEL).

Fixes #125.