### PR TITLE
Replace ifconfig with ip command

### DIFF
--- a/tools/run/solo5-run-virtio.sh
+++ b/tools/run/solo5-run-virtio.sh
@@ -80,7 +80,13 @@ while true; do
         ;;
     -n)
         NETIF="$2"
-        ifconfig ${NETIF} >/dev/null || die "no such network interface: ${NETIF}"
+        # Check dependencies
+        type ip &>/dev/null ||
+            type ifconfig &>/dev/null ||
+            die "need ip or ifconfig installed"
+        ip a show ${NETIF} &>/dev/null ||
+            ifconfig ${NETIF} &>/dev/null ||
+            die "no such network interface: ${NETIF}"
         shift; shift
         ;;
     -q)


### PR DESCRIPTION
It seems net-tools is supposed to be phased out and scripts are discouraged from using them. https://lwn.net/Articles/710533/

Only found out about this since I noticed my OS didn't have `ifconfig` by default when I ran `solo5-run-virtio`. Turns out some distros no longer include it by default and expecting people to use iproute2 instead. 