### PR TITLE
malloc: check for clang_major >= 6 to disable null-pointer-arithmetic

### DIFF
--- a/kernel/malloc.c
+++ b/kernel/malloc.c
@@ -70,8 +70,7 @@ void *solo5_calloc(size_t, size_t) __attribute__ ((alias ("calloc")));
 void *solo5_realloc(void *, size_t) __attribute__ ((alias ("realloc")));
 
 /* disable null-pointer-arithmetic warning on clang */
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#if defined(__clang__) && __clang_major__ >= 6
 #pragma clang diagnostic ignored "-Wnull-pointer-arithmetic"
 #endif
 


### PR DESCRIPTION
disabling `unknown-pragmas` seems to not work on OpenBSD, as reported by @adamsteen in https://github.com/Solo5/solo5/pull/226/commits/6de9cf7a4fb9c5eb89581ed3ae63d9169ef62623

instead, check for the clang major version being `>= 6`