### PR TITLE
include `uname -a` and `cc --version` output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,7 @@ else
 fi
 
 set -xe
+uname -a
+cc --version
 ${MAKE}
 # Don't run any tests yet


### PR DESCRIPTION
while surf has names of builders, this is not stored in the resulting gist.