### PR TITLE
ukvm: tscclock: Dynamically calculate tsc_shift

### DIFF
--- a/kernel/cpu_aarch64.h
+++ b/kernel/cpu_aarch64.h
@@ -36,4 +36,8 @@ static inline uint64_t cpu_cntvct(void)
     return val;
 }
 
+static inline uint64_t mul64_32(uint64_t a, uint32_t b, uint8_t s)
+{
+    return (a * b) >> s;
+}
 #endif /* !ASM_FILE */

--- a/kernel/cpu_x86_64.h
+++ b/kernel/cpu_x86_64.h
@@ -164,15 +164,15 @@ static inline uint64_t cpu_rdtsc(void)
     return ((uint64_t)h << 32) | l;
 }
 
-static inline uint64_t mul64_32(uint64_t a, uint32_t b)
+static inline uint64_t mul64_32(uint64_t a, uint32_t b, uint8_t s)
 {
     uint64_t prod;
 
     __asm__ (
         "mul %%rdx ; "
-        "shrd $32, %%rdx, %%rax"
+        "shrd %%cl, %%rdx, %%rax"
         : "=a" (prod)
-        : "0" (a), "d" ((uint64_t)b)
+        : "0" (a), "d" ((uint64_t)b), "Ic" (s)
     );
 
     return prod;

--- a/kernel/muen/muen-clock.c
+++ b/kernel/muen/muen-clock.c
@@ -50,7 +50,7 @@ uint64_t tscclock_monotonic(void)
         tsc_now = current_start = next_start;
 
     tsc_delta = tsc_now - tsc_base;
-    time_base += mul64_32(tsc_delta, tsc_mult);
+    time_base += mul64_32(tsc_delta, tsc_mult, 32);
     tsc_base = tsc_now;
 
     return time_base;
@@ -79,6 +79,10 @@ int tscclock_init(uint64_t freq __attribute__((unused)))
     } while (wc_epochoffset == 0);
 
     tsc_freq = time_info->tsc_tick_rate_hz;
+    /*
+     * TODO: This calculation may overflow for low values of tsc_freq;
+     * dynamically calculate tsc_shift as in ukvm version.
+     */
     tsc_mult = (NSEC_PER_SEC << 32) / tsc_freq;
     min_delta = (tsc_freq + (NSEC_PER_SEC - 1)) / NSEC_PER_SEC;
     time_base = 0;

--- a/kernel/virtio/pvclock.c
+++ b/kernel/virtio/pvclock.c
@@ -106,7 +106,7 @@ uint64_t pvclock_monotonic(void) {
             delta >>= -pvclock_ti.tsc_shift;
         else
             delta <<= pvclock_ti.tsc_shift;
-        time_now = mul64_32(delta, pvclock_ti.tsc_to_system_mul) +
+        time_now = mul64_32(delta, pvclock_ti.tsc_to_system_mul, 32) +
             pvclock_ti.system_time;
         __asm__ ("mfence" ::: "memory");
     } while ((pvclock_ti.version & 1) || (pvclock_ti.version != version));


### PR DESCRIPTION
The calculation of tsc_mult will overflow for low values of tsc_freq;
dynamically calculate a suitable tsc_shift where tsc_mult fits into 32
bits.

Additionally, add a DEBUG level log message (visible with --solo5:debug)
to tscclock_init() which prints the values in use on the current
hardware.

TODO: Virtio and muen continue to use a fixed shift of 32 for now,
fixing those targets needs a bit more refactoring to avoid code
duplication.

Thanks to @hannesm for diagnosing the problem and writing the first half
of the fix.

Tested on PCEngines APU2C4 (AMD Embedded G series GX-412TC CPU),
Raspberry Pi 3 model B+ (Broadcom BCM2837B0).

Fixes #242 and also test_time failures observed on ARM64 boards which
have the same root cause.