### PR TITLE
Added missing stdlib.h in ukvm_hv_kvm.c and ukvm_hv_kvm_x86_64.c

### DIFF
--- a/ukvm/ukvm_hv_kvm.c
+++ b/ukvm/ukvm_hv_kvm.c
@@ -29,7 +29,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <string.h>
-
+#include <stdlib.h>
 #include <linux/kvm.h>
 
 #include "ukvm.h"

--- a/ukvm/ukvm_hv_kvm_x86_64.c
+++ b/ukvm/ukvm_hv_kvm_x86_64.c
@@ -31,7 +31,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <string.h>
-
+#include <stdlib.h>
 #include <linux/kvm.h>
 
 #include "ukvm.h"


### PR DESCRIPTION
The two edited files in question call malloc(ukvm_hv_kvm.c) and calloc(ukvm_hv_kvm_x86_64.c), but does not include the standard library. As far as I know, this leads to one of two things; either the compilation aborts because of 'implicit declaration of function'(modern compilers) or the compiler assumes a function that returns an int. The first is safe, while the second can be highly dangerous.

This pull request fixes the problem by including stdlib.h in both files.