### PR TITLE
Replace kernel/lib.c with musl-derived implementations

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -64,6 +64,8 @@ all: virtio ukvm
 virtio: virtio/solo5.o 
 ukvm: ukvm/solo5.o 
 
+CFLAGS+=-D__SOLO5_KERNEL__
+
 %.o: %.c $(HEADERS)
 	$(CC) $(CFLAGS) -c $< -o $@
 

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -115,11 +115,12 @@ int snprintf(char *str, size_t size, const char *format, ...);
 int vsnprintf(char *buf, size_t size, const char *fmt, va_list args);
 
 /* lib.c: expect this to grow... */
-void *memset(void *ptr, uint8_t c, size_t size);
-void *memcpy(void *dst, const void *src, size_t size);
-void *memmove(void *dst, const void *src, size_t n);
-int memcmp(const void *s1, const void *s2, size_t n);
-char *strcpy(char *dst, const char *src);
+void *memset(void *dest, int c, size_t n);
+void *memcpy(void *restrict dest, const void *restrict src, size_t n);
+void *memmove(void *dest, const void *src, size_t n);
+int memcmp(const void *vl, const void *vr, size_t n);
+int strcmp(const char *l, const char *r);
+char *strcpy(char *restrict dest, const char *restrict src);
 size_t strlen(const char *s);
 
 /* platform.c: specifics for ukvm or virito platform */

--- a/kernel/lib.c
+++ b/kernel/lib.c
@@ -18,84 +18,131 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/*
+ * This file contains code derived from musl libc, licensed under the
+ * following standard MIT license:
+ *
+ * Copyright © 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * This file currently serves dual purposes; it's used both by the Solo5
+ * kernel code and the tests. The presence of __SOLO5_KERNEL__ controls
+ * which mode of operation is selected.
+ *
+ * When adding functions to this file ensure that they are entirely
+ * self-contained, or, even better, work on the TODO below instead.
+ *
+ * TODO: Replace this with a proper intergration of nolibc into both the
+ * kernel and tests.
+ */
+#ifdef __SOLO5_KERNEL__
 #include "kernel.h"
+#endif
 
-void *memset(void *ptr, uint8_t c, size_t size)
+void *memset(void *dest, int c, size_t n)
 {
-    size_t i;
+    unsigned char *s = dest;
 
-    for (i = 0; i < size; i++)
-        ((uint8_t *)ptr)[i] = c;
-
-    return ptr;
+    for (; n; n--, s++) *s = c;
+    return dest;
 }
 
-void *memcpy(void *dst, const void *src, size_t size)
+void *memcpy(void *restrict dest, const void *restrict src, size_t n)
 {
-    size_t i;
+    unsigned char *d = dest;
+    const unsigned char *s = src;
 
-    for (i = 0; i < size; i++)
-        ((uint8_t *)dst)[i] = ((uint8_t *)src)[i];
-    return dst;
+    for (; n; n--) *d++ = *s++;
+    return dest;
 }
 
-void *memmove(void *dst, const void *src, size_t n)
+#define WT size_t
+#define WS (sizeof(WT))
+
+void *memmove(void *dest, const void *src, size_t n)
 {
-    uint8_t *tmp = (uint8_t *)malloc(n);
+    char *d = dest;
+    const char *s = src;
 
-    memcpy(tmp, src, n);
-    memcpy(dst, tmp, n);
-    free(tmp);
+    if (d==s) return d;
+    if (s+n <= d || d+n <= s) return memcpy(d, s, n);
 
-    return dst;
-}
-
-int memcmp(const void *s1, const void *s2, size_t n)
-{
-    size_t i;
-
-    for (i = 0; i < n; i++) {
-        if (((uint8_t *)s1)[i] < ((uint8_t *)s2)[i])
-            return -1;
-        if (((uint8_t *)s1)[i] > ((uint8_t *)s2)[i])
-            return 1;
-    }
-    return 0;
-}
-
-int strcmp(const char *s1, const char *s2)
-{
-    while (s1 != 0) {
-        if ((uint8_t)*s1 > (uint8_t)*s2)
-            return 1;
-        if ((uint8_t)*s1 < (uint8_t)*s2)
-            return -1;
-        s1++;
-        s2++;
+    if (d<s) {
+        if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
+            while ((uintptr_t)d % WS) {
+                if (!n--) return dest;
+                *d++ = *s++;
+            }
+            for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(WT *)s;
+        }
+        for (; n; n--) *d++ = *s++;
+    } else {
+        if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
+            while ((uintptr_t)(d+n) % WS) {
+                if (!n--) return dest;
+                d[n] = s[n];
+            }
+            while (n>=WS) n-=WS, *(WT *)(d+n) = *(WT *)(s+n);
+        }
+        while (n) n--, d[n] = s[n];
     }
 
