### PR TITLE
dumpcore on OpenBSD: provide a stub (copied from ukvm_dumpcore_kvm_aarch64)

### DIFF
--- a/ukvm/ukvm_dumpcore_openbsd_x86_64.c
+++ b/ukvm/ukvm_dumpcore_openbsd_x86_64.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of ukvm, a unikernel monitor.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * ukvm_dumpcore_openbsd_x86_64.c: Glue between the dumpcore module and OpenBSD
+ * (x86_64).
+ */
+
+int ukvm_dumpcore_supported()
+{
+    return -1;
+}
+
+size_t ukvm_dumpcore_prstatus_size(void)
+{
+    /* Not supported yet */
+    return 0;
+}
+
+int ukvm_dumpcore_write_prstatus(int fd, struct ukvm_hv *hv, void *cookie)
+{
+    /* Not supported yet */
+    return -1;
+}

--- a/ukvm/ukvm_module_dumpcore.c
+++ b/ukvm/ukvm_module_dumpcore.c
@@ -53,6 +53,12 @@ typedef unsigned char *host_mvec_t;
 #define EM_HOST EM_X86_64
 typedef char *host_mvec_t;
 
+#elif defined(__OpenBSD__) && defined(__x86_64__)
+
+#include "ukvm_dumpcore_openbsd_x86_64.c"
+#define EM_HOST EM_X86_64
+typedef unsigned char *host_mvec_t;
+
 #elif defined(__linux__) && defined(__aarch64__)
 
 #include "ukvm_dumpcore_kvm_aarch64.c"


### PR DESCRIPTION
I tried to compiled solo5 on OpenBSD and ran into trouble, this is the minimal fix I could come up with.