### PR TITLE
ukvm_module_net: Check if interface is up and running

### DIFF
--- a/tests/test_ping_serve/test_ping_serve.c
+++ b/tests/test_ping_serve/test_ping_serve.c
@@ -272,16 +272,9 @@ static void ping_serve(int verbose, int limit)
         int len = sizeof(buf);
 
         /* wait for packet */
-        /* XXX doing the below produces an assert in ukvm, look into it */
-        /*
         while (solo5_net_read_sync(buf, &len) != 0) {
             solo5_poll(solo5_clock_monotonic() + 1000000000ULL);
         }
-        */
-        while (solo5_poll(solo5_clock_monotonic() + 1000000000ULL) == 0) {
-            ;
-        }
-        assert(solo5_net_read_sync(buf, &len) == 0);
 
         if (memcmp(p->target, macaddr, HLEN_ETHER) &&
             memcmp(p->target, macaddr_brd, HLEN_ETHER))

--- a/ukvm/ukvm_module_net.c
+++ b/ukvm/ukvm_module_net.c
@@ -83,11 +83,13 @@ static int tap_attach(const char *ifname)
     }
 
     /*
-     * Verify that the interface exists. If we don't do this then we get
-     * "create on open" behaviour on most systems which is not what we want.
+     * Verify that the interface exists and is up and running. If we don't do
+     * this then we get "create on open" behaviour on most systems which is not
+     * what we want.
      */
     struct ifaddrs *ifa, *ifp;
     int found = 0;
+    int up = 0;
 
     if (getifaddrs(&ifa) == -1)
         return -1;
@@ -95,6 +97,7 @@ static int tap_attach(const char *ifname)
     while (ifp) {
         if (strcmp(ifp->ifa_name, ifname) == 0) {
             found = 1;
+            up = ifp->ifa_flags & (IFF_UP | IFF_RUNNING);
             break;
         }
         ifp = ifp->ifa_next;
@@ -102,6 +105,10 @@ static int tap_attach(const char *ifname)
     freeifaddrs(ifa);
     if (!found) {
         errno = ENOENT;
+        return -1;
+    }
+    if (!up) {
+        errno = ENETDOWN;
         return -1;
     }
 

--- a/ukvm/ukvm_module_net.c
+++ b/ukvm/ukvm_module_net.c
@@ -46,6 +46,8 @@
 
 #elif defined(__FreeBSD__)
 
+#include <net/if.h>
+
 #else /* !__linux__ && !__FreeBSD__ */
 
 #error Unsupported target


### PR DESCRIPTION
Prior to attaching to a tap device, check that the network inferface is up and running. This gives the user more meaningful feedback regarding this error.

Furthermore, switch to wait-for-packet variant in the ping serve test because ukvm does no longer raise an assertion.