### PR TITLE
clang 6.0 on FreeBSD

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -107,7 +107,7 @@ case $(uname -s) in
         SRCS_MACH="machine/_stdint.h machine/_types.h machine/endian.h \
             machine/_limits.h"
         SRCS_SYS="sys/_null.h sys/_stdint.h sys/_types.h sys/cdefs.h \
-            sys/endian.h"
+            sys/endian.h sys/_stdarg.h"
         SRCS_X86="x86/float.h x86/_stdint.h x86/stdarg.h x86/endian.h \
             x86/_types.h x86/_limits.h"
         SRCS="float.h osreldate.h stddef.h stdint.h stdbool.h stdarg.h"

--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -69,6 +69,12 @@ void solo5_free(void *) __attribute__ ((alias ("free")));
 void *solo5_calloc(size_t, size_t) __attribute__ ((alias ("calloc")));
 void *solo5_realloc(void *, size_t) __attribute__ ((alias ("realloc")));
 
+/* disable null-pointer-arithmetic warning on clang */
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wnull-pointer-arithmetic"
+#endif
+
 /*
   This is a version (aka dlmalloc) of malloc/free/realloc written by
   Doug Lea and released to the public domain, as explained at


### PR DESCRIPTION
since 20180114, FreeBSD-master uses clang 6.0.0.  This introduces new warnings and separated headers further:
- (a) `stdarg.h` now `#include <sys/_stdarg.h>` -- we need `stdarg.h` to define `va_list` (for declaring `vsnprintf`)
- (b) `malloc.c` violates `null-pointer-arithmetic` warnings (see below)

this is not meant to be merged in its current state, instead I'm hoping for directions whether to make the copy for (a) conditional?  and how to proceed with (b)? fix up dlmalloc (the most recent from http://g.oswego.edu/dl/html/malloc.html has the same issues)?  or move it anyways out of solo5 (see #224) and ignore it for now!?

```bash
] gmake
gmake -C kernel ukvm
gmake[1]: Entering directory '/usr/home/hannes/devel/mirage/solo5/kernel'
cc -nostdlibinc -ffreestanding -mno-red-zone -mno-sse -mno-mmx -mno-aes -mno-avx -isystem /usr/home/hannes/devel/mirage/solo5/include-host -std=gnu99 -Wall -Wextra -ferror-limit=1000 -Werror -O2 -g -D__SOLO5_KERNEL__ -c malloc.c -o malloc.o
malloc.c:3973:39: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
  chunk_plus_offset(p, psize)->head = TOP_FOOT_SIZE;
                                      ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:3973:39: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
  chunk_plus_offset(p, psize)->head = TOP_FOOT_SIZE;
                                      ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4066:41: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
  init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);
                                        ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4066:41: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
  init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);
                                        ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4119:34: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
  asize = granularity_align(nb + SYS_ALLOC_PADDING);
          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
                ^
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:2744:6: note: expanded from macro 'granularity_align'
  (((S) + (mparams.granularity - SIZE_T_ONE))\
     ^
malloc.c:4119:34: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
  asize = granularity_align(nb + SYS_ALLOC_PADDING);
          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
                ^
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:2744:6: note: expanded from macro 'granularity_align'
  (((S) + (mparams.granularity - SIZE_T_ONE))\
     ^
malloc.c:4175:51: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
      ssize = granularity_align(nb - m->topsize + SYS_ALLOC_PADDING);
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
                ^
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:2744:6: note: expanded from macro 'granularity_align'
  (((S) + (mparams.granularity - SIZE_T_ONE))\
     ^
malloc.c:4175:51: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
      ssize = granularity_align(nb - m->topsize + SYS_ALLOC_PADDING);
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
                ^
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:2744:6: note: expanded from macro 'granularity_align'
  (((S) + (mparams.granularity - SIZE_T_ONE))\
     ^
malloc.c:4187:26: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
            ssize < nb + SYS_ALLOC_PADDING) {
                         ^~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4187:26: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
            ssize < nb + SYS_ALLOC_PADDING) {
                         ^~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4188:49: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
          size_t esize = granularity_align(nb + SYS_ALLOC_PADDING - ssize);
                         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
                ^
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:2744:6: note: expanded from macro 'granularity_align'
  (((S) + (mparams.granularity - SIZE_T_ONE))\
     ^
malloc.c:4188:49: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
          size_t esize = granularity_align(nb + SYS_ALLOC_PADDING - ssize);
                         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
malloc.c:2756:28: note: expanded from macro 'SYS_ALLOC_PADDING'
#define SYS_ALLOC_PADDING (TOP_FOOT_SIZE + MALLOC_ALIGNMENT)
                           ^
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
                ^
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:2744:6: note: expanded from macro 'granularity_align'
  (((S) + (mparams.granularity - SIZE_T_ONE))\
     ^
malloc.c:4230:26: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
        if (ssize > nb + TOP_FOOT_SIZE) {
                         ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4230:26: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
        if (ssize > nb + TOP_FOOT_SIZE) {
                         ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4254:47: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
        init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);
                                              ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4254:47: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
        init_top(m, (mchunkptr)tbase, tsize - TOP_FOOT_SIZE);
                                              ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4260:64: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
        init_top(m, mn, (size_t)((tbase + tsize) - (char*)mn) -TOP_FOOT_SIZE);
                                                               ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4260:64: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
        init_top(m, mn, (size_t)((tbase + tsize) - (char*)mn) -TOP_FOOT_SIZE);
                                                               ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4329:61: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
      if (!is_inuse(p) && (char*)p + psize >= base + size - TOP_FOOT_SIZE) {
                                                            ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4329:61: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
      if (!is_inuse(p) && (char*)p + psize >= base + size - TOP_FOOT_SIZE) {
                                                            ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
malloc.c:4366:12: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
    pad += TOP_FOOT_SIZE; /* ensure enough room for segment overhead */
           ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1692:14: note: expanded from macro 'align_offset'
 ((((size_t)(A) & CHUNK_ALIGN_MASK) == 0)? 0 :\
             ^
malloc.c:4366:12: error: arithmetic on a null pointer treated as a cast from integer to pointer is a GNU extension [-Werror,-Wnull-pointer-arithmetic]
    pad += TOP_FOOT_SIZE; /* ensure enough room for segment overhead */
           ^~~~~~~~~~~~~
malloc.c:2801:17: note: expanded from macro 'TOP_FOOT_SIZE'
  (align_offset(chunk2mem(0))+pad_request(sizeof(struct malloc_segment))+MIN_CHUNK_SIZE)
   ~~~~~~~~~~~~~^~~~~~~~~~~~~
malloc.c:2288:55: note: expanded from macro 'chunk2mem'
#define chunk2mem(p)        ((void*)((char*)(p)       + TWO_SIZE_T_SIZES))
                                                      ^
malloc.c:1693:34: note: expanded from macro 'align_offset'
  ((MALLOC_ALIGNMENT - ((size_t)(A) & CHUNK_ALIGN_MASK)) & CHUNK_ALIGN_MASK))
                                 ^
22 errors generated.
gmake[1]: *** [GNUmakefile:99: malloc.o] Error 1
```