### PR TITLE
CI: Enable tests on surf nodes that support them

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,4 +15,8 @@ set -xe
 uname -a
 cc --version
 ${MAKE}
-# Don't run any tests yet
+# Some CIs can now run tests, so do that.
+if [ -n "${SURF_RUN_TESTS}" ]; then
+    sudo tests/setup-tests.sh
+    sudo tests/run-tests.sh
+fi


### PR DESCRIPTION
`x86_64-Debian9-gcc630` now uses the new CI infrastructure, based on
https://github.com/roburio/vm. More nodes will migrate to this in due
course.