### PR TITLE
add command line argument for memory size

### DIFF
--- a/ukvm/ukvm.h
+++ b/ukvm/ukvm.h
@@ -83,7 +83,7 @@ struct ukvm_hv *ukvm_hv_init(size_t mem_size);
 
 /*
  * Computes the memory size to use for this monitor, based on the user-provided
- * value (rounding up if necessary).
+ * value (rounding down if necessary).
  */
 void ukvm_hv_mem_size(size_t *mem_size);
 

--- a/ukvm/ukvm.h
+++ b/ukvm/ukvm.h
@@ -82,6 +82,12 @@ inline void *ukvm_checked_gpa_p(struct ukvm_hv *hv, ukvm_gpa_t gpa, size_t sz,
 struct ukvm_hv *ukvm_hv_init(size_t mem_size);
 
 /*
+ * Computes the memory size to use for this monitor, based on the user-provided
+ * value (rounding up if necessary).
+ */
+void ukvm_hv_mem_size(size_t *mem_size);
+
+/*
  * Initialise VCPU state with (gpa_ep) as the entry point and (gpa_kend) as the
  * last byte of memory used by the guest binary. In (*cmdline), returns a
  * buffer with UKVM_CMDLINE_SIZE bytes of space for the guest command line.

--- a/ukvm/ukvm_cpu_aarch64.c
+++ b/ukvm/ukvm_cpu_aarch64.c
@@ -108,15 +108,14 @@ void aarch64_setup_memory_mapping(uint8_t *va_addr, uint64_t ram_size,
 
 void aarch64_mem_size(size_t *mem_size) {
   size_t mem;
-  if (*mem_size < PMD_SIZE * 4)
-    warnx("adjusting memory to minimum of %zu", PMD_SIZE * 4);
-  mem = PMD_SIZE * 4;
-  mem = (mem + (PMD_SIZE - 1)) / PMD_SIZE;
-  mem *= PMD_SIZE;
+  mem = (*mem_size / PMD_SIZE) * PMD_SIZE;
   if (mem > *mem_size)
-    warnx("adjusting memory to %zu", mem);
+    err(1, "won't increase your memory from %zu bytes to %zu bytes",
+        *mem_size, mem);
+  if (mem < *mem_size)
+    warnx("adjusting memory to %zu bytes", mem);
   if (mem > AARCH64_MMIO_BASE)
-    err(1, "The guest memory %zu exceeds the max size %zu\n",
+    err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
         mem, AARCH64_MMIO_BASE);
   *mem_size = mem;
 }

--- a/ukvm/ukvm_cpu_aarch64.c
+++ b/ukvm/ukvm_cpu_aarch64.c
@@ -105,3 +105,18 @@ void aarch64_setup_memory_mapping(uint8_t *va_addr, uint64_t ram_size,
         phy_space_size -= map_size;
     }
 }
+
+void aarch64_mem_size(size_t *mem_size) {
+  size_t mem;
+  if (*mem_size < PMD_SIZE * 4)
+    warnx("adjusting memory to minimum of %zu", PMD_SIZE * 4);
+  mem = PMD_SIZE * 4;
+  mem = (mem + (PMD_SIZE - 1)) / PMD_SIZE;
+  mem *= PMD_SIZE;
+  if (mem > *mem_size)
+    warnx("adjusting memory to %zu", mem);
+  if (mem > AARCH64_MMIO_BASE)
+    err(1, "The guest memory %zu exceeds the max size %zu\n",
+        mem, AARCH64_MMIO_BASE);
+  *mem_size = mem;
+}

--- a/ukvm/ukvm_cpu_aarch64.c
+++ b/ukvm/ukvm_cpu_aarch64.c
@@ -113,7 +113,7 @@ void aarch64_mem_size(size_t *mem_size) {
     if (mem < *mem_size)
         warnx("adjusting memory to %zu bytes", mem);
     if (mem > AARCH64_MMIO_BASE)
-        err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
+        err(1, "guest memory size %zu bytes exceeds the max size %lu bytes",
             mem, AARCH64_MMIO_BASE);
     *mem_size = mem;
 }

--- a/ukvm/ukvm_cpu_aarch64.c
+++ b/ukvm/ukvm_cpu_aarch64.c
@@ -107,13 +107,13 @@ void aarch64_setup_memory_mapping(uint8_t *va_addr, uint64_t ram_size,
 }
 
 void aarch64_mem_size(size_t *mem_size) {
-  size_t mem;
-  mem = (*mem_size / PMD_SIZE) * PMD_SIZE;
-  assert (mem <= *mem_size);
-  if (mem < *mem_size)
-    warnx("adjusting memory to %zu bytes", mem);
-  if (mem > AARCH64_MMIO_BASE)
-    err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
-        mem, AARCH64_MMIO_BASE);
-  *mem_size = mem;
+    size_t mem;
+    mem = (*mem_size / PMD_SIZE) * PMD_SIZE;
+    assert (mem <= *mem_size);
+    if (mem < *mem_size)
+        warnx("adjusting memory to %zu bytes", mem);
+    if (mem > AARCH64_MMIO_BASE)
+        err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
+            mem, AARCH64_MMIO_BASE);
+    *mem_size = mem;
 }

--- a/ukvm/ukvm_cpu_aarch64.c
+++ b/ukvm/ukvm_cpu_aarch64.c
@@ -109,9 +109,7 @@ void aarch64_setup_memory_mapping(uint8_t *va_addr, uint64_t ram_size,
 void aarch64_mem_size(size_t *mem_size) {
   size_t mem;
   mem = (*mem_size / PMD_SIZE) * PMD_SIZE;
-  if (mem > *mem_size)
-    err(1, "won't increase your memory from %zu bytes to %zu bytes",
-        *mem_size, mem);
+  assert (mem <= *mem_size);
   if (mem < *mem_size)
     warnx("adjusting memory to %zu bytes", mem);
   if (mem > AARCH64_MMIO_BASE)

--- a/ukvm/ukvm_cpu_aarch64.h
+++ b/ukvm/ukvm_cpu_aarch64.h
@@ -149,5 +149,6 @@ struct pgd {
 };
 
 void aarch64_setup_memory_mapping(uint8_t *va_addr, uint64_t mem_size, uint64_t space_size);
+void aarch64_mem_size(size_t *mem_size);
 
 #endif /* UKVM_CPU_AARCH64_H */

--- a/ukvm/ukvm_cpu_x86_64.c
+++ b/ukvm/ukvm_cpu_x86_64.c
@@ -32,15 +32,15 @@
 #include "ukvm_cpu_x86_64.h"
 
 void ukvm_x86_mem_size(size_t *mem_size) {
-  size_t mem;
-  mem = (*mem_size / X86_GUEST_PAGE_SIZE) * X86_GUEST_PAGE_SIZE;
-  assert (mem <= *mem_size);
-  if (mem < *mem_size)
-    warnx("adjusting memory to %zu bytes", mem);
-  if (mem > X86_GUEST_PAGE_SIZE * 512)
-    err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
-        mem, X86_GUEST_PAGE_SIZE * 512);
-  *mem_size = mem;
+    size_t mem;
+    mem = (*mem_size / X86_GUEST_PAGE_SIZE) * X86_GUEST_PAGE_SIZE;
+    assert (mem <= *mem_size);
+    if (mem < *mem_size)
+        warnx("adjusting memory to %zu bytes", mem);
+    if (mem > X86_GUEST_PAGE_SIZE * 512)
+        err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
+            mem, X86_GUEST_PAGE_SIZE * 512);
+    *mem_size = mem;
 }
 
 void ukvm_x86_setup_pagetables(uint8_t *mem, size_t mem_size)

