### PR TITLE
Add quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@
 # About Solo5
 
 Solo5 is most useful as a "base layer" to run
-[MirageOS](https://mirage.io/) unikernels, either on various existing
+[MirageOS](https://mirage.io/) and [IncludeOS](http://www.includeos.org/) unikernels, either on various existing
 hypervisors (KVM/QEMU, bhyve) or on a specialized "unikernel monitor" called
 `ukvm`.
+
+# Quickstart
+
+You can run a hello-world application like this:
+
+    $ make
+    $ ./tests/test_hello/ukvm-bin ./tests/test_hello/test_hello.ukvm
 
 # About ukvm
 
@@ -154,39 +161,27 @@ with gdb support.
 
 Start ukvm with the `--gdb` flag, like this:
 
-    ./ukvm-bin mir-console.solo5-ukvm --gdb
+    $ cd tests/test_hello
+    $ ./ukvm-bin --gdb test_hello.ukvm
 
 And then from another console start gdb and connect to the remote target
 listening at `localhost:1234`:
 
-    $ gdb mir-console.solo5-ukvm
-
-    (gdb) target remote localhost:1234
+    $ gdb --ex="target remote localhost:1234" test_hello.ukvm
 
 Here is a typical gdb session:
 
-    (gdb) target remote localhost:1234
-    Remote debugging using localhost:1234
-    kernel_main (size=536870912, kernel_end=2625536) at kernel.c:36
-    36    void kernel_main(uint64_t size, uint64_t kernel_end) {
-    (gdb) break unikernel.ml:9
-    Breakpoint 11 at 0x104c39: file unikernel.ml, line 9.
+    (gdb) break puts
+    Breakpoint 1 at 0x100530: puts. (2 locations)
     (gdb) c
     Continuing.
 
-    Breakpoint 11, camlUnikernel__loop_1401 () at unikernel.ml:9
-    9            C.log c "hello";
+    Breakpoint 1, puts (s=s@entry=0x107808 "\n**** Solo5 standalone test_hello ****\n\n") at test_hello.c:25
+    25	{
     (gdb) bt
-    #0  camlUnikernel__loop_1401 () at unikernel.ml:9
-    #1  0x000000000010480e in camlMain__fun_1487 () at main.ml:32
-    #2  0x0000000000178ad9 in camlCamlinternalLazy__force_lazy_block_1010 () at camlinternalLazy.ml:25
-    #3  0x00000000001049e4 in camlMain__fun_1494 () at main.ml:38
-    #4  0x0000000000178ad9 in camlCamlinternalLazy__force_lazy_block_1010 () at camlinternalLazy.ml:25
-    #5  0x0000000000104bfa in camlMain__entry () at src/core/lwt.ml:660
-    #6  0x0000000000100ed9 in caml_program ()
-    #7  0x00000000001c26a6 in caml_start_program ()
-    #8  0x0000000000000000 in ?? ()
+    #0  puts (s=s@entry=0x107808 "\n**** Solo5 standalone test_hello ****\n\n") at test_hello.c:25
+    #1  0x0000000000106a8e in solo5_app_main (cmdline=cmdline@entry=0x6000 "") at test_hello.c:31
+    #2  0x0000000000100089 in _start (arg=0x5000) at ukvm/kernel.c:42
     (gdb) s
-
-    Breakpoint 11, camlUnikernel__loop_1401 () at unikernel.ml:9
-    9            C.log c "hello";
+    26	    solo5_console_write(s, strlen(s));
+    (gdb) 

--- a/tests/test_hello/GNUmakefile
+++ b/tests/test_hello/GNUmakefile
@@ -19,6 +19,6 @@
 UKVM_TARGETS=test_hello.ukvm ukvm-bin
 VIRTIO_TARGETS=test_hello.virtio
 MUEN_TARGETS=test_hello.muen
-UKVM_MODULES=
+UKVM_MODULES=gdb
 
 include ../Makefile.tests


### PR DESCRIPTION
Adding a quickstart, and updating the gdb section of the README.

Also, adding the gdb module to tests/test_hello so gdb debugging is easier to play with. It will also be used for the gdb tests to be added after.