### PR TITLE
vmmvar.h: change vm_exit from union to struct

### DIFF
--- a/ukvm/ukvm_hv_openbsd_x86_64.c
+++ b/ukvm/ukvm_hv_openbsd_x86_64.c
@@ -157,7 +157,7 @@ int ukvm_hv_vcpu_loop(struct ukvm_hv *hv)
     if (vrp == NULL)
         err(1, "malloc vrp");
 
-    vrp->vrp_exit = malloc(sizeof(union vm_exit));
+    vrp->vrp_exit = malloc(sizeof(struct vm_exit));
     if (vrp == NULL)
         err(1, "malloc vrp_exit");
 
@@ -196,7 +196,7 @@ int ukvm_hv_vcpu_loop(struct ukvm_hv *hv)
             err(1, "ukvm_hv_vcpu_loop: vm / vcpu run ioctl failed");
         }
 
-        union vm_exit *vei = vrp->vrp_exit;
+        struct vm_exit *vei = vrp->vrp_exit;
         if (vrp->vrp_exit_reason != VM_EXIT_NONE) {
             switch (vrp->vrp_exit_reason) {
                 case VMX_EXIT_IO:


### PR DESCRIPTION
sync with https://github.com/openbsd/src/commit/02ee787fcd78d11b22dcab625f1f53fd122b6cd9

Successfully built and run mirage-skeleton/tutorial/noop on latest snapshot of OpenBSD amd64-current from this morning, using
$ opam --version
2.0.0~rc3
$ ocaml -version
The OCaml toplevel, version 4.06.0