--- a/ukvm/ukvm_cpu_x86_64.c
+++ b/ukvm/ukvm_cpu_x86_64.c
@@ -23,12 +23,28 @@
  * backend implementations.
  */
 
+#include <err.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
 #include "ukvm_cpu_x86_64.h"
+
+void ukvm_x86_mem_size(size_t *mem_size) {
+  size_t mem;
+  if (*mem_size < X86_GUEST_PAGE_SIZE * 4)
+    warnx("adjusting memory to minimum of %ul", X86_GUEST_PAGE_SIZE * 4);
+  mem = X86_GUEST_PAGE_SIZE * 4;
+  mem = (mem + (X86_GUEST_PAGE_SIZE - 1)) / X86_GUEST_PAGE_SIZE;
+  mem *= X86_GUEST_PAGE_SIZE;
+  if (mem > *mem_size)
+    warnx("adjusting memory to %zu", mem);
+  if (mem > X86_GUEST_PAGE_SIZE * 512)
+    err(1, "guest memory size %zu exceeds the max size %ul\n",
+        mem, X86_GUEST_PAGE_SIZE * 512);
+  *mem_size = mem;
+}
 
 void ukvm_x86_setup_pagetables(uint8_t *mem, size_t mem_size)
 {

--- a/ukvm/ukvm_cpu_x86_64.c
+++ b/ukvm/ukvm_cpu_x86_64.c
@@ -38,7 +38,7 @@ void ukvm_x86_mem_size(size_t *mem_size) {
     if (mem < *mem_size)
         warnx("adjusting memory to %zu bytes", mem);
     if (mem > X86_GUEST_PAGE_SIZE * 512)
-        err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
+        err(1, "guest memory size %zu bytes exceeds the max size %u bytes",
             mem, X86_GUEST_PAGE_SIZE * 512);
     *mem_size = mem;
 }

--- a/ukvm/ukvm_cpu_x86_64.c
+++ b/ukvm/ukvm_cpu_x86_64.c
@@ -33,15 +33,14 @@
 
 void ukvm_x86_mem_size(size_t *mem_size) {
   size_t mem;
-  if (*mem_size < X86_GUEST_PAGE_SIZE * 4)
-    warnx("adjusting memory to minimum of %ul", X86_GUEST_PAGE_SIZE * 4);
-  mem = X86_GUEST_PAGE_SIZE * 4;
-  mem = (mem + (X86_GUEST_PAGE_SIZE - 1)) / X86_GUEST_PAGE_SIZE;
-  mem *= X86_GUEST_PAGE_SIZE;
+  mem = (*mem_size / X86_GUEST_PAGE_SIZE) * X86_GUEST_PAGE_SIZE;
   if (mem > *mem_size)
-    warnx("adjusting memory to %zu", mem);
+    err(1, "won't increase your memory from %zu byes to %zu bytes",
+        *mem_size, mem);
+  if (mem < *mem_size)
+    warnx("adjusting memory to %zu bytes", mem);
   if (mem > X86_GUEST_PAGE_SIZE * 512)
-    err(1, "guest memory size %zu exceeds the max size %ul\n",
+    err(1, "guest memory size %zu bytes exceeds the max size %ul bytes",
         mem, X86_GUEST_PAGE_SIZE * 512);
   *mem_size = mem;
 }

--- a/ukvm/ukvm_cpu_x86_64.c
+++ b/ukvm/ukvm_cpu_x86_64.c
@@ -34,9 +34,7 @@
 void ukvm_x86_mem_size(size_t *mem_size) {
   size_t mem;
   mem = (*mem_size / X86_GUEST_PAGE_SIZE) * X86_GUEST_PAGE_SIZE;
-  if (mem > *mem_size)
-    err(1, "won't increase your memory from %zu byes to %zu bytes",
-        *mem_size, mem);
+  assert (mem <= *mem_size);
   if (mem < *mem_size)
     warnx("adjusting memory to %zu bytes", mem);
   if (mem > X86_GUEST_PAGE_SIZE * 512)

--- a/ukvm/ukvm_cpu_x86_64.h
+++ b/ukvm/ukvm_cpu_x86_64.h
@@ -211,6 +211,7 @@ static const struct x86_sreg ukvm_x86_sreg_unusable = {
  */
 #define X86_RFLAGS_INIT         0x2
 
+void ukvm_x86_mem_size(size_t *mem_size);
 void ukvm_x86_setup_pagetables(uint8_t *mem, size_t mem_size);
 void ukvm_x86_setup_gdt(uint8_t *mem);
 

--- a/ukvm/ukvm_hv_freebsd_x86_64.c
+++ b/ukvm/ukvm_hv_freebsd_x86_64.c
@@ -45,6 +45,10 @@
 #include "ukvm_hv_freebsd.h"
 #include "ukvm_cpu_x86_64.h"
 
+void ukvm_hv_mem_size(size_t *mem_size) {
+  ukvm_x86_mem_size(mem_size);
+}
+
 static void vmm_set_desc(int vmfd, int reg, uint64_t base, uint32_t limit,
         uint32_t access)
 {

--- a/ukvm/ukvm_hv_freebsd_x86_64.c
+++ b/ukvm/ukvm_hv_freebsd_x86_64.c
@@ -46,7 +46,7 @@
 #include "ukvm_cpu_x86_64.h"
 
 void ukvm_hv_mem_size(size_t *mem_size) {
-  ukvm_x86_mem_size(mem_size);
+    ukvm_x86_mem_size(mem_size);
 }
 
 static void vmm_set_desc(int vmfd, int reg, uint64_t base, uint32_t limit,

--- a/ukvm/ukvm_hv_kvm_aarch64.c
+++ b/ukvm/ukvm_hv_kvm_aarch64.c
@@ -403,3 +403,7 @@ void ukvm_hv_vcpu_loop(struct ukvm_hv *hv)
         } /* switch(run->exit_reason) */
     }
 }
+
+void ukvm_hv_mem_size(size_t *mem_size) {
+  aarch64_mem_size(mem_size);
+}

--- a/ukvm/ukvm_hv_kvm_aarch64.c
+++ b/ukvm/ukvm_hv_kvm_aarch64.c
@@ -405,5 +405,5 @@ void ukvm_hv_vcpu_loop(struct ukvm_hv *hv)
 }
 
 void ukvm_hv_mem_size(size_t *mem_size) {
-  aarch64_mem_size(mem_size);
+    aarch64_mem_size(mem_size);
 }

--- a/ukvm/ukvm_hv_kvm_x86_64.c
+++ b/ukvm/ukvm_hv_kvm_x86_64.c
@@ -38,6 +38,10 @@
 #include "ukvm_hv_kvm.h"
 #include "ukvm_cpu_x86_64.h"
 
+void ukvm_hv_mem_size(size_t *mem_size) {
+  ukvm_x86_mem_size(mem_size);
+}
+
 static void setup_cpuid(struct ukvm_hvb *hvb)
 {
     struct kvm_cpuid2 *kvm_cpuid;

--- a/ukvm/ukvm_hv_kvm_x86_64.c
+++ b/ukvm/ukvm_hv_kvm_x86_64.c
@@ -39,7 +39,7 @@
 #include "ukvm_cpu_x86_64.h"
 
 void ukvm_hv_mem_size(size_t *mem_size) {
-  ukvm_x86_mem_size(mem_size);
+    ukvm_x86_mem_size(mem_size);
 }
 
 static void setup_cpuid(struct ukvm_hvb *hvb)

--- a/ukvm/ukvm_main.c
+++ b/ukvm/ukvm_main.c
@@ -86,6 +86,17 @@ static void sig_handler(int signo)
     errx(1, "Exiting on signal %d", signo);
 }
 
+static void handle_mem(char *cmdarg, size_t *mem_size)
+{
+  size_t mem;
+  int rc = sscanf(cmdarg, "--mem=%zd", &mem);
+  mem = mem << 20;
+  if (rc != 1 || mem <= 0) {
+    errx(1, "Malformed argument to --mem");
+  }
+  *mem_size = mem;
+}
+
 static void usage(const char *prog)
 {
     fprintf(stderr, "usage: %s [ CORE OPTIONS ] [ MODULE OPTIONS ] [ -- ] "
@@ -93,6 +104,7 @@ static void usage(const char *prog)
     fprintf(stderr, "KERNEL is the filename of the unikernel to run.\n");
     fprintf(stderr, "ARGS are optional arguments passed to the unikernel.\n");
     fprintf(stderr, "Core options:\n");
+    fprintf(stderr, "  [ --mem=512 ] (guest memory in MB)\n");
     fprintf(stderr, "    --help (display this help)\n");
     fprintf(stderr, "Compiled-in modules: ");
     for (struct ukvm_module **m = ukvm_core_modules; *m; m++) {
@@ -137,6 +149,12 @@ int main(int argc, char **argv)
         }
 
         matched = 0;
+        if (strncmp("--mem=", *argv, 6) == 0) {
+            handle_mem(*argv, &mem_size);
+            matched = 1;
+            argc--;
+            argv++;
+        }
         if (handle_cmdarg(*argv) == 0) {
             /* Handled by module, consume and go on to next arg */
             matched = 1;

--- a/ukvm/ukvm_main.c
+++ b/ukvm/ukvm_main.c
@@ -88,13 +88,13 @@ static void sig_handler(int signo)
 
 static void handle_mem(char *cmdarg, size_t *mem_size)
 {
-  size_t mem;
-  int rc = sscanf(cmdarg, "--mem=%zd", &mem);
-  mem = mem << 20;
-  if (rc != 1 || mem <= 0) {
-    errx(1, "Malformed argument to --mem");
-  }
-  *mem_size = mem;
+    size_t mem;
+    int rc = sscanf(cmdarg, "--mem=%zd", &mem);
+    mem = mem << 20;
+    if (rc != 1 || mem <= 0) {
+        errx(1, "Malformed argument to --mem");
+    }
+    *mem_size = mem;
 }
 
 static void usage(const char *prog)

--- a/ukvm/ukvm_main.c
+++ b/ukvm/ukvm_main.c
@@ -185,6 +185,7 @@ int main(int argc, char **argv)
     if (sigaction(SIGTERM, &sa, NULL) == -1)
         err(1, "Could not install signal handler");
 
+    ukvm_hv_mem_size(&mem_size);
     struct ukvm_hv *hv = ukvm_hv_init(mem_size);
 
     ukvm_elf_load(elffile, hv->mem, hv->mem_size, &gpa_ep, &gpa_kend);


### PR DESCRIPTION
I have tested this locally, and (when using MirageOS), values `>=12 MB` are reasonable (with 8 MB the OCaml runtime won't start up, 10 MB results in a out of memory before execution of main in the hello example from mirage-skeleton/tutorial).  Solo5/UKVM uses 2MB steps (see assertion in ukvm_cpu_x86_64: `mem_size & (X86_GUEST_PAGE_SIZE - 1)) == 0` -- where `X86_GUEST_PAGE_SIZE = 2 << 20`), while this `--mem` option allows 1MB granularity.

(It would make more sense to allow for 2MB steps, but it is not very intuitive to do so -- this is why 1MB steps are allowed in this PR, but an odd value results in an assertion failure.)

Previously, each virtual machine mmap()ed 512MB memory (plus overhead in the host system, which seems to be constant 8MB).  With this change, ~50x reduction can be achieved for the simplest kernels.