### PR TITLE
Travis: Switch to container-based Trusty infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: c
-sudo: required
+sudo: false
 dist: trusty
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq qemu-system-x86
-script: make && sudo tests/setup-tests.sh && sudo tests/run-tests.sh
+addons:
+    apt:
+        packages:
+            - qemu-system-x86
+script: make && tests/run-tests.sh


### PR DESCRIPTION
With the new VM-based CI in place, Travis is more or less just a
fallback. To speed up the Travis builds, switch to using the
Ubuntu Trusty container-based infrastructure.

This loses us sudo access so we can no longer run tests/test_ping_serve,
this is an acceptable compromise for (hopefully) faster builds.