### PR TITLE
ukvm_net: move check whether interface is up to after open() on FreeBSD

### DIFF
--- a/ukvm/ukvm_module_net.c
+++ b/ukvm/ukvm_module_net.c
@@ -109,12 +109,13 @@ static int tap_attach(const char *ifname)
         errno = ENOENT;
         return -1;
     }
+
+#if defined(__linux__)
+
     if (!up) {
         errno = ENETDOWN;
         return -1;
     }
-
-#if defined(__linux__)
 
     int err;
     struct ifreq ifr;


### PR DESCRIPTION
This fixes solo5-net running on FreeBSD (update to #178) with `tap` interfaces which are only up after `open()` was called.

EDIT: this moves the check under the `#ifdef linux` conditional.  It also does not check for the interface being `up` on FreeBSD.