### PR TITLE
Explicitly define USE_LOCKS to 0 in dlmalloc

### DIFF
--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -55,6 +55,7 @@
 #define LACKS_SCHED_H
 #define LACKS_TIME_H
 #define MALLOC_FAILURE_ACTION
+#define USE_LOCKS 0
 
 /* return values from posix_memalign() */
 #define ENOMEM -1      /* Out of memory */


### PR DESCRIPTION
Clang 3.9 does not parse the default value of USE_LOCKS (0). This
change explicitly sets the value to 0 to appease the compiler. No
functional change intended.