### PR TITLE
Solo5 verbosity

### DIFF
--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -26,7 +26,9 @@ ee_printf.o \
 intr.o \
 lib.o \
 malloc.o \
-exit.o
+exit.o \
+log.o \
+cmdline.o
 
 UKVM_COBJS=\
 ukvm/kernel.o \

--- a/kernel/cmdline.c
+++ b/kernel/cmdline.c
@@ -1,0 +1,62 @@
+/* 
+ * Copyright (c) 2015-2017 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a unikernel base layer.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include "kernel.h"
+
+char *cmdline_parse(const char *cmdline)
+{
+    const char opt_quiet[] = "--solo5:quiet";
+    const char opt_debug[] = "--solo5:debug";
+
+    const char *p = cmdline;
+    bool matched;
+    char *after;
+
+    while (*p && isspace(*p))
+        p++;
+
+    while (*p) {
+        matched = false;
+        if (strncmp(p, opt_quiet, (sizeof(opt_quiet) - 1)) == 0) {
+            after = (char *) (p + (sizeof(opt_quiet) - 1));
+            if (isspace(*after) || *after == '\0') {
+                log_set_level(ERROR);
+                p += (sizeof(opt_quiet) - 1);
+                matched = true;
+            }
+        }
+        else if (strncmp(p, opt_debug, (sizeof(opt_debug) - 1)) == 0) {
+            after = (char *) (p + (sizeof(opt_debug) - 1));
+            if (isspace(*after) || *after == '\0') {
+                log_set_level(DEBUG);
+                p += (sizeof(opt_debug) - 1);
+                matched = true;
+            }
+        }
+        if (matched) {
+            while (*p && isspace(*p))
+                p++;
+        }
+        else {
+            break;
+        }
+    }
+
+    return (char *) p;
+}

--- a/kernel/ee_printf.c
+++ b/kernel/ee_printf.c
@@ -700,7 +700,7 @@ repeat:
 }
 
 #define PRINTF_BUF_LEN (4*80)
-static int ee_vprintf(const char *fmt, va_list args)
+int ee_vprintf(const char *fmt, va_list args)
 {
     /* XXX Replace ee_printf() with a version that does not need buffers */
     char buf[PRINTF_BUF_LEN];

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -22,6 +22,6 @@
 
 void solo5_exit(void)
 {
-    printf("Solo5: solo5_exit() called\n");
+    log(INFO, "Solo5: solo5_exit() called\n");
     platform_exit();
 }

--- a/kernel/intr.c
+++ b/kernel/intr.c
@@ -192,10 +192,10 @@ static char *traps[32] = {
 
 void trap_handler(uint64_t num, struct trap_regs *regs)
 {
-    printf("Solo5: trap: type=%s ec=0x%lx rip=0x%lx rsp=0x%lx rflags=0x%lx\n",
+    log(INFO, "Solo5: trap: type=%s ec=0x%lx rip=0x%lx rsp=0x%lx rflags=0x%lx\n",
         traps[num], regs->ec, regs->rip, regs->rsp, regs->rflags);
     if (num == 14)
-        printf("Solo5: trap: cr2=0x%lx\n", regs->cr2);
+        log(INFO, "Solo5: trap: cr2=0x%lx\n", regs->cr2);
     PANIC("Fatal trap");
 }
 
@@ -236,7 +236,7 @@ void irq_handler(uint64_t irq)
     }
 
     if (!handled)
-        printf("Solo5: unhandled irq %d\n", irq);
+        log(ERROR, "Solo5: unhandled irq %d\n", irq);
     else
         /* Only ACK the IRQ if handled; we only need to know about an unhandled
          * IRQ the first time round. */

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -117,8 +117,10 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n);
 void *memmove(void *dest, const void *src, size_t n);
 int memcmp(const void *vl, const void *vr, size_t n);
 int strcmp(const char *l, const char *r);
+int strncmp(const char *l, const char *r, size_t n);
 char *strcpy(char *restrict dest, const char *restrict src);
 size_t strlen(const char *s);
+int isspace(int c);
 
 /* platform.c: specifics for ukvm or virito platform */
 void platform_exit(void) __attribute__((noreturn));
@@ -134,6 +136,19 @@ void platform_intr_ack_irq(unsigned irq);
 int pvclock_init(void);
 uint64_t pvclock_monotonic(void);
 uint64_t pvclock_epochoffset(void);
