### PR TITLE
Ensure tests are run on OpenBSD

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -43,7 +43,7 @@ setup() {
     x86_64-*-freebsd*)
       # TODO, just try and run the test anyway
       ;;
-    OpenBSD)
+    amd64-unknown-openbsd*)
       # TODO, just try and run the test anyway
       ;;
     *)

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -52,6 +52,9 @@ setup() {
     esac
     ;;
   *virtio)
+    if [ "$(uname -s)" = "OpenBSD" ]; then
+      skip "virtio tests not run for OpenBSD"
+    fi
     [ "${BUILD_VIRTIO}" = "no" ] && skip "virtio not built"
     VIRTIO=../tools/run/solo5-run-virtio.sh
     ;;


### PR DESCRIPTION
The tests were not getting run on OpenBSD
9 ukvm tests pass
9 virtio tests fail
1 test not run

`abort ukvm (skipped: not implemented for amd64-unknown-openbsd6.3)`

`18 tests, 9 failures, 1 skipped`