### PR TITLE
Solo5 public API refresh, take 2

### DIFF
--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -39,7 +39,7 @@ ukvm/time.o
 UKVM_COBJS=\
 $(COMMON_UKVM_COBJS) \
 ukvm/platform_lifecycle.o \
-ukvm/poll.o \
+ukvm/yield.o \
 ukvm/tscclock.o \
 ukvm/console.o \
 ukvm/net.o \
@@ -72,7 +72,7 @@ muen/muen-clock.o \
 muen/muen-console.o \
 muen/muen-net.o \
 muen/muen-platform_lifecycle.o \
-muen/muen-poll.o \
+muen/muen-yield.o \
 muen/muen-sinfo.o \
 $(COMMON_COBJS)
 

--- a/kernel/muen/muen-block.c
+++ b/kernel/muen/muen-block.c
@@ -20,32 +20,21 @@
 
 #include "../kernel.h"
 
-/* ukvm block interface */
-int solo5_blk_write_sync(uint64_t sec __attribute__((unused)),
-                         uint8_t *data __attribute__((unused)),
-                         int n __attribute__((unused)))
+solo5_result_t solo5_block_write(solo5_off_t offset __attribute__((unused)),
+                         const uint8_t *buf __attribute__((unused)),
+                         size_t size __attribute__((unused)))
 {
-    return -1;
+    return SOLO5_R_EUNSPEC;
 }
 
-int solo5_blk_read_sync(uint64_t sec __attribute__((unused)),
-                        uint8_t *data __attribute__((unused)),
-                        int *n __attribute__((unused)))
+solo5_result_t solo5_block_read(solo5_off_t offset __attribute__((unused)),
+                        uint8_t *buf __attribute__((unused)),
+                        size_t size __attribute__((unused)))
 {
-    return -1;
+    return SOLO5_R_EUNSPEC;
 }
 
-int solo5_blk_sector_size(void)
+void solo5_block_info(struct solo5_block_info *info __attribute__((unused)))
 {
-    return -1;
-}
-
-uint64_t solo5_blk_sectors(void)
-{
-    return 0;
-}
-
-int solo5_blk_rw(void)
-{
-    return -1;
+    assert(0);
 }

--- a/kernel/muen/muen-console.c
+++ b/kernel/muen/muen-console.c
@@ -64,8 +64,10 @@ int platform_puts(const char *buf, int n)
     return n;
 }
 
-int solo5_console_write(const char *, size_t)
-    __attribute__ ((alias("platform_puts")));
+void solo5_console_write(const char *buf, size_t size)
+{
+    (void)platform_puts(buf, size);
+}
 
 void console_init(void)
 {

--- a/kernel/solo5.h
+++ b/kernel/solo5.h
@@ -139,9 +139,9 @@ solo5_time_t solo5_clock_wall(void);
  * Suspends execution of the application until either:
  *
  *   a) monotonic time reaches (deadline), or
- *   b) solo5_net_recv() would succeed.
+ *   b) solo5_net_read() would succeed.
  *
- * Returns true if solo5_net_recv() will succeed, otherwise false.
+ * Returns true if solo5_net_read() will succeed, otherwise false.
  *
  * This interface may be extended in the future to allow for selection of I/O
  * events of interest to the application.

--- a/kernel/ukvm/console.c
+++ b/kernel/ukvm/console.c
@@ -32,8 +32,10 @@ int platform_puts(const char *buf, int n)
     return str.len;
 }
 
