### PR TITLE
Remove -mno-3dnow from MD_CFLAGS

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -10,7 +10,7 @@ OBJCOPY=objcopy
 include $(TOP)/Makeconf
 
 # Exported to OPAM via pkg-config.
-MD_CFLAGS=$(HOST_CFLAGS) -ffreestanding -mno-red-zone -mno-3dnow
+MD_CFLAGS=$(HOST_CFLAGS) -ffreestanding -mno-red-zone
 # Likewise.
 LDFLAGS=-nostdlib -z max-page-size=0x1000 -static
 # CFLAGS used for building kernel/ and in-tree tests.


### PR DESCRIPTION
This has no effect on x86_64 and is a holdover from early cut and paste.