### PR TITLE
Minimal refresh of Solo5 public APIs

### DIFF
--- a/kernel/ee_printf.c
+++ b/kernel/ee_printf.c
@@ -709,7 +709,8 @@ int ee_vprintf(const char *fmt, va_list args)
     n = vsnprintf(buf, PRINTF_BUF_LEN, fmt, args);
     assert(n < PRINTF_BUF_LEN);
 
-    return platform_puts(buf, n);
+    platform_puts(buf, n);
+    return n;
 }
 
 int printf(const char *fmt, ...)

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -20,8 +20,8 @@
 
 #include "kernel.h"
 
-void solo5_exit(void)
+void solo5_exit(int status)
 {
-    log(INFO, "Solo5: solo5_exit() called\n");
+    log(INFO, "Solo5: solo5_exit(%d) called\n", status);
     platform_exit();
 }

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -108,7 +108,7 @@ void platform_init(void *arg);
 const char *platform_cmdline(void);
 uint64_t platform_mem_size(void);
 void platform_exit(void) __attribute__((noreturn));
-int platform_puts(const char *buf, int n);
+void platform_puts(const char *buf, size_t size);
 
 /* platform_intr.c: platform-specific interrupt handling */
 void platform_intr_init(void);

--- a/kernel/muen/muen-block.c
+++ b/kernel/muen/muen-block.c
@@ -20,27 +20,26 @@
 
 #include "../kernel.h"
 
-/* ukvm block interface */
-int solo5_blk_write_sync(uint64_t sec __attribute__((unused)),
-                         uint8_t *data __attribute__((unused)),
-                         int n __attribute__((unused)))
+int solo5_blk_write_sync(uint64_t offset __attribute__((unused)),
+                         const uint8_t *buf __attribute__((unused)),
+                         size_t size __attribute__((unused)))
 {
     return -1;
 }
 
-int solo5_blk_read_sync(uint64_t sec __attribute__((unused)),
-                        uint8_t *data __attribute__((unused)),
-                        int *n __attribute__((unused)))
+int solo5_blk_read_sync(uint64_t offset __attribute__((unused)),
+                        uint8_t *buf __attribute__((unused)),
+                        size_t size __attribute__((unused)))
 {
     return -1;
 }
 
 int solo5_blk_sector_size(void)
 {
-    return -1;
+    return 0;
 }
 
-uint64_t solo5_blk_sectors(void)
+uint64_t solo5_blk_capacity(void)
 {
     return 0;
 }

--- a/kernel/muen/muen-console.c
+++ b/kernel/muen/muen-console.c
@@ -46,9 +46,9 @@ static void flush()
     clear_buffer();
 }
 
-int platform_puts(const char *buf, int n)
+void platform_puts(const char *buf, size_t n)
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < n; i++) {
         if (buf[i] && buf[i] != 0x0d)
@@ -60,11 +60,9 @@ int platform_puts(const char *buf, int n)
                 msg_index++;
         }
     }
-
-    return n;
 }
 
-int solo5_console_write(const char *, size_t)
+void solo5_console_write(const char *, size_t)
     __attribute__ ((alias("platform_puts")));
 
 void console_init(void)

--- a/kernel/ukvm/block.c
+++ b/kernel/ukvm/block.c
@@ -20,14 +20,13 @@
 
 #include "kernel.h"
 
-/* ukvm block interface */
-int solo5_blk_write_sync(uint64_t sec, uint8_t *data, int n)
+int solo5_blk_write_sync(uint64_t offset, const uint8_t *buf, size_t size)
 {
     volatile struct ukvm_blkwrite wr;
 
-    wr.sector = sec;
-    wr.data = data;
-    wr.len = n;
+    wr.sector = offset;
+    wr.data = buf;
+    wr.len = size;
     wr.ret = 0;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_BLKWRITE, &wr);
@@ -35,18 +34,17 @@ int solo5_blk_write_sync(uint64_t sec, uint8_t *data, int n)
     return wr.ret;
 }
 
-int solo5_blk_read_sync(uint64_t sec, uint8_t *data, int *n)
+int solo5_blk_read_sync(uint64_t offset, uint8_t *buf, size_t size)
 {
     volatile struct ukvm_blkread rd;
 
-    rd.sector = sec;
-    rd.data = data;
-    rd.len = *n;
+    rd.sector = offset;
+    rd.data = buf;
+    rd.len = size;
     rd.ret = 0;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_BLKREAD, &rd);
 
-    *n = rd.len;
     return rd.ret;
 }
 
@@ -59,7 +57,7 @@ int solo5_blk_sector_size(void)
     return info.sector_size;
 }
 
-uint64_t solo5_blk_sectors(void)
+uint64_t solo5_blk_capacity(void)
 {
     volatile struct ukvm_blkinfo info;
 

--- a/kernel/ukvm/console.c
+++ b/kernel/ukvm/console.c
@@ -20,19 +20,17 @@
 
 #include "kernel.h"
 
-int platform_puts(const char *buf, int n)
+void platform_puts(const char *buf, size_t size)
 {
     struct ukvm_puts str;
 
     str.data = (char *)buf;
-    str.len = n;
+    str.len = size;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_PUTS, &str);
-
-    return str.len;
 }
 
