### PR TITLE
OpenBSD only needs -nopie LDFLAGS, remove -fno-pie from CFLAGS

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -155,7 +155,7 @@ case $(uname -s) in
         for f in ${SRCS_AMD64}; do cp -f ${INCDIR}/$f ${HOST_INCDIR}/amd64; done
         for f in ${SRCS}; do cp -f ${INCDIR}/$f ${HOST_INCDIR}; done
 
-        HOST_CFLAGS="-fno-pie -fno-stack-protector -nostdlibinc"
+        HOST_CFLAGS="-fno-stack-protector -nostdlibinc"
         HOST_LDFLAGS="-nopie"
         BUILD_UKVM="yes"
         BUILD_VIRTIO="yes"


### PR DESCRIPTION
After reading [PIC, PIE and Sanitizers](https://mropert.github.io/2018/02/02/pic_pie_sanitizers/#mixing-up-binaries)

I realized we don't need to try and push -fno-pie every where and complicate all the builds.

remove -fno-pie from CFLAGS

all the solo5 tests run and succeed(for which OpenBSD should pass), i have been able to build and run (resolving failed) http-fetch(mirage-skeleton/device-usage/http-fetch), which previously failed in gmp-freestanding, zarith-freestanding and nocryto(all with hacks to get that far).