### PR TITLE
solo5-run-virtio: correct name of freebsd grub2-bhyve package

### DIFF
--- a/tools/run/solo5-run-virtio.sh
+++ b/tools/run/solo5-run-virtio.sh
@@ -124,7 +124,7 @@ if [ "${HV}" = "best" ]; then
         HV=bhyve
         [ $(id -u) -eq 0 ] || die "Root privileges required for bhyve"
         type grub-bhyve >/dev/null 2>&1 \
-            || die "Please install grub-bhyve from ports"
+            || die "Please install sysutils/grub2-bhyve from ports"
         ;;
     *)
         die "unsupported os: ${SYS}"


### PR DESCRIPTION
Confirmed by trying it and checking the FreeBSD Handbook in 21.7.3
https://www.freebsd.org/doc/handbook/virtualization-host-bhyve.html