-int solo5_console_write(const char *, size_t)
+void solo5_console_write(const char *, size_t)
     __attribute__ ((alias("platform_puts")));
 
 void console_init(void)

--- a/kernel/ukvm/kernel.c
+++ b/kernel/ukvm/kernel.c
@@ -40,7 +40,7 @@ void _start(void *arg)
     net_init();
 
     ret = solo5_app_main(cmdline);
-    log(DEBUG, "Solo5: solo5_app_main() returned with %d\n", ret);
+    log(INFO, "Solo5: solo5_app_main() returned with %d\n", ret);
 
     platform_exit();
 }

--- a/kernel/ukvm/net.c
+++ b/kernel/ukvm/net.c
@@ -20,13 +20,12 @@
 
 #include "kernel.h"
 
-/* ukvm net interface */
-int solo5_net_write_sync(uint8_t *data, int n)
+int solo5_net_write_sync(const uint8_t *buf, size_t size)
 {
     volatile struct ukvm_netwrite wr;
 
-    wr.data = data;
-    wr.len = n;
+    wr.data = buf;
+    wr.len = size;
     wr.ret = 0;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_NETWRITE, &wr);
@@ -34,28 +33,29 @@ int solo5_net_write_sync(uint8_t *data, int n)
     return wr.ret;
 }
 
-int solo5_net_read_sync(uint8_t *data, int *n)
+int solo5_net_read_sync(uint8_t *buf, size_t buf_size, size_t *read_size)
 {
     volatile struct ukvm_netread rd;
 
-    rd.data = data;
-    rd.len = *n;
+    rd.data = buf;
+    rd.len = buf_size;
     rd.ret = 0;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_NETREAD, &rd);
 
-    *n = rd.len;
+    *read_size = rd.len;
     return rd.ret;
 }
 
 static char mac_str[18];
-char *solo5_net_mac_str(void)
+
+const char *solo5_net_mac_str(void)
 {
     volatile struct ukvm_netinfo info;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_NETINFO, &info);
 
-    memcpy(mac_str, (void *)&info, 18);
+    memcpy(mac_str, (void *)info.mac_str, 18);
     return mac_str;
 }
 

--- a/kernel/virtio/kernel.c
+++ b/kernel/virtio/kernel.c
@@ -61,7 +61,7 @@ static void _start2(void *arg __attribute__((unused)))
     cpu_intr_enable();
 
     ret = solo5_app_main(cmdline);
-    log(DEBUG, "Solo5: solo5_app_main() returned with %d\n", ret);
+    log(INFO, "Solo5: solo5_app_main() returned with %d\n", ret);
 
     platform_exit();
 }

--- a/kernel/virtio/kernel.h
+++ b/kernel/virtio/kernel.h
@@ -57,9 +57,9 @@ void pci_enumerate(void);
 void virtio_config_network(struct pci_config_info *);
 void virtio_config_block(struct pci_config_info *);
 
-uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
+uint8_t *virtio_net_pkt_get(size_t *size);  /* get a pointer to recv'd data */
 void virtio_net_pkt_put(void);      /* we're done with recv'd data */
-int virtio_net_xmit_packet(void *data, int len);
+int virtio_net_xmit_packet(const void *data, size_t len);
 int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
 
 #endif

--- a/kernel/virtio/platform.c
+++ b/kernel/virtio/platform.c
@@ -114,15 +114,13 @@ void platform_exit(void)
     cpu_halt();
 }
 
-int platform_puts(const char *buf, int n)
+void platform_puts(const char *buf, size_t n)
 {
-    int i;
+    size_t i;
 
     for (i = 0; i < n; i++)
         serial_putc(buf[i]);
-
-    return n;
 }
 
-int solo5_console_write(const char *, size_t)
+void solo5_console_write(const char *, size_t)
     __attribute__ ((alias("platform_puts")));

