### PR TITLE
Fix --gdb-port handling

### DIFF
--- a/ukvm/ukvm_module_gdb.c
+++ b/ukvm/ukvm_module_gdb.c
@@ -641,13 +641,13 @@ static int setup(struct ukvm_hv *hv)
 
 static int handle_cmdarg(char *cmdarg)
 {
-    if (!strncmp("--gdb", cmdarg, 5)) {
+    if (!strcmp("--gdb", cmdarg)) {
         use_gdb = true;
         return 0;
     } else if (!strncmp("--gdb-port=", cmdarg, 11)) {
-        portno = strtol(cmdarg + 11, NULL, 10);
-        if (portno < 0 || portno > 65535) {
-          errx(1, "Malformed port: %d", portno);
+        int rc = sscanf(cmdarg, "--gdb-port=%d", &portno);
+        if (rc != 1 || portno < 0 || portno > 65535) {
+            errx(1, "Malformed argument to --gdb-port");
         }
         return 0;
     }


### PR DESCRIPTION
Followup to #208. In this case I actually tested the changes. /cc @hannesm 

Two problems in the original change to --gdb-port:

1. Can't use `strncmp()` to test for `"--gdb"` since this is true for `"--gdb-port=X"` also.
2. `strtol()` error handling is horrible and will happily return `0` with `errno=0` if no digits were matched. Use `sscanf()` instead.