### PR TITLE
Paths for Syslinux files in Arch Linux

### DIFF
--- a/tools/mkimage/solo5-mkimage.sh
+++ b/tools/mkimage/solo5-mkimage.sh
@@ -145,11 +145,14 @@ type mtools >/dev/null 2>/dev/null || die "need mtools installed"
 type mkdosfs >/dev/null 2>/dev/null || die "need dosfstools installed"
 
 SYSLINUX_MBR=$(maybefind /usr/lib/syslinux/mbr/mbr.bin \
-    /usr/share/syslinux/mbr.bin) || die "can't find syslinux mbr.bin"
+                         /usr/share/syslinux/mbr.bin \
+                         /usr/lib/syslinux/bios/mbr.bin) || die "can't find syslinux mbr.bin"
 SYSLINUX_COM32=$(maybefind /usr/lib/syslinux/modules/bios/libcom32.c32 \
-    /usr/share/syslinux/libcom32.c32) || die "can't find syslinux libcom32.c32"
+                           /usr/share/syslinux/libcom32.c32 \
+                           /usr/lib/syslinux/bios/libcom32.c32) || die "can't find syslinux libcom32.c32"
 SYSLINUX_MBOOT=$(maybefind /usr/lib/syslinux/modules/bios/mboot.c32 \
-    /usr/share/syslinux/mboot.c32) || die "can't find syslinux mboot.c32"
+                           /usr/share/syslinux/mboot.c32 \
+                           /usr/lib/syslinux/bios/mboot.c32) || die "can't find syslinux mboot.c32"
 
 trap nuketmpdir 0 INT TERM
 TMPDIR=$(mktemp -d)


### PR DESCRIPTION
Running `solo5-mkimage -f tar blog.tar.gz ./main.native` was failing for me since it can't find `mbr.bin`, `libcom32.c32` and `mboot.c32`. 

Adding the paths for those in this PR creates an image without error. I did encounter another error when uploading the image output Google Compute Engine which may be unrelated:
```
Loading unikernel.bin... ok
Invalid Multiboot image: neither ELF header nor a.out kludge found
boot: 
```
Any idea how to resolve the error above?
