### PR TITLE
avoid truncation of tsc_mult

### DIFF
--- a/kernel/ukvm/tscclock.c
+++ b/kernel/ukvm/tscclock.c
@@ -77,11 +77,14 @@ int tscclock_init(uint64_t tsc_freq)
      *
      * (0.32) tsc_mult = NSEC_PER_SEC (32.32) / tsc_freq (32.0)
      */
-#if defined(__x86_64__)
-    tsc_mult = (NSEC_PER_SEC << 32) / tsc_freq;
-#elif defined(__aarch64__)
-    tsc_mult = NSEC_PER_SEC / tsc_freq;
-#endif
+    int shift = 32;
+    uint64_t tmp;
+    do {
+      tmp = (NSEC_PER_SEC << shift) / tsc_freq;
+      if ((tmp & 0xFFFFFFFF00000000L) == 0L)
+        tsc_mult = (uint32_t)tmp;
+      else shift--;
+    } while (tsc_mult == 0l);
 
     /*
      * Monotonic time begins at tsc_base (first read of TSC before


### PR DESCRIPTION
as described in #242, `tsc_mult` is a 32bit unsigned integer which truncates if `tsc_freq` is too small (and the result of `1 * 10^9 << 32 / freq` is bigger than `2^32-1`).

instead of hardcoding the scale to `32`, this patch starts with `32` and decrements until the division fits into 32 bit.  there may be better solutions (i.e. start with a heuristic for `scale` based on the `tsc_freq`).  the proposed patch may also (for very small `tsc_freq`, i.e. `1`) loop infinite.

this PR fixes #242 partially
NB: this PR is incomplete since the code seems to be copy & pasted in both muen and virtio.
EDIT: time moves on my AMD 1GHz CPU still too slow, roughly by a factor of 2 (after 20 hours uptime, the wallclock is 10 hours behind)