### PR TITLE
add support for UKVM_DROP_PRIVILEGES/ukvm_hv_drop_privileges

### DIFF
--- a/ukvm/ukvm-configure
+++ b/ukvm/ukvm-configure
@@ -73,6 +73,9 @@ add_module ()
     if [ ! -f ${UKVM_SRC}/ukvm_module_$1.c ]; then
         die "Invalid module: $1"
     fi
+    if [ $1 = 'dumpcore' ]; then
+        add_cflags "-DUKVM_DROP_PRIVILEGES=0"
+    fi
     enableit="-DUKVM_MODULE_$(echo $1 | tr '[a-z]' '[A-Z]')"
     add_obj "ukvm_module_$1.o"
     add_cflags "${enableit}"

--- a/ukvm/ukvm.h
+++ b/ukvm/ukvm.h
@@ -36,6 +36,10 @@
 #include "ukvm_guest.h"
 #include "ukvm_gdb.h"
 
+#ifndef UKVM_DROP_PRIVILEGES
+#define UKVM_DROP_PRIVILEGES 1
+#endif
+
 /*
  * Hypervisor {arch,backend}-independent data is defined here.
  * {arch,backend}-dependent data (b) is defined in ukvm_hv_{backend}.h.
@@ -62,7 +66,7 @@ void ukvm_elf_load(const char *file, uint8_t *mem, size_t mem_size,
 
 inline void *ukvm_checked_gpa_p(struct ukvm_hv *hv, ukvm_gpa_t gpa, size_t sz,
         const char *file, int line)
-{    
+{
     ukvm_gpa_t r;
 
     if ((gpa >= hv->mem_size) || add_overflow(gpa, sz, r) ||
@@ -100,6 +104,12 @@ void ukvm_hv_vcpu_init(struct ukvm_hv *hv, ukvm_gpa_t gpa_ep,
  * from the unikernel on the final exit.
  */
 int ukvm_hv_vcpu_loop(struct ukvm_hv *hv);
+
+
+/*
+ * Drop Privileges
+ */
+void ukvm_hv_drop_privileges();
 
 /*
  * Register the file descriptor (fd) for use with UKVM_HYPERCALL_POLL.

--- a/ukvm/ukvm_hv_freebsd.c
+++ b/ukvm/ukvm_hv_freebsd.c
@@ -130,3 +130,6 @@ struct ukvm_hv *ukvm_hv_init(size_t mem_size)
     hv->mem_size = mem_size;
     return hv;
 }
+
+void ukvm_hv_drop_privileges() {
+}

--- a/ukvm/ukvm_hv_kvm.c
+++ b/ukvm/ukvm_hv_kvm.c
@@ -93,3 +93,6 @@ struct ukvm_hv *ukvm_hv_init(size_t mem_size)
     hv->b = hvb;
     return hv;
 }
+
+void ukvm_hv_drop_privileges() {
+}

--- a/ukvm/ukvm_hv_openbsd_x86_64.c
+++ b/ukvm/ukvm_hv_openbsd_x86_64.c
@@ -28,7 +28,6 @@
 #include <err.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -149,9 +148,6 @@ int ukvm_hv_vcpu_loop(struct ukvm_hv *hv)
 {
     struct ukvm_hvb         *hvb = hv->b;
     struct vm_run_params    *vrp;
-    struct passwd *pw;
-    uid_t uid;
-    gid_t gid;
 
     vrp = malloc(sizeof(struct vm_run_params));
     if (vrp == NULL)
@@ -164,30 +160,6 @@ int ukvm_hv_vcpu_loop(struct ukvm_hv *hv)
     vrp->vrp_vm_id = hvb->vcp_id;
     vrp->vrp_vcpu_id = hvb->vcpu_id;
     vrp->vrp_continue = 0;
-
-    if ((pw = getpwnam(VMD_USER)) == NULL)
-        err(1, "can't get _vmd user");
-    uid = pw->pw_uid;
-    gid = pw->pw_gid;
-
-    if (chroot(pw->pw_dir) == -1)
-        err(1, "chroot: %s", pw->pw_dir);
-
-    if (chdir("/") == -1)
-        err(1, "chdir(\"/\")");
-
-    if (setgroups(1, &gid) ||
-        setresgid(gid, gid, gid) ||
-        setresuid(uid, uid, uid))
-        err(1, "unable to revoke privs");
-
-    /*
-     * pledge in the vm processes:
-     * stdio - for malloc and basic I/O including events.
-     * vmm - for the vmm ioctls and operations.
-     */
-    if (pledge("stdio vmm", NULL) == -1)
-        err(errno, "pledge");
 
     for (;;) {
         vrp->vrp_irq = 0xFFFF;

--- a/ukvm/ukvm_main.c
+++ b/ukvm/ukvm_main.c
@@ -196,5 +196,10 @@ int main(int argc, char **argv)
 
     setup_modules(hv);
 
+    if(UKVM_DROP_PRIVILEGES == 1) {
+        ukvm_hv_drop_privileges();
+    } else {
+        warnx("Stern Warning, not recommended for production");
+    }
     return ukvm_hv_vcpu_loop(hv);
 }


### PR DESCRIPTION
as per @mato [email](https://www.mail-archive.com/solo5@lists.h3q.com/msg00043.html) 

and  then move OpenBSD drop privileges into ukvm_hv_drop_privileges.

I am unsure about the text for `Stern Warning, not recommended for production` and function description of `void ukvm_hv_drop_privileges();` but wanted to get the PR submitted for discussion