### PR TITLE
 Add dumpcore support for OpenBSD

### DIFF
--- a/tenders/hvt/hvt_dumpcore_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_dumpcore_openbsd_x86_64.c
@@ -21,21 +21,96 @@
 /*
  * hvt_dumpcore_openbsd_x86_64.c: Glue between the dumpcore module and OpenBSD
  * (x86_64).
+ *
+ * Please note the core generated on OpenBSD is not readable by gdb on OpenBSD.
  */
+
+#include <sys/ioctl.h>
+#include <machine/vmmvar.h>
+
+#include "hvt.h"
+#include "hvt_openbsd.h"
+#include "hvt_cpu_x86_64.h"
 
 int hvt_dumpcore_supported()
 {
-    return -1;
+    return sizeof (prstatus_t);
 }
 
 size_t hvt_dumpcore_prstatus_size(void)
 {
-    /* Not supported yet */
-    return 0;
+    return sizeof(prstatus_t);
 }
 
 int hvt_dumpcore_write_prstatus(int fd, struct hvt *hvt, void *cookie)
 {
-    /* Not supported yet */
-    return -1;
+    struct hvt_b      *hvb = hvt->b;
+    struct vcpu_reg_state vrs = *hvb->vrs;
+
+    prstatus_t prstatus;
+    memset(&prstatus, 0, sizeof prstatus);
+
+    /*
+     * prstatus_t.pr_reg is actually a (struct user_regs_struct) in disguise.
+     * This is all non-portable, but both GLIBC and musl expose the struct
+     * definition in <sys/user.h>, so just use the sane interface instead of
+     * dealing with SVR4 garbage.
+     */
+    struct user_regs_struct *uregs =
+        (struct user_regs_struct *)&prstatus.pr_reg;
+
+    uregs->r8 = vrs.vrs_gprs[VCPU_REGS_R8];
+    uregs->r9 = vrs.vrs_gprs[VCPU_REGS_R9];
+    uregs->r10 = vrs.vrs_gprs[VCPU_REGS_R10];
+    uregs->r11 = vrs.vrs_gprs[VCPU_REGS_R11];
+    uregs->r12 = vrs.vrs_gprs[VCPU_REGS_R12];
+    uregs->r13 = vrs.vrs_gprs[VCPU_REGS_R13];
+    uregs->r14 = vrs.vrs_gprs[VCPU_REGS_R14];
+    uregs->r15 = vrs.vrs_gprs[VCPU_REGS_R15];
+    uregs->rbp = vrs.vrs_gprs[VCPU_REGS_RBP];
+    uregs->rsp = vrs.vrs_gprs[VCPU_REGS_RSP];
+    uregs->rdi = vrs.vrs_gprs[VCPU_REGS_RDI];
+    uregs->rsi = vrs.vrs_gprs[VCPU_REGS_RSI];
+    uregs->rdx = vrs.vrs_gprs[VCPU_REGS_RDX];
+    uregs->rcx = vrs.vrs_gprs[VCPU_REGS_RCX];
+    uregs->rbx = vrs.vrs_gprs[VCPU_REGS_RBX];
+    uregs->rax = vrs.vrs_gprs[VCPU_REGS_RAX];
+    uregs->rip = vrs.vrs_gprs[VCPU_REGS_RIP];
+    uregs->eflags = vrs.vrs_gprs[VCPU_REGS_RFLAGS];
+
+    uregs->cs = vrs.vrs_sregs[VCPU_REGS_CS].vsi_sel;
+    uregs->ss = vrs.vrs_sregs[VCPU_REGS_SS].vsi_sel;
+    uregs->ds = vrs.vrs_sregs[VCPU_REGS_DS].vsi_sel;
+    uregs->es = vrs.vrs_sregs[VCPU_REGS_ES].vsi_sel;
+    uregs->fs = vrs.vrs_sregs[VCPU_REGS_FS].vsi_sel;
+    uregs->gs = vrs.vrs_sregs[VCPU_REGS_GS].vsi_sel;
+    uregs->fs_base = vrs.vrs_sregs[VCPU_REGS_FS].vsi_base;
+    uregs->gs_base = vrs.vrs_sregs[VCPU_REGS_GS].vsi_base;
+
+    /*
+     * If the guest provided us with register data from a trap handler, use
+     * that.
+     */
+    if (cookie) {
+        assert(sizeof(struct x86_trap_regs) < HVT_HALT_COOKIE_MAX);
+        struct x86_trap_regs *regs = (struct x86_trap_regs *)cookie;
+        uregs->rip = regs->rip;
+        uregs->cs = regs->cs;
+        uregs->eflags = regs->rflags;
+        uregs->rsp = regs->rsp;
+        uregs->ss = regs->ss;
+    }
+
+    ssize_t nbytes;
+    nbytes = write(fd, &prstatus, sizeof prstatus);
+    if (nbytes < 0) {
+        warn("dumpcore: Error writing prstatus");
+        return -1;
+    }
+    else if (nbytes != sizeof prstatus) {
+        warnx("dumpcore: Short write() writing prstatus: %zd", nbytes);
+        return -1;
+    }
+
+    return 0;
 }

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -76,7 +76,7 @@ struct hvt *hvt_init(size_t mem_size)
     struct vm_create_params *vcp;
     struct vm_mem_range *vmr;
     void *p;