+
+/* cmdline.c: command line parsing */
+char *cmdline_parse(const char *cmdline);
+
+/* log.c: */
+typedef enum {
+    ERROR=0,
+    WARN, 
+    INFO, 
+    DEBUG,
+} log_level_t;
+int log(log_level_t level, const char *fmt, ...);
+void log_set_level(log_level_t level);
 
 /* accessing devices via port space */
 

--- a/kernel/lib.c
+++ b/kernel/lib.c
@@ -146,3 +146,16 @@ size_t strlen(const char *s)
     for (s = (const void *)w; *s; s++);
     return s-a;
 }
+
+int isspace(int c)
+{
+    return c == ' ' || (unsigned)c-'\t' < 5;
+}
+
+int strncmp(const char *_l, const char *_r, size_t n)
+{
+    const unsigned char *l=(void *)_l, *r=(void *)_r;
+    if (!n--) return 0;
+    for (; *l && *r && n && *l == *r ; l++, r++, n--);
+    return *l - *r;
+}

--- a/kernel/log.c
+++ b/kernel/log.c
@@ -17,31 +17,27 @@
  * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-
 #include "kernel.h"
 
-void _start(struct ukvm_boot_info *bi)
+static log_level_t log_level = INFO;
+
+int ee_vprintf(const char *fmt, va_list args);
+
+int log(log_level_t level, const char *fmt, ...)
 {
-    int ret;
-    char *cmdline;
+    va_list args;
+    int ret = 0;
 
-    cmdline = cmdline_parse((const char *) bi->cmdline);
+    if (log_level >= level) {
+        va_start(args, fmt);
+        ret = ee_vprintf(fmt, args);
+        va_end(args);
+    }
 
-    log(INFO, "            |      ___|\n");
-    log(INFO, "  __|  _ \\  |  _ \\ __ \\\n");
-    log(INFO, "\\__ \\ (   | | (   |  ) |\n");
-    log(INFO, "____/\\___/ _|\\___/____/\n");
+    return ret;
+}
 
-    gdt_init();
-    mem_init(bi->mem_size, bi->kernel_end);
-    intr_init();
-
-    time_init(bi->cpu.tsc_freq);
-
-    intr_enable();
-
-    ret = solo5_app_main(cmdline);
-    log(DEBUG, "Solo5: solo5_app_main() returned with %d\n", ret);
-
-    platform_exit();
+void log_set_level(log_level_t level)
+{
+    log_level = level;
 }

--- a/kernel/ukvm/mem.c
+++ b/kernel/ukvm/mem.c
@@ -37,12 +37,12 @@ void mem_init(uint64_t size, uint64_t kernel_end)
     heap_start = (kernel_end + PAGE_SIZE - 1) & PAGE_MASK;
     heap_top = heap_start;
 
-    printf("Solo5: Memory map: %lu MB addressable:\n", max_addr >> 20);
-    printf("Solo5:     unused @ (0x0 - 0x%lx)\n", &_stext[-1]);
-    printf("Solo5:       text @ (0x%lx - 0x%lx)\n", &_stext, &_etext[-1]);
-    printf("Solo5:     rodata @ (0x%lx - 0x%lx)\n", &_etext, &_erodata[-1]);
-    printf("Solo5:       data @ (0x%lx - 0x%lx)\n", &_erodata, &_end[-1]);
-    printf("Solo5:       heap >= 0x%lx < stack < 0x%lx\n", heap_start,
+    log(INFO, "Solo5: Memory map: %lu MB addressable:\n", max_addr >> 20);
+    log(INFO, "Solo5:     unused @ (0x0 - 0x%lx)\n", &_stext[-1]);
+    log(INFO, "Solo5:       text @ (0x%lx - 0x%lx)\n", &_stext, &_etext[-1]);
+    log(INFO, "Solo5:     rodata @ (0x%lx - 0x%lx)\n", &_etext, &_erodata[-1]);
+    log(INFO, "Solo5:       data @ (0x%lx - 0x%lx)\n", &_erodata, &_end[-1]);
+    log(INFO, "Solo5:       heap >= 0x%lx < stack < 0x%lx\n", heap_start,
         max_addr);
 }
 

