### PR TITLE
Fix bug in non-builtin add_overflow() when (b < 1)

### DIFF
--- a/ukvm/ukvm-private.h
+++ b/ukvm/ukvm-private.h
@@ -56,7 +56,7 @@
     __typeof(a) __a = a;                                                       \
     __typeof(b) __b = b;                                                       \
     (__b) < 1 ?                                                                \
-    ((__MIN(__typeof(r)) - (__b) >= (__a)) ? __assign(r, __a + __b) : 1) :     \
+    ((__MIN(__typeof(r)) - (__b) <= (__a)) ? __assign(r, __a + __b) : 1) :     \
     ((__MAX(__typeof(r)) - (__b) >= (__a)) ? __assign(r, __a + __b) : 1);      \
     })
 


### PR DESCRIPTION
Commit d0cf32cd5e9d7959c5f66800df1a821b8db68296 introduced the generic
add_overflow() macro for compilers without checked arithmetic builtins.
Unfortunately it also introduced a copy-paste-error for the case where
(b < 1).

This showed up as an "Invalid guest access" in ukvm_port_puts() with a
p->len of 0. This change fixes the typo and the invalid guest access no
longer triggers.