-    
+
     if(geteuid() != 0) {
         errno = EPERM;
         err(1, "need root privileges");
@@ -128,6 +128,7 @@ struct hvt *hvt_init(size_t mem_size)
 
     hvb->vcp_id = vcp->vcp_id;
     hvb->vcpu_id = 0; // the first and only cpu is at 0
+    hvb->vrs = NULL;
 
     atexit(cleanup_vm);
 

--- a/tenders/hvt/hvt_openbsd.h
+++ b/tenders/hvt/hvt_openbsd.h
@@ -32,6 +32,69 @@ struct hvt_b {
     int      vmd_fd;
     uint32_t vcp_id;
     uint32_t vcpu_id;
+    struct   vcpu_reg_state *vrs;
 };
 
+/*
+the following code has been extracted from musl
+arch/x86_64/bits/user.h
+include/sys/procfs.h
+
+musl as a whole is licensed under the following standard MIT license:
+
+----------------------------------------------------------------------
+Copyright © 2005-2014 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+----------------------------------------------------------------------
+*/
+struct user_regs_struct {
+        unsigned long r15, r14, r13, r12, rbp, rbx, r11, r10, r9, r8;
+        unsigned long rax, rcx, rdx, rsi, rdi, orig_rax, rip;
+        unsigned long cs, eflags, rsp, ss, fs_base, gs_base, ds, es, fs, gs;
+};
+
+#define ELF_NGREG 27
+typedef unsigned long long elf_gregset_t[ELF_NGREG];
+
+struct elf_siginfo {
+	int si_signo;
+	int si_code;
+	int si_errno;
+};
+
+struct elf_prstatus {
+	struct elf_siginfo pr_info;
+	short int pr_cursig;
+	unsigned long int pr_sigpend;
+	unsigned long int pr_sighold;
+	pid_t pr_pid;
+	pid_t pr_ppid;
+	pid_t pr_pgrp;
+	pid_t pr_sid;
+	struct timeval pr_utime;
+	struct timeval pr_stime;
+	struct timeval pr_cutime;
+	struct timeval pr_cstime;
+	elf_gregset_t pr_reg;
+	int pr_fpvalid;
+};
+typedef struct elf_prstatus prstatus_t;
 #endif /* HVT_HV_OPENBSD_H */

--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -28,7 +28,6 @@
 #include <err.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -186,9 +185,8 @@ int hvt_vcpu_loop(struct hvt *hvt)
                     /* Guest has halted the CPU. */
                     if (nr == HVT_HYPERCALL_HALT) {
                         hvt_gpa_t gpa = vei->vei.vei_data;
-                        struct hvt_halt *p =
-                            HVT_CHECKED_GPA_P(hvt, gpa, sizeof (struct hvt_halt));
-                        return p->exit_status;
+                        hvb->vrs = &vei->vrs;
+                        return hvt_core_hypercall_halt(hvt, gpa);
                     }
 
                     hvt_hypercall_fn_t fn = hvt_core_hypercalls[nr];

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -201,7 +201,7 @@ teardown() {
 
 @test "abort hvt" {
   case ${TEST_TARGET} in
-    x86_64-linux-gnu|x86_64-*-freebsd*)
+    x86_64-linux-gnu|x86_64-*-freebsd*|amd64-unknown-openbsd*)
       ;;
     *)
       skip "not implemented for ${TEST_TARGET}"


### PR DESCRIPTION
Please note:
- #276 should be merged first and this PR might need updating. (I wanted to post this for discussion)
- Using gdb from base or ports does not work, the src, core and hvt binary need to be copied to linux for post-mortem debugging (see below)

OpenBSD gdb(from ports) output
```
openbsd:~$ egdb test_abort.hvt core.solo5-hvt.72701
GNU gdb (GDB) 7.12.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-unknown-openbsd6.4".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from test_abort.hvt...done.
[New <main task>]

warning: Unexpected size of section `.reg' in core file.

warning: Unexpected size of section `.reg' in core file.
#0  0x00000000001001c2 in platform_exit (status=1077248, cookie=0x5000) at /home/asteen/devl/solo5/include/solo5/hvt_abi.h:68
68          __asm__ __volatile__("outl %0, %1"
(gdb) bt
#0  0x00000000001001c2 in platform_exit (status=1077248, cookie=0x5000) at /home/asteen/devl/solo5/include/solo5/hvt_abi.h:68
#1  0x0000000000000000 in ?? ()
(gdb)
```

Linux(alpine) gdb output
```
alpine:~$ gdb test_abort.hvt core.solo5-hvt.72701
GNU gdb (GDB) 8.0.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-alpine-linux-musl".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from test_abort.hvt...done.
[New process 1]
#0  0x00000000001001c2 in platform_exit (status=255, cookie=0x0) at /home/asteen/devl/solo5/include/solo5/hvt_abi.h:68
68          __asm__ __volatile__("outl %0, %1"
(gdb) bt
#0  0x00000000001001c2 in platform_exit (status=255, cookie=0x0) at /home/asteen/devl/solo5/include/solo5/hvt_abi.h:68
#1  0x00000000001037e3 in solo5_abort () at exit.c:32
#2  0x000000000010453e in solo5_app_main (si=<optimized out>) at test_abort.c:32
#3  0x00000000001000b1 in _start (arg=0x5000) at hvt/start.c:42
(gdb)
```

Future Work: Learn way more than i ever expected to about generating a core file that OpenBSD base gdb can read.