--- a/kernel/virtio/kernel.c
+++ b/kernel/virtio/kernel.c
@@ -24,6 +24,7 @@ extern void bounce_stack(uint64_t stack_start, void (*tramp)(void));
 static void kernel_main2(void) __attribute__((noreturn));
 
 static char cmdline[8192];
+static char *app_cmdline;
 
 void kernel_main(uint32_t arg)
 {
@@ -31,13 +32,8 @@ void kernel_main(uint32_t arg)
 
     serial_init();
 
-    printf("            |      ___|\n");
-    printf("  __|  _ \\  |  _ \\ __ \\\n");
-    printf("\\__ \\ (   | | (   |  ) |\n");
-    printf("____/\\___/ _|\\___/____/\n");
-
     if (!gdb)
-        printf("Solo5: Waiting for gdb...\n");
+        log(INFO, "Solo5: Waiting for gdb...\n");
     while (gdb == 0)
         ;
 
@@ -65,12 +61,19 @@ void kernel_main(uint32_t arg)
 
         if (cmdline_len >= sizeof(cmdline)) {
             cmdline_len = sizeof(cmdline) - 1;
-            printf("Solo5: warning: command line too long, truncated\n");
+            log(WARN, "Solo5: warning: command line too long, truncated\n");
         }
         memcpy(cmdline, mi_cmdline, cmdline_len);
     } else {
         cmdline[0] = 0;
     }
