### PR TITLE
Fix check for KVM 32-bit gap

### DIFF
--- a/ukvm/ukvm-core.c
+++ b/ukvm/ukvm-core.c
@@ -628,7 +628,7 @@ int main(int argc, char **argv)
      * slots: one before the pci gap, and one after it.
      * Reference: kvmtool x86/kvm.c:kvm__init_ram()
      */
-    assert(GUEST_SIZE < KVM_32BIT_GAP_SIZE);
+    assert(GUEST_SIZE < KVM_32BIT_GAP_START);
 
     /* Allocate GUEST_SIZE page-aligned guest memory. */
     mem = mmap(NULL, GUEST_SIZE, PROT_READ | PROT_WRITE,


### PR DESCRIPTION
The existing check seems to be incorrect and inconsistent with the comment that precedes it.