-int solo5_console_write(const char *, size_t)
-    __attribute__ ((alias("platform_puts")));
+void solo5_console_write(const char *buf, size_t size)
+{
+    (void)platform_puts(buf, size);
+}
 
 void console_init(void)
 {

--- a/kernel/ukvm/kernel.c
+++ b/kernel/ukvm/kernel.c
@@ -22,12 +22,12 @@
 
 void _start(void *arg)
 {
-    static struct solo5_boot_info bi;
+    static struct solo5_start_info si;
 
     console_init();
     cpu_init();
     platform_init(arg);
-    bi.cmdline = cmdline_parse(platform_cmdline());
+    si.cmdline = cmdline_parse(platform_cmdline());
 
     log(INFO, "            |      ___|\n");
     log(INFO, "  __|  _ \\  |  _ \\ __ \\\n");
@@ -38,6 +38,6 @@ void _start(void *arg)
     time_init(arg);
     net_init();
 
-    mem_lock_heap(&bi.heap_start, &bi.heap_size);
-    solo5_exit(solo5_app_main(&bi));
+    mem_lock_heap(&si.heap_start, &si.heap_size);
+    solo5_exit(solo5_app_main(&si));
 }

--- a/kernel/ukvm/net.c
+++ b/kernel/ukvm/net.c
@@ -20,43 +20,43 @@
 
 #include "kernel.h"
 
-/* ukvm net interface */
-int solo5_net_write_sync(uint8_t *data, int n)
+solo5_result_t solo5_net_write(const uint8_t *buf, size_t size)
 {
     volatile struct ukvm_netwrite wr;
 
-    wr.data = data;
-    wr.len = n;
+    wr.data = buf;
+    wr.len = size;
     wr.ret = 0;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_NETWRITE, &wr);
 
-    return wr.ret;
+    return (wr.ret == 0 && wr.len == size) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }
 
-int solo5_net_read_sync(uint8_t *data, int *n)
+solo5_result_t solo5_net_read(uint8_t *buf, size_t size, size_t *read_size)
 {
     volatile struct ukvm_netread rd;
 
-    rd.data = data;
-    rd.len = *n;
+    rd.data = buf;
+    rd.len = size;
     rd.ret = 0;
 
     ukvm_do_hypercall(UKVM_HYPERCALL_NETREAD, &rd);
 
-    *n = rd.len;
-    return rd.ret;
+    *read_size = rd.len;
+    return (rd.ret == 0) ? SOLO5_R_OK : SOLO5_R_AGAIN;
 }
 
-static char mac_str[18];
-char *solo5_net_mac_str(void)
+void solo5_net_info(struct solo5_net_info *info)
 {
-    volatile struct ukvm_netinfo info;
+    volatile struct ukvm_netinfo ni;
 
-    ukvm_do_hypercall(UKVM_HYPERCALL_NETINFO, &info);
+    ukvm_do_hypercall(UKVM_HYPERCALL_NETINFO, &ni);
 
-    memcpy(mac_str, (void *)&info, 18);
-    return mac_str;
+    memcpy(info->mac_address, (uint8_t *)&ni.mac_address,
+            sizeof info->mac_address);
+    /* XXX: No support on host side yet, so hardcode for now */
+    info->mtu = 1500;
 }
 
 void net_init(void)

--- a/kernel/virtio/kernel.c
+++ b/kernel/virtio/kernel.c
@@ -45,9 +45,9 @@ void _start(void *arg)
 
 static void _start2(void *arg __attribute__((unused)))
 {
-    static struct solo5_boot_info bi;
+    static struct solo5_start_info si;
 
-    bi.cmdline = cmdline_parse(platform_cmdline());
+    si.cmdline = cmdline_parse(platform_cmdline());
 
     log(INFO, "            |      ___|\n");
     log(INFO, "  __|  _ \\  |  _ \\ __ \\\n");
@@ -59,6 +59,6 @@ static void _start2(void *arg __attribute__((unused)))
     pci_enumerate();
     cpu_intr_enable();
 
-    mem_lock_heap(&bi.heap_start, &bi.heap_size);
-    solo5_exit(solo5_app_main(&bi));
+    mem_lock_heap(&si.heap_start, &si.heap_size);
+    solo5_exit(solo5_app_main(&si));
 }

--- a/kernel/virtio/kernel.h
+++ b/kernel/virtio/kernel.h
@@ -57,9 +57,9 @@ void pci_enumerate(void);
 void virtio_config_network(struct pci_config_info *);
 void virtio_config_block(struct pci_config_info *);
 
-uint8_t *virtio_net_pkt_get(int *size);  /* get a pointer to recv'd data */
+uint8_t *virtio_net_pkt_get(size_t *size);  /* get a pointer to recv'd data */
 void virtio_net_pkt_put(void);      /* we're done with recv'd data */
-int virtio_net_xmit_packet(void *data, int len);
+int virtio_net_xmit_packet(const void *data, size_t len);
 int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
 
 #endif

