### PR TITLE
Documentation re-work for 0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,66 @@
-                |      ___|  
-      __|  _ \  |  _ \ __ \  
-    \__ \ (   | | (   |  ) | 
-    ____/\___/ _|\___/____/  
-
-# Status update, February 2018
-
-Solo5 is currently undergoing major refactoring including breaking API/ABI
-changes. This document reflects the state of the project as of the last formal
-release (version 0.2.2), and will be updated once this refactoring has
-concluded.
-
-If you are a Mirage/Solo5 user and would like to keep using Mirage 3.0 based on
-Solo5 version 0.2.x, the instructions here are still applicable and you do not
-need to do anything special.
-
-If you want to follow the development version you should use the OPAM remote in
-the [Solo5/opam-solo5](https://github.com/Solo5/opam-solo5) repository and
-update your packages regularly. For more details, refer to this mirageos-devel
-[thread](https://lists.xenproject.org/archives/html/mirageos-devel/2018-02/msg00011.html).
+                |      ___|
+      __|  _ \  |  _ \ __ \
+    \__ \ (   | | (   |  ) |
+    ____/\___/ _|\___/____/
 
 # About Solo5
 
-Solo5 is most useful as a "base layer" to run
-[MirageOS](https://mirage.io/) and [IncludeOS](http://www.includeos.org/) unikernels, either on various existing
-hypervisors (KVM/QEMU, bhyve) or on a specialized "unikernel monitor" called
-`ukvm`.
+Solo5 originally started as a project by Dan Williams at IBM Research to port
+MirageOS to run on the Linux/KVM hypervisor. Since then, it has grown into a
+more general sandboxed execution environment, suitable for running applications
+built using various unikernels (a.k.a. library operating systems), targeting
+different sandboxing technologies on diverse host operating systems and
+hypervisors.
+
+Some of the unique features of Solo5:
+
+- a public [API](kernel/solo5.h) designed for ease of porting existing and
+  future unikernel-native applications,
+- a host to guest interface designed with isolation, a _minimal attack surface_
+  and ease of porting to different sandboxing technologies or host systems in
+  mind,
+- a minimal, modular _monitor_ which [implements](ukvm/) this interface using
+  hardware virtualization (several orders of magnitude smaller than QEMU),
+- support for live and post-mortem [debugging](docs/debugging.md) of unikernels,
+- fast "boot" times (comparable to loading a standard user process), suitable
+  for "function as a service" use-cases.
+
+_Looking for the ukvm monitor?_ Ukvm is only one
+[component](docs/architecture.md) of Solo5, and due to be renamed to a better
+name shortly to reflect that it is no longer specific to the KVM hypervisor.
+
+# Getting started
+
+As Solo5 is essentially a piece of "middleware" interfacing unikernel-style
+applications with their host systems, it is not an end-developer product as
+such.
+
+To get started as a developer with Solo5, please refer primarily to the
+instructions provided by the unikernel project you intend to develop
+applications with:
+
+- MirageOS: https://mirage.io/wiki/install
+- IncludeOS: http://www.includeos.org/get-started.html
+
+That said, we provide the following documentation, not specific to any
+unikernel in particular:
+
+- [Building Solo5 and running Solo5-based unikernels](docs/building.md)
+- [Debugging Solo5-based unikernels](docs/debugging.md)
+- [Technical overview, goals and limitations, and architecture of Solo5](docs/architecture.md)
 
 # Contributing and community
 
-Solo5 is developed on Github and licensed under a liberal ISC license. We
-accept contributions via Github pull requests. When submitting a contribution,
+Solo5 is developed on GitHub and licensed under a liberal ISC license. We
+accept contributions via GitHub pull requests. When submitting a contribution,
 please add your details to the `AUTHORS` file, and if your contribution adds
 new source files copy the copyright header from an existing source file.
 
-The coding style for this project is "as for the Linux kernel, but with 4
-spaces instead of tabs".
+The coding style for the project is "as for the Linux kernel, but with 4
+spaces instead of tabs". When in doubt, please follow style in existing source
+files.
 
-To get help as a user of Solo5, the best place to start is the community
-specific to the unikernel you intend to develop applications with:
-
-- MirageOS: https://mirage.io/community/
-- IncludeOS: http://www.includeos.org/
-
-We also operate a mailing list for general Solo5 development discussion, at
+We operate a mailing list for general Solo5 development discussion, at
 solo5@lists.h3q.com. To subscribe to the list, send an empty email to
 solo5-subscribe@lists.h3q.com. Archives are available at [The Mail
 Archive](https://www.mail-archive.com/solo5@lists.h3q.com/).
@@ -50,172 +68,3 @@ Archive](https://www.mail-archive.com/solo5@lists.h3q.com/).
 If you are considering a substantial contribution to Solo5, would like to port
 a new unikernel to Solo5, or have general questions unrelated to a specific
 unikernel, please get in touch via the mailing list.
-
-# Quickstart
-
-You can run a hello-world application like this:
-
-    $ make
-    $ ./tests/test_hello/ukvm-bin ./tests/test_hello/test_hello.ukvm
-
-# About ukvm
-
-`ukvm` runs as a Linux process and uses KVM.  The goal of `ukvm` is to
-be a small, modular monitor, in which its functionality and interfaces
-are customized to the unikernel that is being built.  In other words,
-the unikernel monitor exhibits the characteristic of "only what is
-needed" for the unikernel to run.  It has the potential to provide a
-thinner interface to the guest unikernel (thinner than either a
-container or a VM), a simpler I/O interface (e.g., packet send rather
-than virtio), and better performance due to its simplicity (e.g., fast
-boot). Check out our
-[paper](https://www.usenix.org/system/files/conference/hotcloud16/hotcloud16_williams.pdf)
-and
-[presentation](https://www.usenix.org/sites/default/files/conference/protected-files/hotcloud16_slides_williams.pdf)
-from USENIX HotCloud '16 for more information.
-
-# Building MirageOS unikernels with Solo5
-
-Support for Solo5 as a target is integrated since the release of MirageOS 3.0,
-which adds two new targets to the `mirage configure` command:
-
-1. `ukvm`: A specialized "unikernel monitor" which runs on Linux
-   (`x86_64` and `arm64`) and uses KVM directly via `/dev/kvm`.
-2. `virtio`: An `x86_64` system with `virtio` network and disk
-   interfaces. Use this target for QEMU/KVM, plain QEMU, bhyve or other
-   hypervisors (see below).
-
-You can build for either of these targets using the standard MirageOS build
-process, which will output either a `.ukvm` or `.virtio` unikernel binary.
-
-For the `ukvm` target, in addition to the `.ukvm` unikernel binary a `ukvm-bin`
-binary will be built. This is the `ukvm` monitor specialised for your
-unikernel.
-
-# Running Solo5 unikernels directly
-
-The following examples use the standalone
-[test_ping_serve](tests/test_ping_serve/test_ping_serve.c) unikernel which is
-built as part of the normal Solo5 build process. 
-
-`test_ping_serve` is a minimalist network test which will respond only to ARP
-and ICMP echo requests sent to the hard-coded IP address of `10.0.0.2`. It
-accepts two possible command line arguments: Either `verbose` for verbose
-operation or `limit` to terminate after having sent 100,000 ICMP echo replies.
-
-**Setting up**
-
-By convention, we will use the `tap100` interface to talk to the unikernel.
-
-To set up the `tap100` interface on Linux, run (as root):
-
-    ip tuntap add tap100 mode tap
-    ip addr add 10.0.0.1/24 dev tap100
-    ip link set dev tap100 up
-
-To set up bhyve and the `tap100` interface on FreeBSD, run (as root):
-
-    kldload vmm
-    kldload if_tap
-    kldload nmdm
-    sysctl -w net.link.tap.up_on_open=1
-    ifconfig tap100 create 10.0.0.1/24 link0 up
-
-**Running with ukvm on Linux**
-
-A specialized monitor called `ukvm-bin` is generated as part of the
-build process, so the command line arguments may differ depending on
-the needs of the unikernel.  To see the arguments, run `ukvm-bin` with
-no arguments or `--help`.
-
-To launch the unikernel:
-
-    ./ukvm-bin --net=tap100 ./test_ping_serve.ukvm verbose
-
-Use `^C` to terminate the unikernel.
-
-**Running with KVM/QEMU on Linux, or bhyve on FreeBSD**
-
-To launch the unikernel:
-
-    solo5-run-virtio -n tap100 ./test_ping_serve.virtio verbose
-
-Use `^C` to terminate the unikernel.
-
-The [solo5-run-virtio](tools/run/solo5-run-virtio.sh) script is automatically
-installed in your `$PATH` when using the `solo5-kernel-virtio` OPAM package as
-part of a MirageOS build environment.
-Using it is not required; by default it will print the commands used to setup
-and launch the guest VM. You can run these manually if desired.
-
-**Running virtio unikernels with other hypervisors**
-
-The `virtio` target produces a unikernel that uses the multiboot
-protocol for booting. If your hypervisor can boot a multiboot-compliant
-kernel directly then this is the preferred method.
-
-If your hypervisor requires a full disk image to boot, you can use the
-[solo5-mkimage](tools/mkimage/solo5-mkimage.sh) tool to build one. This tool is
-automatically installed in your `$PATH` when using the `solo5-kernel-virtio`
-OPAM package as part of a MirageOS build environment.
-
-`solo5-mkimage` supports the following image formats:
-
-* `raw`: A raw disk image, written out as a sparse file.
-* `tar`: A disk image suitable for [uploading to](https://cloud.google.com/compute/docs/tutorials/building-images#publishingimage) Google Compute Engine.
-
-The following devices are supported by the Solo5 `virtio` target:
-
-* the serial console, fixed at COM1 and 115200 baud
-* the KVM paravirtualized clock, if available
-* a single virtio network device attached to the PCI bus
-* a single virtio block device attached to the PCI bus
-
-Note that Solo5 on virtio does not support ACPI power-off. This can manifest
-itself in delays shutting down Solo5 guests running on hypervisors which wait
-for the guest to respond to ACPI power-off before performing a hard shutdown.
-
-# Developing Solo5 and ukvm
-
-If you'd like to develop Solo5, ukvm and/or investigate porting other
-unikernels to use Solo5 as a base layer, the public APIs are defined in
-`kernel/solo5.h` and `ukvm/ukvm.h`. These interfaces are still evolving
-and subject to change.
-
-We also have some simple standalone unikernels written in C to test
-Solo5, see `tests` for these.
-
-# Debugging on ukvm
-
-You can debug the unikernel running in ukvm using gdb, but need to
-build a `ukvm-bin` with gdb support.  To do so, edit the Makefile
-(generated in the case of Mirage), and add `gdb` to the `UKVM_MODULES`
-make variable.  Then, running `make ukvm-bin` should build a version
-with gdb support.
-
-Start ukvm with the `--gdb` flag, like this:
-
-    $ cd tests/test_hello
-    $ ./ukvm-bin --gdb test_hello.ukvm
-
-And then from another console start gdb and connect to the remote target
-listening at `localhost:1234`:
-
-    $ gdb --ex="target remote localhost:1234" test_hello.ukvm
-
-Here is a typical gdb session:
-
-    (gdb) break puts
-    Breakpoint 1 at 0x100530: puts. (2 locations)
-    (gdb) c
-    Continuing.
-
-    Breakpoint 1, puts (s=s@entry=0x107808 "\n**** Solo5 standalone test_hello ****\n\n") at test_hello.c:25
-    25	{
-    (gdb) bt
-    #0  puts (s=s@entry=0x107808 "\n**** Solo5 standalone test_hello ****\n\n") at test_hello.c:25
-    #1  0x0000000000106a8e in solo5_app_main (cmdline=cmdline@entry=0x6000 "") at test_hello.c:31
-    #2  0x0000000000100089 in _start (arg=0x5000) at ukvm/kernel.c:42
-    (gdb) s
-    26	    solo5_console_write(s, strlen(s));
-    (gdb) 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,114 @@
+# Technical overview
+
+Solo5 is a sandboxed execution environment primarily intended for, but not
+limited to, running applications built using various unikernels (a.k.a.
+library operating systems).
+
+Conceptually, if you think of a unikernel as a user process, albeit one that
+does more in "userspace", Solo5 re-defines the [interface](../kernel/solo5.h)
+between the process and its host operating system or hypervisor in a way that
+is designed to:
+
+- be as "legacy-free" and "thin"(\*) as possible, thus having a _minimal attack
+  surface_, making it much easier to reason about the isolation properties of
+  Solo5-based applications,
+  
+  (\*) compared to existing interfaces, such as that exposed to a Linux process
+  by the kernel, or to a full-system virtual machine by QEMU
+
+- make it easy to implement new _targets_, targeting a variety of different
+  sandboxing technologies (e.g. hardware virtualization, Linux seccomp, Intel
+  SGX), host operating systems and hypervisors. Solo5-based applications can
+  then be straightforwardly deployed on any supported target without the need
+  to modify their source code.
+
+It turns out that simplifying this interface has the following desirable
+properties:
+
+- removal of interrupts implies more deterministic behaviour of applications,
+  allowing for efficient record/replay and debugging,
+- fast "boot" times, comparable to loading a standard user process, suitable
+  for "function as a service" use-cases,
+- ease of porting existing and future unikernels to run on top of the Solo5
+  interface.
+
+Additionally, Solo5 introduces the concept of a _monitor_, which is loosely the
+equivalent of QEMU in the standard KVM/QEMU setup. The [ukvm](../ukvm/)
+_monitor_ is designed to be modular from the outset, and is several orders of
+magnitude smaller in code size than QEMU. (See the original ukvm
+[paper](https://www.usenix.org/system/files/conference/hotcloud16/hotcloud16_williams.pdf)
+from Hotcloud 2016 for a detailed comparison).
+
+Note that ukvm (both the _monitor_ and _target_) are due to be renamed to a
+better name shortly to reflect both that it is no longer specific to the
+Linux/KVM hypervisor, and to allow for more _monitors_ using different
+sandboxing technologies.
+
+## Goals
+
+The Solo5 implementation strives to be _minimalist_ and _correct_, with an
+emphasis on working out good external, internal and user/operator interfaces in
+preference to (prematurely) adding features or scope creep.
+
+## Non-goals
+
+- SMP is not supported. This is intentional, Solo5-based applications should
+  scale out by running multiple instances of the application,
+- no interrupts or preemptive scheduling, in fact no scheduling at all is
+  provided at the Solo5 level. This reduces complexity and removes the problem
+  of "scheduling a scheduler" while fitting in with the prevalent model of
+  current unikernels, which use co-operative scheduling internally,
+- Solo5 does not run on bare metal (without a host operating system or
+  hypervisor).
+
+## Current status and limitations
+
+Solo5 has been in development since late 2015, and is suitable for early
+adopters. A variety of different _[targets](building.md#supported-targets)_ are
+supported. Production deployments of Solo5-based unikernels exist on Linux/KVM,
+FreeBSD/vmm and Google Compute Engine.
+
+The current interface and its implementations have not been designed for high
+I/O performance. Proposed prototypes show that I/O performance comparable or
+better than that of virtual machines using virtio-style devices is possible.
+
+The current architecture is limited to supporting a single network interface
+and block device per unikernel instance. For details on why this is so, and
+what needs to happen for this limitation to be lifted, please see this mailing
+list [thread](https://www.mail-archive.com/solo5@lists.h3q.com/msg00024.html).
+
+The Solo5 interfaces and ABI are not yet stable, and will change in the future.
+We expect to provide a stable ABI (binary compatibility) in the future.
+
+# Architecture and code organisation
+
+Please note that this organisation and terminology will change after the 0.3.0
+release, for details refer to issue
+[#172](https://github.com/Solo5/solo5/issues/172).
+
+The main components of Solo5 are:
+
+- [kernel/](../kernel/): the Solo5 _bindings_ to (implementation of) the
+  unikernel-facing interface for the various supported targets, as defined in
+  [kernel/solo5.h](../kernel/solo5.h).
+- [ukvm/](../ukvm/): the monitor implementation for the _ukvm_ target, with
+  monitor-wide interfaces defined in [ukvm/ukvm.h](../ukvm/ukvm.h) and the
+  internal isolation ("hypercall") interface to Solo5 defined in
+  [ukvm/ukvm\_guest.h](../ukvm/ukvm_guest.h). All non-core code is contained in
+  optional modules, which are selected at unikernel build time by the
+  [ukvm-configure](../ukvm/ukvm-configure) script.
+- [tests/](../tests/): self tests used as part of our CI system.
+- [tools/](..tools/): extra tooling and scripts (mainly to support the _virtio_
+  target).
+
+The code is architected to split processor architecture and/or host operating
+system (_target_)-specific modules from shared functionality where possible.
+However, it is acceptable to make minimal, judicious use of `#ifdef` where
+doing otherwise would result in excessive code duplication.
+
+Due to the need to run automated tests on bare metal, our CI system is a custom
+solution, the details of which can be found in a dedicated
+[repository](https://github.com/Solo5/solo5-ci). The scripts run by the CI
+system on every GitHub pull request can be found in [build.sh](../build.sh). We
+also use Travis CI as a "backup", with the corresponding configuration in
+[.travis.yml](../.travis.yml).

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,186 @@
+# Building Solo5 and running Solo5-based unikernels
+
+As Solo5 is essentially a piece of "middleware" interfacing unikernel-style
+applications with their host systems, it is not an end-developer product as
+such.
+
+To get started as a developer with Solo5, please refer primarily to the
+instructions provided by unikernel project you intend to develop applications
+with:
+
+- MirageOS: https://mirage.io/wiki/install
+- IncludeOS: http://www.includeos.org/get-started.html
+
+That said, this document provides general information -- not specific to any
+unikernel -- about building Solo5, and running Solo5-based unikernels.
+
+## Building Solo5
+
+Solo5 itself has the following build dependencies:
+
+* a 64-bit Linux, FreeBSD or OpenBSD system (see also below under "Supported
+  targets" for further requirements),
+* a C99 compiler; recent versions of GCC and clang are supported,
+* GNU make,
+* full host system headers (on Linux, kernel headers are not always installed
+  by default).
+
+To build Solo5 from the Git repository, it is sufficient to run `make` (`gmake`
+on BSD systems). This will build all _targets_ supported on the host system.
+
+To run the built-in self-tests:
+
+    tests/setup-tests.sh # As root, sets up `tap100` for networking
+    tests/run-tests.sh   # Root required to run network tests
+
+Note that Solo5 does not support cross-compilation; with the exception of the
+_muen_ target (which is not self-hosting), you should build Solo5 and
+unikernels on a system matching the host you will be running them on.
+
+## Supported targets
+
+Supported _targets_, host operating systems/hypervisors and processor
+architectures:
+
+Production:
+
+* _ukvm_: Linux/KVM, using ukvm as a monitor, on the x86\_64 architecture.
+* _ukvm_; FreeBSD vmm, using ukvm as a monitor, on the x86\_64 architecture.
+  FreeBSD 11-RELEASE or later is required.
+
+Experimental:
+
+* _ukvm_: Linux/KVM, using ukvm as a monitor, on the aarch64 architecture. You
+  will need hardware capable of running a recent (v4.14+) 64-bit mainline
+  kernel and a 64-bit Linux distribution.
+* _ukvm_: OpenBSD vmm, using ukvm as a monitor, on the x86\_64 architecture.
+  OpenBSD 6.3 is known to work, however for correct operation with downstream
+  unikernel build systems, as of June 2018 OpenBSD-current is required.
+* _muen_: The Muen Separation Kernel, on the x86\_64 architecture. Please see
+  this [article](https://muen.sk/articles.html#mirageos-unikernels) for
+  Muen-specific instructions.
+
+Limited:
+
+* _virtio_: Any hypervisor which virtualizes an x86\_64 system with virtio
+  devices (e.g.  Linux/KVM with QEMU as a monitor, Google Compute Engine). See
+  below under "_virtio_: Limitations" for details.
+
+# Running Solo5-based unikernels
+
+Solo5 itself does not provide a high-level mangement or orchestration layer for
+unikernels -- this is intended to be provided by separate downstream projects.
+If you are coming from Linux containers you can think of Solo5 as conceptually
+occupying the same space in the stack as, for example, `runc`.
+
+If you are looking for a high-level stack for deploying unikernels, one such
+project is [Albatross](https://hannes.nqsb.io/Posts/VMM).
+
+The following examples use the standalone
+[test\_ping\_serve](tests/test_ping_serve/test_ping_serve.c) unikernel which is
+built as part of the normal Solo5 build process.
+
+The products of building a Solo5 unikernel are, depending on the _target_, one
+or two artifacts:
+
+- an ELF binary containing the built unikernel,
+- for the _ukvm_ target, a specialized _[monitor](architecture.md)_, by
+  convention currently built as `ukvm-bin` alongside the unikernel binary.
+
+`test_ping_serve` is a minimalist network test which will respond only to ARP
+and ICMP echo requests sent to the hard-coded IP address of `10.0.0.2`. It
+accepts two possible command line arguments: Either `verbose` for verbose
+operation or `limit` to terminate after having sent 100,000 ICMP echo replies.
+
+## Setting up
+
+By convention, we will use the `tap100` interface to talk to the unikernel.
+
+To set up the `tap100` interface on Linux, run (as root):
+
+    ip tuntap add tap100 mode tap
+    ip addr add 10.0.0.1/24 dev tap100
+    ip link set dev tap100 up
+
+To set up vmm and the `tap100` interface on FreeBSD, run (as root):
+
+    kldload vmm
+    kldload if_tap
+    sysctl -w net.link.tap.up_on_open=1
+    ifconfig tap100 create 10.0.0.1/24 link0
+
+To set up vmm and the `tap100` interface on OpenBSD, run (as root):
+
+    cd /dev
+    ./MAKEDEV tap100
+    ifconfig tap100 inet 10.0.0.1 netmask 255.255.255.0
+
+## _ukvm_: Running on Linux, FreeBSD and OpenBSD
+
+A specialized monitor called `ukvm-bin` is generated as part of the
+build process, so the command line arguments may differ depending on
+the needs of the unikernel.  To see the arguments, run `ukvm-bin` with
+no arguments or `--help`.
+
+On Linux, `ukvm-bin` only requires access to `/dev/kvm` and `/dev/net/tun`, and
+thus does NOT need to run as `root` provided your have granted the user in
+question the correct permissions. On FreeBSD and OpenBSD, `root` privileges are
+currently required in order to access the `vmm` APIs.
+
+To launch the unikernel:
+
+    ./ukvm-bin --net=tap100 -- test_ping_serve.ukvm verbose
+
+Use `^C` to terminate the unikernel.
+
+## _virtio_: Running with KVM/QEMU on Linux, or bhyve on FreeBSD
+
+The [solo5-run-virtio](tools/run/solo5-run-virtio.sh) script provides a wrapper
+to correctly launch `qemu-system-x86_64` or `bhyve` on the host system.  Using
+it is not required; by default it will print the commands used to setup and
+launch the guest VM. You can run these manually if desired.
+
+To launch the unikernel:
+
+    solo5-run-virtio -n tap100 -- test_ping_serve.virtio verbose
+
+Use `^C` to terminate the unikernel.
+
+## _virtio_: Running on other hypervisors
+
+The _virtio_ target produces a unikernel that uses the multiboot
+protocol for booting. If your hypervisor can boot a multiboot-compliant
+kernel directly then this is the preferred method.
+
+If your hypervisor requires a full disk image to boot, you can use the
+[solo5-mkimage](tools/mkimage/solo5-mkimage.sh) tool to build one.
+
+`solo5-mkimage` supports the following image formats:
+
+* `raw`: A raw disk image, written out as a sparse file.
+* `tar`: A disk image suitable for [uploading to](https://cloud.google.com/compute/docs/tutorials/building-images#publishingimage) Google Compute Engine.
+
+## _virtio_: Limitations
+
+The _virtio_ target was the initial target supported by Solo5 -- while we are
+keeping it around as it is useful to some users, it is essentially a
+"compatibility layer" providing the Solo5 interface atop "legacy" full-system
+virtualization. As the goals of Solo5 have since evolved, we do not expect to
+devote a substantial amount of time to the further development of _virtio_.
+
+Therefore, we recommend that new deployments use the _ukvm_ target instead.
+
+The following devices are supported by the _virtio_ target:
+
+* the serial console, fixed at COM1 and 115200 baud
+* the KVM paravirtualized clock, if available
+* a single virtio network device attached to the PCI bus
+* a single virtio block device attached to the PCI bus
+
+Note that _virtio_ does not support ACPI power-off. This can manifest itself in
+delays shutting down Solo5 guests running on hypervisors which wait for the
+guest to respond to ACPI power-off before performing a hard shutdown.
+
+----
+
+Next: [Debugging Solo5-based unikernels](debugging.md)

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,81 @@
+# Debugging Solo5-based unikernels
+
+The _ukvm_ target provides support both for live debugging of a running
+unikernel, and post-mortem debugging (guest core dumps). In both cases, you
+will need to enable building the relevant module in your `ukvm-bin` _monitor_.
+
+To do so for the standalone tests provided with Solo5, edit the Makefile and
+add the module to the `UKVM_MODULES` variable. For other downstream build
+systems, consult the documentation of your unikernel project, and/or instruct
+your build system to add the module to the invocation of `ukvm-configure`.
+
+## Live debugging
+
+This feature is currently only supported on Linux/KVM on the x86\_64
+architecture. The `gdb` module must be included in your build of `ukvm-bin`.
+
+Start ukvm with the `--gdb` flag, like this:
+
+    $ cd tests/test_hello
+    $ ./ukvm-bin --gdb test_hello.ukvm
+
+This will start a GDB server on TCP port 1234, and the monitor will wait for
+GDB to connect before launching the unikernel. You can use the `--gdb-port`
+option to specify a different port.
+
+And then from another console start `gdb` and connect to the remote target
+listening at `localhost:1234`:
+
+    $ gdb --ex="target remote localhost:1234" test_hello.ukvm
+
+Here is a typical gdb session:
+
+    (gdb) break puts
+    Breakpoint 1 at 0x100530: puts. (2 locations)
+    (gdb) c
+    Continuing.
+
+    Breakpoint 1, puts (s=s@entry=0x107808 "\n**** Solo5 standalone test_hello ****\n\n") at test_hello.c:25
+    25	{
+    (gdb) bt
+    #0  puts (s=s@entry=0x107808 "\n**** Solo5 standalone test_hello ****\n\n") at test_hello.c:25
+    #1  0x0000000000106a8e in solo5_app_main (cmdline=cmdline@entry=0x6000 "") at test_hello.c:31
+    #2  0x0000000000100089 in _start (arg=0x5000) at ukvm/kernel.c:42
+    (gdb) s
+    26	    solo5_console_write(s, strlen(s));
+    (gdb)
+
+## Post-mortem debugging
+
+This feature is currently only supported on Linux/KVM and FreeBSD vmm on the
+x86\_64 architecture. The `dumpcore` module must be included in your build of
+`ukvm-bin`.
+
+The functionality must also be enabled at run-time by passing the `--dumpcore`
+option to `ukvm-bin`. This will cause `ukvm-bin` to generate a core file if the
+guest aborts, either due to a trap/fault, or by calling `solo5_abort()`
+directly.
+
+You can then load the core file into GDB as follows (this example uses the
+`test_abort` provided with Solo5):
+
+    $ gdb test_abort.ukvm core.ukvm.11509
+    Reading symbols from ./test_abort.ukvm...done.
+    [New process 1]
+    #0  0x00000000001001af in ukvm_do_hypercall (arg=0x1fffffb0, n=10) at ukvm/ukvm_guest.h:68
+    68          __asm__ __volatile__("outl %0, %1"
+    (gdb) bt
+    #0  0x00000000001001af in ukvm_do_hypercall (arg=0x1fffffb0, n=10) at ukvm/ukvm_guest.h:68
+    #1  platform_exit (status=status@entry=255, cookie=cookie@entry=0x0) at ukvm/platform_lifecycle.c:35
+    #2  0x0000000000103293 in solo5_abort () at exit.c:32
+    #3  0x0000000000103824 in solo5_app_main (si=si@entry=0x106000 <si>) at test_abort.c:32
+    #4  0x00000000001000a7 in _start (arg=0x5000) at ukvm/kernel.c:42
+    (gdb)
+
+Note that due to the generated core files being somewhat "unusual" from the
+point of view of the host system's toolchain, only recent (7.x or newer)
+versions of mainline GDB will load them correctly.
+
+----
+
+Next: [Technical overview, goals and limitations, and architecture of Solo5](architecture.md)

--- a/gdb.txt
+++ b/gdb.txt
@@ -1,2 +1,0 @@
-target remote localhost:1234
-set gdb=1


### PR DESCRIPTION
This is a long overdue re-work of the Solo5 documentation, in preparation for the upcoming 0.3.0 release.

Most of this has already been reviewed out of band by @djwillia and @ricarkol, but am opening a PR for wider review here. Note that this does not need to be 100% complete for the release, especially since parts will change after #172.

@Kensan Could you please supply a link to the Muen-specific instructions I could refer to in `building.md`?