+
+    app_cmdline = cmdline_parse((const char *) cmdline);
+
+    log(INFO, "            |      ___|\n");
+    log(INFO, "  __|  _ \\  |  _ \\ __ \\\n");
+    log(INFO, "\\__ \\ (   | | (   |  ) |\n");
+    log(INFO, "____/\\___/ _|\\___/____/\n");
 
     /*
      * Initialise memory map, then immediately switch stack to top of RAM.
@@ -93,8 +96,8 @@ static void kernel_main2(void)
 
     intr_enable();
 
-    ret = solo5_app_main(cmdline);
-    printf("Solo5: solo5_app_main() returned with %d\n", ret);
+    ret = solo5_app_main(app_cmdline);
+    log(DEBUG, "Solo5: solo5_app_main() returned with %d\n", ret);
 
     platform_exit();
 }

--- a/kernel/virtio/mem.c
+++ b/kernel/virtio/mem.c
@@ -62,12 +62,12 @@ void mem_init(struct multiboot_info *mb)
     heap_start = (kernel_end + PAGE_SIZE - 1) & PAGE_MASK;
     heap_top = heap_start;
 
-    printf("Solo5: Memory map: %lu MB addressable:\n", max_addr >> 20);
-    printf("Solo5:     unused @ (0x0 - 0x%lx)\n", &_stext[-1]);
-    printf("Solo5:       text @ (0x%lx - 0x%lx)\n", &_stext, &_etext[-1]);
-    printf("Solo5:     rodata @ (0x%lx - 0x%lx)\n", &_etext, &_erodata[-1]);
-    printf("Solo5:       data @ (0x%lx - 0x%lx)\n", &_erodata, &_end[-1]);
-    printf("Solo5:       heap >= 0x%lx < stack < 0x%lx\n", heap_start,
+    log(INFO, "Solo5: Memory map: %lu MB addressable:\n", max_addr >> 20);
+    log(INFO, "Solo5:     unused @ (0x0 - 0x%lx)\n", &_stext[-1]);
+    log(INFO, "Solo5:       text @ (0x%lx - 0x%lx)\n", &_stext, &_etext[-1]);
+    log(INFO, "Solo5:     rodata @ (0x%lx - 0x%lx)\n", &_etext, &_erodata[-1]);
+    log(INFO, "Solo5:       data @ (0x%lx - 0x%lx)\n", &_erodata, &_end[-1]);
+    log(INFO, "Solo5:       heap >= 0x%lx < stack < 0x%lx\n", heap_start,
         max_addr);
 }
 

--- a/kernel/virtio/pci.c
+++ b/kernel/virtio/pci.c
@@ -64,26 +64,26 @@ static void virtio_config(struct pci_config_info *pci)
     /* we only support one net device and one blk device */
     switch (pci->subsys_id) {
     case PCI_CONF_SUBSYS_NET:
-        printf("Solo5: PCI:%02x:%02x: virtio-net device, base=0x%x, irq=%u\n",
-                pci->bus, pci->dev, pci->base, pci->irq);
+        log(INFO, "Solo5: PCI:%02x:%02x: virtio-net device, base=0x%x, irq=%u\n",
+            pci->bus, pci->dev, pci->base, pci->irq);
         if (!net_devices_found++)
             virtio_config_network(pci);
         else
-            printf("Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
+            log(WARN, "Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
                 pci->dev);
         break;
     case PCI_CONF_SUBSYS_BLK:
-        printf("Solo5: PCI:%02x:%02x: virtio-block device, base=0x%x, irq=%u\n",
-                pci->bus, pci->dev, pci->base, pci->irq);
+        log(INFO, "Solo5: PCI:%02x:%02x: virtio-block device, base=0x%x, irq=%u\n",
+            pci->bus, pci->dev, pci->base, pci->irq);
         if (!blk_devices_found++)
             virtio_config_block(pci);
         else
-            printf("Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
+            log(WARN, "Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
                 pci->dev);
         break;
     default:
-        printf("Solo5: PCI:%02x:%02x: unknown virtio device (0x%x)\n",
-                pci->bus, pci->dev, pci->subsys_id);
+        log(WARN, "Solo5: PCI:%02x:%02x: unknown virtio device (0x%x)\n",
+            pci->bus, pci->dev, pci->subsys_id);
         return;
     }
 }

--- a/kernel/virtio/pvclock.c
+++ b/kernel/virtio/pvclock.c
@@ -154,7 +154,7 @@ int pvclock_init(void) {
         return 1;
     }
 
-    printf("Solo5: Clock source: KVM paravirtualized clock\n");
+    log(INFO, "Solo5: Clock source: KVM paravirtualized clock\n");
 
     __asm__ __volatile("wrmsr" ::
         "c" (msr_kvm_system_time),

--- a/kernel/virtio/tscclock.c
+++ b/kernel/virtio/tscclock.c
@@ -209,7 +209,7 @@ int tscclock_init(void) {
     tsc_base = cpu_rdtsc();
     i8254_delay(100000);
     tsc_freq = (cpu_rdtsc() - tsc_base) * 10;
-    printf("Solo5: Clock source: TSC, frequency estimate is %lu Hz\n",
+    log(INFO, "Solo5: Clock source: TSC, frequency estimate is %lu Hz\n",
         (unsigned long long)tsc_freq);
 
     /*

--- a/kernel/virtio/virtio_blk.c
+++ b/kernel/virtio/virtio_blk.c
@@ -158,7 +158,7 @@ void virtio_config_block(struct pci_config_info *pci)
     outl(pci->base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
 
     virtio_blk_sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
-    printf("Solo5: PCI:%02x:%02x: configured, capacity=%d sectors, "
+    log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%d sectors, "
         "features=0x%x\n",
         pci->bus, pci->dev, virtio_blk_sectors, host_features);
 

--- a/kernel/virtio/virtio_net.c
+++ b/kernel/virtio/virtio_net.c
@@ -170,7 +170,7 @@ void virtio_config_network(struct pci_config_info *pci)
              virtio_net_mac[3],
              virtio_net_mac[4],
              virtio_net_mac[5]);
-    printf("Solo5: PCI:%02x:%02x: configured, mac=%s, features=0x%x\n",
+    log(INFO, "Solo5: PCI:%02x:%02x: configured, mac=%s, features=0x%x\n",
         pci->bus, pci->dev, virtio_net_mac_str, host_features);
 
     /*

--- a/kernel/virtio/virtio_ring.c
+++ b/kernel/virtio/virtio_ring.c
@@ -41,13 +41,12 @@ int virtq_add_descriptor_chain(struct virtq *vq,
     uint16_t mask = vq->num - 1;
     struct virtq_desc *desc;
     uint16_t i;
-    int dbg = 0;
     uint16_t used_descs = num;
 
     if (vq->num_avail < used_descs) {
-        printf("Solo5: virtq full! next_avail:%d last_used:%d\n",
-               vq->next_avail, vq->last_used);
-            return -1;
+        log(WARN, "Solo5: virtq full! next_avail:%d last_used:%d\n",
+            vq->next_avail, vq->last_used);
+        return -1;
     }
 
     assert(used_descs > 0);
@@ -74,10 +73,6 @@ int virtq_add_descriptor_chain(struct virtq *vq,
     /* The last descriptor in the chain does not have a next */
     desc->next = 0;
     desc->flags &= ~VIRTQ_DESC_F_NEXT;
-
-    if (dbg)
-        atomic_printf("0x%p returning head %d\n",
-                      vq, head);
 
     vq->num_avail -= num;
     /* Memory barriers should be unnecessary with one processor */

--- a/tests/test_quiet/Makefile
+++ b/tests/test_quiet/Makefile
@@ -16,28 +16,8 @@
 # NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-TESTDIRS=test_hello test_globals test_ping_serve test_blk \
-         test_exception test_fpu test_time test_quiet
+UKVM_TARGETS=test_quiet.ukvm ukvm-bin
+VIRTIO_TARGETS=test_quiet.virtio
+UKVM_MODULES=
 
-UKVM_TESTS=$(subst test, _test_ukvm, $(TESTDIRS))
-VIRTIO_TESTS=$(subst test, _test_virtio, $(TESTDIRS))
-CLEANS=$(subst test, _clean, $(TESTDIRS))
-
-all: $(UKVM_TESTS) $(VIRTIO_TESTS)
-
-ukvm: $(UKVM_TESTS)
-
-virtio: $(VIRTIO_TESTS)
-
-clean: $(CLEANS)
-
-.PHONY: force_it
-
-_test_ukvm%: force_it
-	$(MAKE) -C $(subst _test_ukvm, test, $@) ukvm
-
-_test_virtio%: force_it
-	$(MAKE) -C $(subst _test_virtio, test, $@) virtio
-
-_clean_%: force_it
-	$(MAKE) -C $(subst _clean, test, $@) clean
+include ../Makefile.tests

--- a/tests/test_quiet/test_quiet.c
+++ b/tests/test_quiet/test_quiet.c
@@ -18,30 +18,27 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "kernel.h"
+#include "solo5.h"
 
-void _start(struct ukvm_boot_info *bi)
+static size_t strlen(const char *s)
 {
-    int ret;
-    char *cmdline;
+    size_t len = 0;
 
-    cmdline = cmdline_parse((const char *) bi->cmdline);
+    while (*s++)
+        len += 1;
+    return len;
+}
 
-    log(INFO, "            |      ___|\n");
-    log(INFO, "  __|  _ \\  |  _ \\ __ \\\n");
-    log(INFO, "\\__ \\ (   | | (   |  ) |\n");
-    log(INFO, "____/\\___/ _|\\___/____/\n");
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
 
-    gdt_init();
-    mem_init(bi->mem_size, bi->kernel_end);
-    intr_init();
-
-    time_init(bi->cpu.tsc_freq);
-
-    intr_enable();
-
-    ret = solo5_app_main(cmdline);
-    log(DEBUG, "Solo5: solo5_app_main() returned with %d\n", ret);
-
-    platform_exit();
+int solo5_app_main(char *cmdline __attribute__((unused)))
+{
+    puts("\n**** Solo5 standalone test_verbose ****\n\n");
+    puts("SUCCESS");
+    /* The run-tests.sh script will run this with --quiet and checks that
+     * there is no "Solo5:". */
+    return 0;
 }


### PR DESCRIPTION
Adding two verbosity related args for solo5 unikernels: `--quiet` and `--debug`.

The changes:

- Most current `printf`s were changed to `log(INFO,...)` and `log(WARN,...)`, and the default verbosity level was set to `INFO` (everything that was logged is still logged).
- Parsing and "eating" the --quiet and --debug args is done inside the unikernel at `_start` before calling `solo5_app_main`. To make things simpler, --quiet/--debug args will be understood as --quiet/--debug only if they are the first argument(s) to the unikernel. For example, `${UNIKERNEL} --quiet blabla` and `${UNIKERNEL} --debug --quiet bleble` will run in quiet mode, while `${UNIKERNEL} blabla --quiet` won't. The cmdline argument to the applications for the previous examples would be `blabla`, `bleble` and `blabla --quiet` respectively.  A large set of examples of how things are parsed can be found at `test-verbosity.sh`.
- Added a test-quiet test into `run-tests.sh`.
- Added a bunch of other tests into `test-verbosity.sh`.

This is part of #161 .