-    return (*s2) ? -1 : 0;
+    return dest;
 }
 
-char *strcpy(char *dst, const char *src)
+int memcmp(const void *vl, const void *vr, size_t n)
 {
-    size_t i = 0;
-
-    do {
-        dst[i] = src[i];
-    } while (src[i++] != 0);
-
-    return dst;
+    const unsigned char *l=vl, *r=vr;
+    for (; n && *l == *r; n--, l++, r++);
+    return n ? *l-*r : 0;
 }
+
+int strcmp(const char *l, const char *r)
+{
+    for (; *l==*r && *l; l++, r++);
+    return *(unsigned char *)l - *(unsigned char *)r;
+}
+
+char *strcpy(char *restrict dest, const char *restrict src)
+{
+    const unsigned char *s = (const unsigned char *)src;
+    unsigned char *d = (unsigned char *)dest;
+    while ((*d++ = *s++));
+    return dest;
+}
+
+#define UCHAR_MAX 255
+#define ALIGN (sizeof(size_t))
+#define ONES ((size_t)-1/UCHAR_MAX)
+#define HIGHS (ONES * (UCHAR_MAX/2+1))
+#define HASZERO(x) (((x)-ONES) & ~(x) & HIGHS)
 
 size_t strlen(const char *s)
 {
-    int n = 0;
-
-    while (*s) {
-        n++;
-        s++;
-    }
-
-    return n;
+    const char *a = s;
+    const size_t *w;
+    for (; (uintptr_t)s % ALIGN; s++) if (!*s) return s-a;
+    for (w = (const void *)s; !HASZERO(*w); w++);
+    for (s = (const void *)w; *s; s++);
+    return s-a;
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -234,7 +234,7 @@ MAKECONF=${SCRIPT_DIR}/../Makeconf
 #
 TESTS=
 if [ -n "${BUILD_UKVM}" ]; then
-    add_test test_hello.ukvm::SUCCESS
+    add_test test_hello.ukvm::Hello_Solo5
     add_test test_globals.ukvm
     add_test test_exception.ukvm:-a
     add_test test_fpu.ukvm
@@ -242,7 +242,7 @@ if [ -n "${BUILD_UKVM}" ]; then
     add_test test_ping_serve.ukvm:-n:limit
 fi
 if [ -n "${BUILD_VIRTIO}" ]; then
-    add_test test_hello.virtio::SUCCESS
+    add_test test_hello.virtio::Hello_Solo5
     add_test test_globals.virtio
     add_test test_exception.virtio:-a
     add_test test_fpu.virtio

--- a/tests/test_blk/test_blk.c
+++ b/tests/test_blk/test_blk.c
@@ -19,15 +19,7 @@
  */
 
 #include "solo5.h"
-
-static size_t strlen(const char *s)
-{
-    size_t len = 0;
-
-    while (*s++)
-        len += 1;
-    return len;
-}
+#include "../../kernel/lib.c"
 
 static void puts(const char *s)
 {

--- a/tests/test_exception/test_exception.c
+++ b/tests/test_exception/test_exception.c
@@ -19,15 +19,7 @@
  */
 
 #include "solo5.h"
-
-static size_t strlen(const char *s)
-{
-    size_t len = 0;
-
-    while (*s++)
-        len += 1;
-    return len;
-}
+#include "../../kernel/lib.c"
 
 static void puts(const char *s)
 {

--- a/tests/test_fpu/test_fpu.c
+++ b/tests/test_fpu/test_fpu.c
@@ -19,15 +19,7 @@
  */
 
 #include "solo5.h"
-
-static size_t strlen(const char *s)
-{
-    size_t len = 0;
-
-    while (*s++)
-        len += 1;
-    return len;
-}
+#include "../../kernel/lib.c"
 
 static void puts(const char *s)
 {

--- a/tests/test_globals/test_globals.c
+++ b/tests/test_globals/test_globals.c
@@ -19,15 +19,7 @@
  */
 
 #include "solo5.h"
-
-static size_t strlen(const char *s)
-{
-    size_t len = 0;
-
-    while (*s++)
-        len += 1;
-    return len;
-}
+#include "../../kernel/lib.c"
 
 static void puts(const char *s)
 {

--- a/tests/test_hello/test_hello.c
+++ b/tests/test_hello/test_hello.c
@@ -19,15 +19,7 @@
  */
 
 #include "solo5.h"
-
-static size_t strlen(const char *s)
-{
-    size_t len = 0;
-
-    while (*s++)
-        len += 1;
-    return len;
-}
+#include "../../kernel/lib.c"
 
 static void puts(const char *s)
 {
@@ -37,8 +29,6 @@ static void puts(const char *s)
 int solo5_app_main(char *cmdline)
 {
     puts("\n**** Solo5 standalone test_hello ****\n\n");
-
-    /* "SUCCESS" will be passed in via the command line */
     puts("Hello, World\nCommand line is: '");
 
     size_t len = 0;
@@ -49,6 +39,10 @@ int solo5_app_main(char *cmdline)
     solo5_console_write(cmdline, len);
 
     puts("'\n");
+
+    /* "Hello_Solo5" will be passed in via the command line */
+    if (strcmp(cmdline, "Hello_Solo5") == 0)
+        puts("SUCCESS\n");
 
     return 0;
 }

--- a/tests/test_ping_serve/test_ping_serve.c
+++ b/tests/test_ping_serve/test_ping_serve.c
@@ -19,39 +19,7 @@
  */
 
 #include "solo5.h"
-
-/* Liberally copied / reinvented libc bits */
-
-static void *memcpy(void *dst, const void *src, size_t size)
-{
-    size_t i;
-
-    for (i = 0; i < size; i++)
-        ((uint8_t *)dst)[i] = ((uint8_t *)src)[i];
-    return dst;
-}
-
-static int memcmp(const void *s1, const void *s2, size_t n)
-{
-    size_t i;
-
-    for (i = 0; i < n; i++) {
-        if (((uint8_t *)s1)[i] < ((uint8_t *)s2)[i])
-            return -1;
-        if (((uint8_t *)s1)[i] > ((uint8_t *)s2)[i])
-            return 1;
-    }
-    return 0;
-}
-
-static size_t strlen(const char *s)
-{
-    size_t len = 0;
-
-    while (*s++)
-        len += 1;
-    return len;
-}
+#include "../../kernel/lib.c"
 
 static void puts(const char *s)
 {


### PR DESCRIPTION
This change replaces the functions defined in kernel/lib.c with
musl-derived implementations, which are then also used by the tests.

This change is motivated by an immediate need for known-good
implementations of these functions. I had not reviewed the original
implementations until running into major bugs in them today. Eventually
we want a better integration of "nolibc" into both kernel (Solo5) and
application (test) code, so this particular arrangement is temporary.

For simplicity the musl-derived implementations have been stripped down
to use the generic "fallback" implementations where possible.