--- a/tests/test_exception/test_exception.c
+++ b/tests/test_exception/test_exception.c
@@ -26,7 +26,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(char *cmdline __attribute__((unused)))
+int solo5_app_main(const char *cmdline __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_exception ****\n\n");
 

--- a/tests/test_fpu/test_fpu.c
+++ b/tests/test_fpu/test_fpu.c
@@ -26,7 +26,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(char *cmdline __attribute__((unused)))
+int solo5_app_main(const char *cmdline __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_fpu ****\n\n");
 

--- a/tests/test_globals/test_globals.c
+++ b/tests/test_globals/test_globals.c
@@ -38,7 +38,7 @@ void do_test(void)
     puts(s);
 }
 
-int solo5_app_main(char *cmdline __attribute__((unused)))
+int solo5_app_main(const char *cmdline __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_globals ****\n\n");
 

--- a/tests/test_hello/test_hello.c
+++ b/tests/test_hello/test_hello.c
@@ -26,13 +26,13 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(char *cmdline)
+int solo5_app_main(const char *cmdline)
 {
     puts("\n**** Solo5 standalone test_hello ****\n\n");
     puts("Hello, World\nCommand line is: '");
 
     size_t len = 0;
-    char *p = cmdline;
+    const char *p = cmdline;
 
     while (*p++)
         len++;

--- a/tests/test_quiet/test_quiet.c
+++ b/tests/test_quiet/test_quiet.c
@@ -34,7 +34,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(char *cmdline __attribute__((unused)))
+int solo5_app_main(const char *cmdline __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_verbose ****\n\n");
     puts("SUCCESS\n");

--- a/tests/test_time/test_time.c
+++ b/tests/test_time/test_time.c
@@ -28,7 +28,7 @@ static void puts(const char *s)
 
 #define NSEC_PER_SEC 1000000000ULL
 
-int solo5_app_main(char *cmdline __attribute__((unused)))
+int solo5_app_main(const char *cmdline __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_time ****\n\n");
 

--- a/ukvm/ukvm_module_blk.c
+++ b/ukvm/ukvm_module_blk.c
@@ -54,7 +54,17 @@ static void hypercall_blkwrite(struct ukvm_hv *hv, ukvm_gpa_t gpa)
     ssize_t ret;
     off_t pos, end;
 
+#if 0
     assert(wr->len <= SSIZE_MAX);
+#else
+    /*
+     * XXX: Artificially limit to single sector writes for now.
+     */
+    if (wr->len != blkinfo.sector_size) {
+        wr->ret = -1;
+        return;
+    }
+#endif
     if (wr->sector >= blkinfo.num_sectors) {
         wr->ret = -1;
         return;
@@ -68,8 +78,15 @@ static void hypercall_blkwrite(struct ukvm_hv *hv, ukvm_gpa_t gpa)
 
     ret = pwrite(diskfd, UKVM_CHECKED_GPA_P(hv, wr->data, wr->len), wr->len,
             pos);
+#if 0
     assert(ret == wr->len);
     wr->ret = 0;
+#else
+    if (ret == wr->len)
+        wr->ret = 0;
+    else
+        wr->ret = -1;
+#endif
 }
 
 static void hypercall_blkread(struct ukvm_hv *hv, ukvm_gpa_t gpa)
@@ -79,7 +96,17 @@ static void hypercall_blkread(struct ukvm_hv *hv, ukvm_gpa_t gpa)
     ssize_t ret;
     off_t pos, end;
 
+#if 0
     assert(rd->len <= SSIZE_MAX);
+#else
+    /*
+     * XXX: Artificially limit to single sector writes for now.
+     */
+    if (rd->len != blkinfo.sector_size) {
+        rd->ret = -1;
+        return;
+    }
+#endif
     if (rd->sector >= blkinfo.num_sectors) {
         rd->ret = -1;
         return;
@@ -93,8 +120,15 @@ static void hypercall_blkread(struct ukvm_hv *hv, ukvm_gpa_t gpa)
 
     ret = pread(diskfd, UKVM_CHECKED_GPA_P(hv, rd->data, rd->len), rd->len,
             pos);
+#if 0
     assert(ret == rd->len);
     rd->ret = 0;
+#else
+    if (ret == rd->len)
+        rd->ret = 0;
+    else
+        rd->ret = -1;
+#endif
 }
 
 static int handle_cmdarg(char *cmdarg)


### PR DESCRIPTION
This is a minimal refresh of the Solo5 public APIs and their underlying backend implementations for ukvm, virtio and muen to fix the most egregious problems as described in #200.

Summary of high-level changes, see [solo5.h](kernel/solo5.h) for full details:
1. `solo5_app_main()`: Add `const` to `cmdline`, document as returning a status code.
2. `solo5_net_write_sync()`: Add `const` to `buf`, pass `size` as `size_t`, document and enforce failure cases.
3. `solo5_net_read_sync()`: Pass sizes as `size_t`, return `read_size` separately from error code, document and enforce failure cases.
4. `solo5_net_mac_str()`: Add `const` to return type.
5. `solo5_blk_write_sync()`: Add `const` to `buf`, use `size_t` for sizes, restrict to single-sector full writes, document and enforce failure cases.
6. `solo5_blk_read_sync()`: Use `size_t` for sizes, restrict to single-sector full reads, document and enforce failure cases.
7. `solo5_blk_sectors()`: Rename to `solo5_blk_capacity()` to lessen confusion with `solo5_blk_sector_size()`.
8. `solo5_console_write()`: Change return type to `void` and document as _not_ having explicit failure cases.
9. All other public functions: Clarify documentation.

No functional change intended, hopefully a lot of edge case bugs elided. Tests have been updated and are passing on Linux and FreeBSD for `ukvm` and `virtio`.