### PR TITLE
fix case fall through for gcc 7

### DIFF
--- a/kernel/ee_printf.c
+++ b/kernel/ee_printf.c
@@ -637,6 +637,7 @@ repeat:
 
         case 'A':
             flags |= UPPERCASE;
+            /* FALLTHRU */
 
         case 'a':
             if (qualifier == 'l')
@@ -654,6 +655,7 @@ repeat:
 
         case 'X':
             flags |= UPPERCASE;
+            /* FALLTHRU */
 
         case 'x':
             base = 16;


### PR DESCRIPTION
gcc 7 warns on switch case fall through.

Due to -Werror this will abort the compilation.

adding /* FALLTHRU */ as a comment stops the warning.

see: https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/