### PR TITLE
ukvm/console: return actual number of bytes written

### DIFF
--- a/kernel/ukvm/console.c
+++ b/kernel/ukvm/console.c
@@ -29,7 +29,7 @@ int platform_puts(const char *buf, int n)
 
     ukvm_do_hypercall(UKVM_HYPERCALL_PUTS, &str);
 
-    return str.len;
+    return str.ret;
 }
 
 int solo5_console_write(const char *, size_t)

--- a/ukvm/ukvm_core.c
+++ b/ukvm/ukvm_core.c
@@ -101,6 +101,7 @@ static void hypercall_puts(struct ukvm_hv *hv, ukvm_gpa_t gpa)
         UKVM_CHECKED_GPA_P(hv, gpa, sizeof (struct ukvm_puts));
     int rc = write(1, UKVM_CHECKED_GPA_P(hv, p->data, p->len), p->len);
     assert(rc >= 0);
+    p->ret = rc;
 }
 
 static struct pollfd pollfds[NUM_MODULES];

--- a/ukvm/ukvm_guest.h
+++ b/ukvm/ukvm_guest.h
@@ -140,6 +140,9 @@ struct ukvm_puts {
     /* IN */
     UKVM_GUEST_PTR(const char *) data;
     size_t len;
+
+    /* OUT */
+    int ret;
 };
 
 /* UKVM_HYPERCALL_BLKINFO */


### PR DESCRIPTION
instead of the string length