### PR TITLE
Disable virtio tests on FreeBSD

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,11 @@ cc --version
 ${MAKE}
 # Some CIs can now run tests, so do that.
 if [ -n "${SURF_RUN_TESTS}" ]; then
+    # XXX grub-bhyve is unstable under nested virt, so don't run the
+    # virtio tests on FreeBSD.
+    if [ "$(uname -s)" = "FreeBSD" ]; then
+        echo BUILD_VIRTIO=no >>Makeconf
+    fi
     sudo tests/setup-tests.sh
     sudo tests/run-tests.sh
 fi


### PR DESCRIPTION
grub-bhyve is a hack, and is unstable under nested virtualization (runs
off into 100% cpu forever). Disable the virtio tests on FreeBSD.