--- a/kernel/virtio/platform.c
+++ b/kernel/virtio/platform.c
@@ -124,5 +124,7 @@ int platform_puts(const char *buf, int n)
     return n;
 }
 
-int solo5_console_write(const char *, size_t)
-    __attribute__ ((alias("platform_puts")));
+void solo5_console_write(const char *buf, size_t size)
+{
+    (void)platform_puts(buf, size);
+}

--- a/tests/test_blk/test_blk.c
+++ b/tests/test_blk/test_blk.c
@@ -26,79 +26,98 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-#define SECTOR_SIZE	512
-
-/* Space for 2 sectors for edge-case tests */
-static uint8_t wbuf[SECTOR_SIZE * 2];
-static uint8_t rbuf[SECTOR_SIZE * 2];
-
-int check_sector_write(uint64_t sector)
+bool check_one_block(solo5_off_t offset, size_t block_size)
 {
-    int rlen = SECTOR_SIZE;
-    unsigned i;
+    size_t i;
+    uint8_t wbuf[block_size],
+            rbuf[block_size];
 
-    for (i = 0; i < SECTOR_SIZE; i++) {
+    for (i = 0; i < block_size; i++) {
         wbuf[i] = '0' + i % 10;
         rbuf[i] = 0;
     }
 
-    if (solo5_blk_write_sync(sector, wbuf, SECTOR_SIZE) != 0)
-        return 1;
-    if (solo5_blk_read_sync(sector, rbuf, &rlen) != 0)
-        return 1;
+    if (solo5_block_write(offset, wbuf, block_size) != SOLO5_R_OK)
+        return false;
+    if (solo5_block_read(offset, rbuf, block_size) != SOLO5_R_OK)
+        return false;
 
-    if (rlen != SECTOR_SIZE)
-        return 1;
-    
-    for (i = 0; i < SECTOR_SIZE; i++) {
+    for (i = 0; i < block_size; i++) {
         if (rbuf[i] != '0' + i % 10)
             /* Check failed */
-            return 1;
+            return false;
     }
 
-    return 0;
+    return true;
 }
 
-int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
-    size_t i, nsectors;
-    int rlen;
-
     puts("\n**** Solo5 standalone test_blk ****\n\n");
+
+    struct solo5_block_info bi;
+    solo5_block_info(&bi);
 
     /*
      * Write and read/check one tenth of the disk.
      */
-    nsectors = solo5_blk_sectors();
-    for (i = 0; i <= nsectors; i += 10) {
-        if (check_sector_write(i))
+    for (solo5_off_t offset = 0; offset < bi.capacity;
+            offset += (10 * bi.block_size)) {
+        if (!check_one_block(offset, bi.block_size))
             /* Check failed */
             return 1;
     }
 
+    uint8_t buf[bi.block_size * 2];
+
     /*
      * Check edge case: read/write of last sector on the device.
      */
-    if (solo5_blk_write_sync(nsectors - 1, wbuf, SECTOR_SIZE) != 0)
+    solo5_off_t last_block = bi.capacity - bi.block_size;
+    if (solo5_block_write(last_block, buf, bi.block_size) != SOLO5_R_OK)
         return 2;
-    rlen = SECTOR_SIZE;
-    if (solo5_blk_read_sync(nsectors - 1, rbuf, &rlen) != 0)
+    if (solo5_block_read(last_block, buf, bi.block_size) != SOLO5_R_OK)
         return 3;
-    if (rlen != SECTOR_SIZE)
-        return 4;
 
     /*
      * Check edge cases: should not be able to read or write beyond end
      * of device.
-     *
-     * XXX Multi-sector block operations currently work only on ukvm, virtio
-     * will always return -1 here.
+     * 
+     * XXX: Current implementations may return either SOLO5_R_EINVAL or
+     * SOLO5_R_EUNSPEC here, that is fine for now.
      */
-    if (solo5_blk_write_sync(nsectors - 1, wbuf, 2 * SECTOR_SIZE) != -1)
+    if (solo5_block_write(bi.capacity, buf, bi.block_size) == SOLO5_R_OK)
+        return 4;
+    if (solo5_block_read(bi.capacity, buf, bi.block_size) == SOLO5_R_OK)
         return 5;
-    rlen = 2 * SECTOR_SIZE;
-    if (solo5_blk_read_sync(nsectors - 1, rbuf, &rlen) != -1)
+
+    /*
+     * Check invalid arguments: Should not be able to read or write less than
+     * bi.block_size or more than bi.block_size.
+     *
+     * XXX: Current implementations may return either SOLO5_R_EINVAL or
+     * SOLO5_R_EUNSPEC here, that is fine for now.
+     */
+    if (solo5_block_write(0, buf, bi.block_size - 1) == SOLO5_R_OK)
         return 6;
+    if (solo5_block_read(0, buf, bi.block_size - 1) == SOLO5_R_OK)
+        return 7;
+    if (solo5_block_write(0, buf, bi.block_size + 1) == SOLO5_R_OK)
+        return 8;
+    if (solo5_block_read(0, buf, bi.block_size + 1) == SOLO5_R_OK)
+        return 9;
+
+    /*
+     * Check invalid arguments: Should not be able to read or write at offsets
+     * not aligned to bi.block_size.
+     *
+     * XXX: Current implementations may return either SOLO5_R_EINVAL or
+     * SOLO5_R_EUNSPEC here, that is fine for now.
+     */
+    if (solo5_block_write(bi.block_size - 1, buf, bi.block_size) == SOLO5_R_OK)
+        return 10;
+    if (solo5_block_read(bi.block_size - 1, buf, bi.block_size) == SOLO5_R_OK)
+        return 11;
 
     puts("SUCCESS\n");
 

--- a/tests/test_exception/test_exception.c
+++ b/tests/test_exception/test_exception.c
@@ -26,7 +26,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_exception ****\n\n");
 

--- a/tests/test_fpu/test_fpu.c
+++ b/tests/test_fpu/test_fpu.c
@@ -26,7 +26,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_fpu ****\n\n");
 

--- a/tests/test_globals/test_globals.c
+++ b/tests/test_globals/test_globals.c
@@ -38,7 +38,7 @@ void do_test(void)
     puts(s);
 }
 
-int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_globals ****\n\n");
 

--- a/tests/test_hello/test_hello.c
+++ b/tests/test_hello/test_hello.c
@@ -26,22 +26,22 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(const struct solo5_boot_info *bi)
+int solo5_app_main(const struct solo5_start_info *si)
 {
     puts("\n**** Solo5 standalone test_hello ****\n\n");
     puts("Hello, World\nCommand line is: '");
 
     size_t len = 0;
-    const char *p = bi->cmdline;
+    const char *p = si->cmdline;
 
     while (*p++)
         len++;
-    solo5_console_write(bi->cmdline, len);
+    solo5_console_write(si->cmdline, len);
 
     puts("'\n");
 
     /* "Hello_Solo5" will be passed in via the command line */
-    if (strcmp(bi->cmdline, "Hello_Solo5") == 0)
+    if (strcmp(si->cmdline, "Hello_Solo5") == 0)
         puts("SUCCESS\n");
 
     return SOLO5_EXIT_SUCCESS;

--- a/tests/test_quiet/test_quiet.c
+++ b/tests/test_quiet/test_quiet.c
@@ -34,7 +34,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_verbose ****\n\n");
     puts("SUCCESS\n");

--- a/tests/test_time/test_time.c
+++ b/tests/test_time/test_time.c
@@ -28,14 +28,15 @@ static void puts(const char *s)
 
 #define NSEC_PER_SEC 1000000000ULL
 
-int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_time ****\n\n");
 
     /*
      * Verify that monotonic time is passing
      */
-    uint64_t ta = 0, tb = 0, iters = 5;
+    solo5_time_t ta = 0, tb = 0;
+    int iters = 5;
     ta = solo5_clock_monotonic();
     tb = solo5_clock_monotonic();
     /*
@@ -51,10 +52,10 @@ int solo5_app_main(const struct solo5_boot_info *bi __attribute__((unused)))
 
     /* 
      * The monitor is configured with no I/O modules for this test so
-     * solo5_poll() is equivalent to a sleep here.
+     * solo5_yield() is equivalent to a sleep here.
      */
     ta = solo5_clock_monotonic();
-    solo5_poll(ta + NSEC_PER_SEC);
+    solo5_yield(ta + NSEC_PER_SEC);
     tb = solo5_clock_monotonic();
     /*
      * Verify that we did not sleep less than requested (see above).

--- a/ukvm/ukvm_guest.h
+++ b/ukvm/ukvm_guest.h
@@ -225,7 +225,7 @@ struct ukvm_blkread {
 /* UKVM_HYPERCALL_NETINFO */
 struct ukvm_netinfo {
     /* OUT */
-    char mac_str[18];
+    uint8_t mac_address[6];
 };
 
 /* UKVM_HYPERCALL_NETWRITE */

--- a/ukvm/ukvm_module_net.c
+++ b/ukvm/ukvm_module_net.c
@@ -178,7 +178,7 @@ static void hypercall_netinfo(struct ukvm_hv *hv, ukvm_gpa_t gpa)
     struct ukvm_netinfo *info =
         UKVM_CHECKED_GPA_P(hv, gpa, sizeof (struct ukvm_netinfo));
 
-    memcpy(info->mac_str, netinfo.mac_str, sizeof(netinfo.mac_str));
+    memcpy(info->mac_address, netinfo.mac_address, sizeof(netinfo.mac_address));
 }
 
 static void hypercall_netwrite(struct ukvm_hv *hv, ukvm_gpa_t gpa)
@@ -224,7 +224,7 @@ static int handle_cmdarg(char *cmdarg)
             warnx("Malformed mac address: %s", macptr);
             return -1;
         }
-        snprintf(netinfo.mac_str, sizeof(netinfo.mac_str), "%s", macptr);
+        memcpy(netinfo.mac_address, mac, sizeof netinfo.mac_address);
         cmdline_mac = 1;
         return 0;
     } else {
@@ -259,10 +259,7 @@ static int setup(struct ukvm_hv *hv)
         close(rfd);
         guest_mac[0] &= 0xfe;
         guest_mac[0] |= 0x02;
-        snprintf(netinfo.mac_str, sizeof(netinfo.mac_str),
-                 "%02x:%02x:%02x:%02x:%02x:%02x",
-                 guest_mac[0], guest_mac[1], guest_mac[2],
-                 guest_mac[3], guest_mac[4], guest_mac[5]);
+        memcpy(netinfo.mac_address, guest_mac, sizeof netinfo.mac_address);
     }
 
     assert(ukvm_core_register_hypercall(UKVM_HYPERCALL_NETINFO,


### PR DESCRIPTION
This is a new take on the Solo5 public API refresh and cleanup (#200, now out of date take 1 in #201).  

Major changes:

- (Tersely) document all public APIs, including their semantics and error handling.
- Remove "type confusion", use the strictest possible types as appropriate throughout.
- Remove use of arch-dependent types where appropriate:
    - Introduce solo5_time_t (for time values), solo5_lba_t (for block addressing).
- Standardise on a solo5_result_t for APIs which may return an error at runtime. For all other APIs, explicitly document that the call will either succeed or abort.
- Block I/O changes:
    - Rename solo5_blk_read_sync() to solo5_block_read(), solo5_blk_write_sync() to solo5_block_write().
    - Introduce a solo5_block_info() call, which replaces the existing _sectors() and _sector_size() calls.
    - Remove the _rw() call as it's not used or implemented anywhere, and I don't think we'll ever need it at this layer.
- Network I/O changes:
    - Rename solo5_net_write() to solo5_net_send() and solo5_net_read() to solo5_net_recv().
    - Introduce a solo5_net_info() call, which replaces the existing solo5_net_mac_str() call, and also returns network device MTU.
- Rename solo5_poll() to solo5_yield().

For the full set of changes, please read through the new kernel/solo5.h (not the diff, that's unreadable as I moved things around to make it read to a human better).

This initial version includes the minimal set of changes required to support the public API change in the ukvm hypercall ABI, and the changes to all test cases. Muen changes have been compile tested only (/cc @Kensan).

I will add more changes to this PR (and/or later PRs, TBD) to further align the ukvm hypercall interface with these changes.

@djwillia @ricarkol @hannesm Please review. 

This is a bit different from what we discussed back in Marrakesh, and includes a few more changes than the old "take 1". I'm reasonably happy with everything in here with the possible exception of the formulation around "Error handling" (@hannesm I'd be especially interested in your opinion on that).