### PR TITLE
Native Genode bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.lib.so
 *.swp
 *.pcap
 Makeconf
@@ -8,6 +9,7 @@ include/crt
 tests/*/*.hvt
 tests/*/*.virtio
 tests/*/*.muen
+tests/*/*.genode
 tests/*/solo5-hvt
 tests/*/Makefile.solo5-hvt
 tenders/hvt/Makefile.solo5-hvt

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Individual Contributors
 Adrian-Ken Rueegsegger
 Adam Steen
 Dan Williams (IBM)
+Emery Hemingway (Genode Labs)
 Gabriel Jaldon
 Hannes Mehnert
 Ian Campbell (Docker, Inc.)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,9 +22,9 @@ $(TOP)/Makeconf:
 include Makefile.common
 
 .PHONY: all
-all: hvt virtio muen
+all: hvt virtio muen genode
 .DEFAULT_GOAL := all
-.NOTPARALLEL: hvt virtio muen
+.NOTPARALLEL: hvt virtio muen genode
 
 .PHONY: virtio
 virtio:
@@ -48,6 +48,13 @@ ifeq ($(BUILD_MUEN), yes)
 	$(MAKE) -C tests muen
 endif
 
+.PHONY: genode
+genode:
+ifeq ($(BUILD_GENODE), yes)
+	$(MAKE) -C bindings genode
+	$(MAKE) -C tests genode
+endif
+
 .PHONY: clean
 clean:
 	$(MAKE) -C bindings clean
@@ -58,6 +65,7 @@ endif
 	$(RM) solo5-bindings-virtio.pc
 	$(RM) solo5-bindings-hvt.pc
 	$(RM) solo5-bindings-muen.pc
+	$(RM) solo5-bindings-genode.pc
 	$(RM) -r include/crt
 	$(RM) Makeconf
 
@@ -69,6 +77,8 @@ OPAM_VIRTIO_LIBDIR=$(PREFIX)/lib/solo5-bindings-virtio
 OPAM_VIRTIO_INCDIR=$(PREFIX)/include/solo5-bindings-virtio
 OPAM_MUEN_LIBDIR=$(PREFIX)/lib/solo5-bindings-muen
 OPAM_MUEN_INCDIR=$(PREFIX)/include/solo5-bindings-muen
+OPAM_GENODE_LIBDIR=$(PREFIX)/lib/solo5-bindings-genode
+OPAM_GENODE_INCDIR=$(PREFIX)/include/solo5-bindings-genode
 
 # We want the MD CFLAGS, LDFLAGS and LD in the .pc file, where they can be
 # picked up by the Mirage tool / other downstream consumers.
@@ -76,6 +86,7 @@ OPAM_MUEN_INCDIR=$(PREFIX)/include/solo5-bindings-muen
 	sed <$< > $@ \
 	    -e 's#!CFLAGS!#$(MD_CFLAGS)#g;' \
 	    -e 's#!LDFLAGS!#$(LDFLAGS)#g;' \
+	    -e 's#!GENODE_APP_LDFLAGS!#$(GENODE_APP_LDFLAGS)#g;' \
 	    -e 's#!LD!#$(LD)#g;' \
 
 .PHONY: opam-virtio-install
@@ -126,3 +137,16 @@ opam-muen-install: solo5-bindings-muen.pc muen
 opam-muen-uninstall:
 	$(RM) -r $(OPAM_MUEN_INCDIR) $(OPAM_MUEN_LIBDIR)
 	$(RM) $(PREFIX)/lib/pkgconfig/solo5-bindings-muen.pc
+
+.PHONY: opam-genode-install
+opam-genode-install: solo5-bindings-genode.pc genode
+	mkdir -p $(OPAM_GENODE_INCDIR) $(OPAM_GENODE_LIBDIR)
+	cp -R include/. $(OPAM_GENODE_INCDIR)
+	cp bindings/genode/solo5.lib.so bindings/genode/genode_dyn.ld $(OPAM_GENODE_LIBDIR)
+	mkdir -p $(PREFIX)/lib/pkgconfig
+	cp solo5-bindings-genode.pc $(PREFIX)/lib/pkgconfig
+
+.PHONY: opam-genode-uninstall
+opam-genode-uninstall:
+	$(RM) -r $(OPAM_GENODE_INCDIR) $(OPAM_GENODE_LIBDIR)
+	$(RM) $(PREFIX)/lib/pkgconfig/solo5-bindings-genode.pc

--- a/Makefile.common
+++ b/Makefile.common
@@ -34,7 +34,13 @@ MD_CFLAGS+=-mno-red-zone
 endif
 
 # Likewise.
-LDFLAGS=-nostdlib -z max-page-size=0x1000 -static $(HOST_LDFLAGS)
+COMMON_LDFLAGS=-nostdlib -z max-page-size=0x1000
+LDFLAGS=$(COMMON_LDFLAGS) -static $(HOST_LDFLAGS)
 # CFLAGS used for building bindings/ and in-tree tests.
 INCDIR=-isystem $(TOP)/include/crt -I$(TOP)/include/solo5
 CFLAGS=$(MD_CFLAGS) -std=gnu99 -Wall -Wextra -Werror -O2 -g $(INCDIR)
+
+# Genode linking is a special case
+GENODE_COMMON_LDFLAGS = $(COMMON_LDFLAGS) -shared -gc-sections --eh-frame-hdr
+GENODE_LIB_LDFLAGS=$(GENODE_COMMON_LDFLAGS) --entry=0x0 -T $(TOP)/bindings/genode/genode_rel.ld
+GENODE_APP_LDFLAGS=$(GENODE_COMMON_LDFLAGS) -Ttext=0x01000000 --dynamic-linker=ld.lib.so -rpath-link=.

--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -76,15 +76,19 @@ muen/muen-yield.o \
 muen/muen-sinfo.o \
 $(COMMON_COBJS)
 
+GENODE_COBJS=\
+genode/stubs.o
+
 HEADERS=\
 bindings.h
 
 all: virtio hvt
 
-.PHONY: virtio hvt muen
+.PHONY: virtio hvt muen genode
 virtio: virtio/solo5_virtio.o
 hvt: hvt/solo5_hvt.o
 muen: muen/solo5_muen.o
+genode: genode/solo5.lib.so
 
 CFLAGS+=-D__SOLO5_BINDINGS__
 
@@ -112,6 +116,9 @@ muen/solo5_muen.o: $(MUEN_COBJS) muen/solo5_muen.lds
 	$(LD) -r $(LDFLAGS) -o $@ $(MUEN_COBJS)
 	$(OBJCOPY) -w -G solo5_\* -G _start\* $@ $@
 
+genode/solo5.lib.so: $(GENODE_COBJS)
+	$(LD) $(GENODE_LIB_LDFLAGS) -o $@ $^
+
 .PHONY: clean
 clean:
-	$(RM) *.o virtio/*.o hvt/*.o muen/*.o
+	$(RM) *.o virtio/*.o hvt/*.o muen/*.o genode/*.o genode/*.lib.so

--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -268,13 +268,20 @@ struct Solo5::Platform
 			return SOLO5_R_AGAIN;
 
 		/* allocate a packet in the shared packet buffer */
-		auto pkt = tx.alloc_packet(size);
-		/* copy-in payload */
-		Genode::memcpy(tx.packet_content(pkt), buf, size);
+		try {
+			auto pkt = tx.alloc_packet(size);
+			/* copy-in payload */
+			Genode::memcpy(tx.packet_content(pkt), buf, size);
 
-		/* signal the server */
-		tx.submit_packet(pkt);
-		return SOLO5_R_OK;
+			/* signal the server */
+			tx.submit_packet(pkt);
+			return SOLO5_R_OK;
+		}
+
+		catch (Nic::Session::Tx::Source::Packet_alloc_failed) {
+			/* the packet buffer is full, try again later */
+			return SOLO5_R_AGAIN;
+		}
 	}
 
 	solo5_result_t net_read(uint8_t *buf, size_t size, size_t *read_size)

--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2018 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * Note: these bindings are not to be built by a standard
+ * C++ compiler, they are instead built by the Genode
+ * toolchain and build system provided elsewhere.
+ */
+
+/* Genode includes */
+#include <block_session/connection.h>
+#include <nic/packet_allocator.h>
+#include <nic_session/connection.h>
+#include <rtc_session/connection.h>
+#include <timer_session/connection.h>
+#include <base/attached_rom_dataspace.h>
+#include <base/heap.h>
+#include <base/component.h>
+#include <base/sleep.h>
+
+/* Solo5 includes */
+extern "C" {
+#include "bindings.h"
+}
+
+
+namespace Solo5 {
+	using namespace Genode;
+	struct Platform;
+};
+
+
+/**
+ * Class for containing and initializing platform services
+ */
+struct Solo5::Platform
+{
+	/**
+	 * Reference to the Genode base enviroment
+	 */
+	Genode::Env &env;
+
+	/**
+	 * Connection to Timer service, this provides
+	 * our running time and timeout signals.
+	 */
+	Timer::Connection timer { env, "solo5" };
+
+	/**
+	 * Timeount handler, calls the `handle_timeout`
+	 * method when timer signals are dispatched.
+	 */
+	Timer::One_shot_timeout<Platform> yield_timeout {
+		timer, *this, &Platform::handle_timeout };
+
+	/**
+	 * Initial wall time
+	 *
+	 * TODO: periodic RTC synchronization
+	 */
+	Genode::uint64_t _initial_epoch = 0;
+
+	/**
+	 * Allocator for Nic and Block packet metadata
+	 */
+	Heap heap { env.pd(), env.rm() };
+	Allocator_avl pkt_alloc { &heap };
+
+	/**
+	 * Optional connection to network service
+	 */
+	Constructible<Nic::Connection> nic { };
+
+	/**
+	 * Optional connection to block service
+	 */
+	Constructible<Block::Connection> block { };
+
+	Block::sector_t blk_count = 0;
+	Genode::size_t blk_size = 0;
+
+	/**
+	 * Incoming Nic packet handler, calls the `handle_nic`
+	 * method when Nic signals are dispatched.
+	 */
+	Io_signal_handler<Platform> nic_handler {
+		env.ep(), *this, &Platform::handle_nic };
+
+	/* No-op */
+	void handle_timeout(Duration) { }
+
+	bool nic_ready = false;
+
+	/**
+	 * Flag that an incoming packet is pending.
+	 */
+	void handle_nic() { nic_ready = true; }
+
+	/**
+	 * Month and leap year conversion
+	 */
+	static int const *year_info(int year)
+	{
+		static const int standard_year[] =
+			{ 365, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
+		static const int leap_year[] =
+			{ 366, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
+		return ((year%4) == 0 && ((year%100) != 0 || (year%400) == 0))
+			? leap_year : standard_year;
+	}
+
+	/**
+	 * Collect a timestamp from the RTC service and convert
+	 * it to a Unix epoch.
+	 */
+	static Genode::uint64_t rtc_epoch(Genode::Env &env)
+	{
+		enum {
+			SEC_PER_MIN  = 60,
+			SEC_PER_HOUR = SEC_PER_MIN * 60,
+			SEC_PER_DAY  = SEC_PER_HOUR * 24
+		};
+
+		/* a brief connection to a RTC service */
+		auto ts = Rtc::Connection(env).current_time();
+
+		Genode::uint64_t epoch = ts.second;
+		epoch += ts.minute * SEC_PER_MIN;
+		epoch += ts.hour   * SEC_PER_HOUR;
+
+		/* add seconds from the start of the month */
+		epoch += (ts.day-1) * SEC_PER_DAY;
+
+		/* add seconds from the start of the year */
+		int const *month_lengths = year_info(ts.year);
+		for (unsigned m = 1; m < ts.month; ++m)
+			epoch += month_lengths[m] * SEC_PER_DAY;
+
+		/* add seconds from 1970 to the start of this year */
+		for (unsigned y = 1970; y < ts.year; ++y)
+			epoch += year_info(y)[0] * SEC_PER_DAY;
+
+		return epoch;
+	}
+
+	/**
+	 * Commandline buffer
+	 */
+	typedef Genode::String<1024> Cmdline;
+	Cmdline cmdline { };
+
+	/**
+	 * Constructor
+	 */
+	Platform(Genode::Env &e) : env(e)
+	{
+		/**
+		 * Acquire and attach a ROM dataspace (shared
+		 * read-only memory) containing our configuration
+		 * as provided by our parent. This attachment is
+		 * bound to the scope of this constructor.
+		 */
+		Attached_rom_dataspace config_rom(env, "config");
+		Xml_node const config = config_rom.xml();
+
+		bool has_rtc = config.has_sub_node("rtc");
+		bool has_nic = config.has_sub_node("nic");
+		bool has_blk = config.has_sub_node("blk");
+
+		if (has_rtc) {
+			_initial_epoch = rtc_epoch(env);
+		}
+
+		/*
+		 * create sessions early to subtract session
+		 * buffers from quota before the application
+		 * heap is created
+		 */
+
+		if (has_nic) {
+			enum { NIC_BUFFER_SIZE =
+				Nic::Packet_allocator::DEFAULT_PACKET_SIZE * 128 };
+
+			nic.construct(
+				env, &pkt_alloc,
+				NIC_BUFFER_SIZE, NIC_BUFFER_SIZE,
+				"guest");
+
+			/*
+			 * Register the signal context capability for our
+			 * packet handler at the Nic service.
+			 */
+			nic->rx_channel()->sigh_packet_avail(nic_handler);
+		}
+
+		if (has_blk) {
+			block.construct(env, &pkt_alloc, 128*1024, "guest");
+		}
+
+		/**
+		 * Copy-out the cmdline if configured.
+		 */
+		try {
+			config.sub_node("solo5")
+				.attribute("cmdline")
+					.value(&cmdline);
+		}
+		catch (...) { }
+	}
+
+
+	/********************
+	 ** Solo5 bindings **
+	 ********************/
+
+	void net_info(struct solo5_net_info &info)
+	{
+		if (!nic.constructed()) {
+			Genode::error("network device not available");
+			return;
+		}
+
+		Net::Mac_address nic_mac = nic->mac_address();
+
+		Genode::memcpy(
+			info.mac_address, nic_mac.addr,
+			min(sizeof(info.mac_address), sizeof(nic_mac.addr)));
+
+		/* MTU is unknown */
+		info.mtu = 1500;
+	}
+
+	solo5_result_t net_write(const uint8_t *buf, size_t size)
+	{
+		if (!nic.constructed())
+			return SOLO5_R_EUNSPEC;
+
+		auto &tx = *nic->tx();
+
+		/*
+		 * release buffer packet space that
+		 * has been processed by the server
+		 */
+		while (tx.ack_avail())
+			tx.release_packet(tx.get_acked_packet());
+
+		/* do not block if packets congest at the server */
+		if (!tx.ready_to_submit())
+			return SOLO5_R_AGAIN;
+
+		/* allocate a packet in the shared packet buffer */
+		auto pkt = tx.alloc_packet(size);
+		/* copy-in payload */
+		Genode::memcpy(tx.packet_content(pkt), buf, size);
+
+		/* signal the server */
+		tx.submit_packet(pkt);
+		return SOLO5_R_OK;
+	}
+
+	solo5_result_t net_read(uint8_t *buf, size_t size, size_t *read_size)
+	{
+		if (!nic.constructed())
+			return SOLO5_R_EUNSPEC;
+
+		auto &rx = *nic->rx();
+
+		/* check for queued packets from the server */
+		if (!rx.packet_avail() || !rx.ready_to_ack())
+			return SOLO5_R_AGAIN;
+
+		/* copy-out payload */
+		auto pkt = rx.get_packet();
+		size_t n = min(size, pkt.size());
+		Genode::memcpy(buf, rx.packet_content(pkt), n);
+		*read_size = n;
+
+		/* inform the server that the packet is processed */
+		rx.acknowledge_packet(pkt);
+
+		/* flag if more packets are pending */
+		nic_ready = rx.packet_avail();
+		return SOLO5_R_OK;
+	}
+
+	void block_info(struct solo5_block_info &info)
+	{
+		if (!block.constructed()) {
+			Genode::error("block device not available");
+			return;
+		}
+
+		Block::Session::Operations ops;
+		block->info(&blk_count, &blk_size, &ops);
+
+		info.capacity = blk_count * blk_size;
+		info.block_size = blk_size;
+	}
+
+	solo5_result_t block_write(solo5_off_t offset,
+	                           const uint8_t *buf,
+	                           size_t size)
+	{
+		if ((offset|size) % blk_size)
+			return SOLO5_R_EINVAL;
+		if (!block.constructed())
+			return SOLO5_R_EUNSPEC;
+
+		auto &source = *block->tx();
+
+		/* allocate a region in the packet buffer */
+		Block::Packet_descriptor pkt(
+			source.alloc_packet(size),
+			Block::Packet_descriptor::WRITE,
+			offset / blk_size, size / blk_size);
+
+		/* copy-in write */
+		Genode::memcpy(source.packet_content(pkt), buf, pkt.size());
+
+		/* submit, block for response, release */
+		source.submit_packet(pkt);
+		pkt = source.get_acked_packet();
+		source.release_packet(pkt);
+
+		return pkt.succeeded() ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
+	}
+
+	solo5_result_t block_read(solo5_off_t offset, uint8_t *buf, size_t size)
+	{
+		if ((offset|size) % blk_size)
+			return SOLO5_R_EINVAL;
+		if (!block.constructed())
+			return SOLO5_R_EUNSPEC;
+
+		auto &source = *block->tx();
+
+		/* allocate a region in the packet buffer */
+		Block::Packet_descriptor pkt(
+			source.alloc_packet(size),
+			Block::Packet_descriptor::READ,
+			offset / blk_size, size / blk_size);
+
+		/* submit, block for response */
+		source.submit_packet(pkt);
+		pkt = source.get_acked_packet();
+
+		/* copy-out read */
+		Genode::memcpy(buf, source.packet_content(pkt), pkt.size());
+
+		/* release packet region */
+		source.release_packet(pkt);
+
+		return pkt.succeeded() ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
+	}
+
+	void exit(int status, void *cookie) __attribute__((noreturn))
+	{
+		if (cookie)
+			log((Hex)addr_t(cookie));
+
+		/* inform the parent we wish to exit */
+		env.parent().exit(status);
+
+		/* deadlock */
+		Genode::sleep_forever();
+	}
+};
+
+
+/**
+ * Global pointer to platform object.
+ */
+static Solo5::Platform *_platform;
+
+
+/**
+ * Solo5 C API
+ */
+extern "C" {
+
+void solo5_exit(int status)
+{
+    _platform->exit(status, nullptr);
+}
+
+
+void solo5_abort(void)
+{
+    _platform->exit(SOLO5_EXIT_ABORT, nullptr);
+}
+
+
+solo5_time_t solo5_clock_monotonic(void)
+{
+	return _platform->timer.curr_time()
+		.trunc_to_plain_us().value*1000;
+}
+
+
+solo5_time_t solo5_clock_wall(void)
+{
+	return _platform->_initial_epoch * 1000000000ULL
+	     + _platform->timer.curr_time().trunc_to_plain_us().value * 1000ULL;
+}
+
+
+bool solo5_yield(solo5_time_t deadline)
+{
+	solo5_time_t deadline_us = deadline / 1000;
+	solo5_time_t now_us = _platform->timer.curr_time()
+		.trunc_to_plain_us().value;
+
+	/* schedule a timeout signal */
+	_platform->yield_timeout.schedule(
+		Genode::Microseconds{deadline_us - now_us});
+
+	/*
+	 * Block for Nic and Timer signals until a packet is
+	 * pending or until the timeout expires.
+	 * The handlers defined in the Platform class will be
+	 * invoked during "wait_and_dispatch_one_io_signal".
+	 */
+	do {
+		_platform->env.ep().wait_and_dispatch_one_io_signal();
+		if (_platform->nic_ready)
+			_platform->yield_timeout.discard();
+	} while (_platform->yield_timeout.scheduled());
+
+	return _platform->nic_ready;
+}
+
+
+void solo5_console_write(const char *buf, size_t size)
+{
+	/* This isn't a buffered file-descriptor, strip the newline. */
+	while (buf[size-1] == '\0' || buf[size-1] == '\n')
+		--size;
+
+	Genode::log(Genode::Cstring(buf, size));
+}
+
+
+void solo5_net_info(struct solo5_net_info *info)
+{
+	Genode::memset(info, 0, sizeof(info));
+	_platform->net_info(*info);
+}
+
+
+solo5_result_t solo5_net_write(const uint8_t *buf, size_t size)
+{
+	return _platform->net_write(buf, size);
+}
+
+
+solo5_result_t solo5_net_read(uint8_t *buf, size_t size, size_t *read_size)
+{
+	return _platform->net_read(buf, size, read_size);
+}
+
+
+void solo5_block_info(struct solo5_block_info *info)
+{
+	Genode::memset(info, 0, sizeof(info));
+	_platform->block_info(*info);
+}
+
+
+solo5_result_t solo5_block_write(solo5_off_t offset,
+                                 const uint8_t *buf,
+                                 size_t size)
+{
+	return _platform->block_write(offset, buf, size);
+}
+
+solo5_result_t solo5_block_read(solo5_off_t offset,
+                                uint8_t *buf, size_t size)
+{
+	return _platform->block_read(offset, buf, size);
+}
+
+
+} // extern "C"
+
+
+/**
+ * Genode compontent entrypoint
+ *
+ * This is the entry symbol invoked by the dynamic loader.
+ */
+void Component::construct(Genode::Env &env)
+{
+	/* Construct a statically allocated platform object */
+	static Solo5::Platform inst(env);
+	_platform = &inst;
+
+	static struct solo5_start_info si;
+
+	si.cmdline = _platform->cmdline.string();
+
+	/*
+	 * Use the remaining memory quota for the
+	 * application heap minus a reservation for
+	 * allocation metadata.
+	 */
+	si.heap_size = env.pd().avail_ram().value;
+	if (si.heap_size > 1<<20)
+		si.heap_size -= 1<<19;
+
+	/* allocate a contiguous memory region for the application */
+	Genode::Dataspace_capability heap_ds =
+		env.pd().alloc(si.heap_size);
+
+	/* attach into our address-space */
+	si.heap_start = env.rm().attach(heap_ds);
+
+	/* block for application then exit */
+	env.parent().exit(solo5_app_main(&si));
+}
+
+
+/**
+ * Override stack size of initial entrypoint
+ */
+size_t Component::stack_size() {
+	return 1<<19; }

--- a/bindings/genode/genode_dyn.ld
+++ b/bindings/genode/genode_dyn.ld
@@ -1,0 +1,294 @@
+/*
+ * \brief  Linker script for dynamically-linked Genode programs
+ * \author Sebastian Sumpf
+ * \date   2009-11-05
+ */
+
+/*
+ * The entry point of dynamically linked components is unused. The dynamic
+ * linker determines the 'Component::construct' function via a symbol lookup.
+ */
+
+PHDRS
+{
+  phdr     PT_PHDR PHDRS;
+  interp   PT_INTERP;
+  ro       PT_LOAD;
+  rw       PT_LOAD;
+  dynamic  PT_DYNAMIC;
+  eh_frame PT_GNU_EH_FRAME;
+}
+
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  .text :
+  {
+    _prog_img_beg = .;
+
+    /*
+     * The ELF entry point is unused for dynamically linked components. The
+     * dynamic linker determined the entry point by looking up the symbol of
+     * the 'Component::construct' function.
+     *
+     * The 'KEEP' directive prevents text that is reachable from one of the
+     * possible entry points from being garbage collected.
+     */
+    KEEP(*(.text._ZN9Component9constructERN6Genode3EnvE))
+
+    *(.text
+      .stub .text.* .gnu.linkonce.t.*)
+    /* .gnu.warning sections are handled specially by elf32.em.  */
+    *(.gnu.warning)
+  } : ro =0x0
+
+  .interp         : { *(.interp) } : interp : ro
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
+  .hash           : { *(.hash) }
+  .gnu.hash       : { *(.gnu.hash) }
+  .dynsym         : { *(.dynsym) }
+  .dynstr         : { *(.dynstr) }
+  .gnu.version    : { *(.gnu.version) }
+  .gnu.version_d  : { *(.gnu.version_d) }
+  .gnu.version_r  : { *(.gnu.version_r) }
+  .rel.init       : { *(.rel.init) }
+  .rela.init      : { *(.rela.init) }
+  .rel.text       : { *(.rel.text .rel.text.* .rel.gnu.linkonce.t.*) }
+  .rela.text      : { *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*) }
+  .rel.fini       : { *(.rel.fini) }
+  .rela.fini      : { *(.rela.fini) }
+  .rel.rodata     : { *(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*) }
+  .rela.rodata    : { *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*) }
+  .rel.data.rel.ro   : { *(.rel.data.rel.ro* .rel.gnu.linkonce.d.rel.ro.*) }
+  .rela.data.rel.ro   : { *(.rela.data.rel.ro* .rela.gnu.linkonce.d.rel.ro.*) }
+  .rel.data       : { *(.rel.data .rel.data.* .rel.gnu.linkonce.d.*) }
+  .rela.data      : { *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*) }
+  .rel.tdata	  : { *(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*) }
+  .rela.tdata	  : { *(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*) }
+  .rel.tbss	  : { *(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*) }
+  .rela.tbss	  : { *(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*) }
+  .rel.ctors      : { *(.rel.ctors) }
+  .rela.ctors     : { *(.rela.ctors) }
+  .rel.dtors      : { *(.rel.dtors) }
+  .rela.dtors     : { *(.rela.dtors) }
+  .rel.got        : { *(.rel.got) }
+  .rela.got       : { *(.rela.got) }
+  .rel.bss        : { *(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*) }
+  .rela.bss       : { *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*) }
+  .rel.plt        : { *(.rel.plt) }
+  .rela.plt       : { *(.rela.plt) }
+  .init           :
+  {
+    KEEP (*(.init))
+  } = 0x0
+  .plt            : { *(.plt) }
+
+  .fini           :
+  {
+    KEEP (*(.fini))
+  } = 0x0
+  PROVIDE (__etext = .);
+  PROVIDE (_etext = .);
+  PROVIDE (etext = .);
+  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) }
+  .rodata1        : { *(.rodata1) }
+
+  .eh_frame_hdr : { *(.eh_frame_hdr) } : eh_frame : ro
+
+  /*
+   * Adjust the address for the data segment.  We want to adjust up to
+   * the same address within the page on the next page up.
+   */
+  . = ALIGN(0x1000);
+  .root_cap : {
+    /*
+     * Leave space for parent capability parameters at start of data
+     * section. The protection-domain creator is reponsible for storing
+     * sane values here.
+     */
+     _parent_cap = .;
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+  } : rw
+
+  /* Exception handling  */
+  .eh_frame       :
+  {
+    __eh_frame_start__ = .;
+    KEEP (*(.eh_frame))
+    LONG(0);
+   } : rw
+  .gcc_except_table   : { *(.gcc_except_table .gcc_except_table.*) }
+
+  /* .ARM.exidx is sorted, so has to go in its own output section */
+  .ARM.extab : {
+    *(.ARM.extab*)
+  }
+
+  __exidx_start = .;
+  .ARM.exidx : {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  }
+  __exidx_end = .;
+
+  /* Thread Local Storage sections  */
+  .tdata : { *(.tdata .tdata.* .gnu.linkonce.td.*) }
+  .tbss  : { *(.tbss .tbss.* .gnu.linkonce.tb.*) *(.tcommon) }
+
+  /* Take out for now because these sections cause warnings on ARM. If this
+   * should lead to an error then we'll take it back in.
+  .preinit_array     :
+  {
+    __preinit_array_start = .;
+    KEEP (*(.preinit_array))
+    __preinit_array_end = .;
+  }
+  .init_array     :
+  {
+     __init_array_start = .;
+     KEEP (*(SORT(.init_array.*)))
+     KEEP (*(.init_array))
+     __init_array_end = .;
+  }
+  .fini_array     :
+  {
+    __fini_array_start = .;
+    KEEP (*(.fini_array))
+    KEEP (*(SORT(.fini_array.*)))
+    __fini_array_end = .;
+  } */
+  .ctors          :
+  {
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    _ctors_start = .;
+    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array))
+    _ctors_end = .;
+  }
+  .dtors          :
+  {
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    _dtors_start = .;
+    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    KEEP (*(.fini_array))
+    KEEP (*(SORT(.fini_array.*)))
+    _dtors_end = .;
+  }
+  .jcr            : { KEEP (*(.jcr)) }
+  .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) }
+  .dynamic        : { *(.dynamic) } : rw : dynamic
+
+  /* merge .got.plt and .got into .got, since the ARM toolchain for OKL4
+   * set's * DT_PLTGOT to .got instead of .got.plt */
+  .got            : { *(.got.plt) *(.got) }
+
+  .data           :
+  {
+    /*
+     * Platform-specific entry for Fiasco.OC.
+     *
+     * PIC-code compiled for Fiasco.OC, needs some PIC-compatible
+     * way to enter the kernel, the fixed address of the kernel
+     * entry code address needs to be found here.
+     */
+    __l4sys_invoke_indirect = .;
+    LONG(0xeacff000);
+
+    *(.data .data.* .gnu.linkonce.d.*)
+    SORT(CONSTRUCTORS)
+
+    __dso_handle = .;
+    LONG(0x0);
+  }
+  .data1          : { *(.data1) }
+  _edata = .; PROVIDE (edata = .);
+  __bss_start = .;
+  .bss            :
+  {
+   *(.dynbss)
+   *(.bss .bss.* .gnu.linkonce.b.*)
+   *(COMMON)
+
+   /*
+    * Align here to ensure that the .bss section occupies space up to
+    * _end.  Align after .bss to ensure correct alignment even if the
+    * .bss section disappears because there are no input sections.
+    *
+    * FIXME: Why do we need it? When there is no .bss section, we don't
+    * pad the .data section.
+    */
+   . = ALIGN(. != 0 ? 32 / 8 : 1);
+  }
+  . = ALIGN(32 / 8);
+  . = ALIGN(32 / 8);
+  _end = .; PROVIDE (end = .);
+
+  /* end of program image -- must be after last section */
+  _prog_img_end = .;
+
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) }
+}

--- a/bindings/genode/genode_rel.ld
+++ b/bindings/genode/genode_rel.ld
@@ -1,0 +1,254 @@
+/*
+ * \brief  Linker script for libraries
+ * \author Sebastian Sumpf
+ * \date   2009-11-05
+ *
+ * Script for --shared -z combreloc: shared library, combine & sort relocs
+ */
+
+PHDRS
+{
+  ro         PT_LOAD;
+  rw         PT_LOAD;
+  dynamic    PT_DYNAMIC;
+  eh_frame   PT_GNU_EH_FRAME;
+}
+
+SECTIONS
+{
+  /* Read-only sections, merged into text segment: */
+  .note.gnu.build-id : { *(.note.gnu.build-id) } : ro
+  .hash           : { *(.hash) }
+  .gnu.hash       : { *(.gnu.hash) }
+  .dynsym         : { *(.dynsym) }
+  .dynstr         : { *(.dynstr) }
+  .gnu.version    : { *(.gnu.version) }
+  .gnu.version_d  : { *(.gnu.version_d) }
+  .gnu.version_r  : { *(.gnu.version_r) }
+  .rel.dyn        :
+    {
+      *(.rel.init)
+      *(.rel.text .rel.text.* .rel.gnu.linkonce.t.*)
+      *(.rel.fini)
+      *(.rel.rodata .rel.rodata.* .rel.gnu.linkonce.r.*)
+      *(.rel.data.rel.ro* .rel.gnu.linkonce.d.rel.ro.*)
+      *(.rel.data .rel.data.* .rel.gnu.linkonce.d.*)
+      *(.rel.tdata .rel.tdata.* .rel.gnu.linkonce.td.*)
+      *(.rel.tbss .rel.tbss.* .rel.gnu.linkonce.tb.*)
+      *(.rel.ctors)
+      *(.rel.dtors)
+      *(.rel.got)
+      *(.rel.bss .rel.bss.* .rel.gnu.linkonce.b.*)
+    }
+  .rela.dyn       :
+    {
+      *(.rela.init)
+      *(.rela.text .rela.text.* .rela.gnu.linkonce.t.*)
+      *(.rela.fini)
+      *(.rela.rodata .rela.rodata.* .rela.gnu.linkonce.r.*)
+      *(.rela.data .rela.data.* .rela.gnu.linkonce.d.*)
+      *(.rela.tdata .rela.tdata.* .rela.gnu.linkonce.td.*)
+      *(.rela.tbss .rela.tbss.* .rela.gnu.linkonce.tb.*)
+      *(.rela.ctors)
+      *(.rela.dtors)
+      *(.rela.got)
+      *(.rela.bss .rela.bss.* .rela.gnu.linkonce.b.*)
+    }
+  .rel.plt        : { *(.rel.plt) }
+  .rela.plt       : { *(.rela.plt) }
+  .init           :
+  {
+    KEEP (*(.init))
+  } = 0x0
+  .plt            : { *(.plt) }
+  .text           :
+  {
+    *(.text .stub .text.* .gnu.linkonce.t.*)
+    /* .gnu.warning sections are handled specially by elf32.em.  */
+    *(.gnu.warning)
+  } = 0x0
+  .fini           :
+  {
+    KEEP (*(.fini))
+  } =0x0
+  PROVIDE (__etext = .);
+  PROVIDE (_etext = .);
+  PROVIDE (etext = .);
+  .rodata         : { *(.rodata .rodata.* .gnu.linkonce.r.*) }
+  .rodata1        : { *(.rodata1) }
+
+  .eh_frame_hdr : { *(.eh_frame_hdr) } : eh_frame : ro
+  .gcc_except_table   : { *(.gcc_except_table .gcc_except_table.*) }
+
+  /*
+   * Adjust the address for the data segment.  We want to adjust up to
+   * the same address within the page on the next page up.
+   */
+  . = ALIGN(0x1000);
+
+  .data           :
+  {
+    /*
+     * Leave space for parent capability parameters at start of data
+     * section. The protection domain creator is reponsible for storing
+     * sane values here.
+     */
+     _parent_cap = .;
+     _parent_cap_thread_id = .;
+     LONG(0xffffffff);
+     _parent_cap_local_name = .;
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+     LONG(0xffffffff);
+
+    /*
+     * Platform-specific entry for Fiasco.OC.
+     *
+     * PIC-code compiled for Fiasco.OC, needs some PIC-compatible
+     * way to enter the kernel, the fixed address of the kernel
+     * entry code address needs to be found here.
+     */
+    __l4sys_invoke_indirect = .;
+    LONG(0xeacff000);
+
+    *(.data .data.* .gnu.linkonce.d.*)
+    SORT(CONSTRUCTORS)
+  } : rw
+
+  /* .ARM.exidx is sorted, so has to go in its own output section */
+  .ARM.extab : {
+    *(.ARM.extab*)
+  }
+  __exidx_start = .;
+  .ARM.exidx : {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  }
+  __exidx_end = .;
+
+  /* Thread Local Storage sections  */
+  .tdata : { *(.tdata .tdata.* .gnu.linkonce.td.*) }
+  .tbss  : { *(.tbss .tbss.* .gnu.linkonce.tb.*) *(.tcommon) }
+
+  .preinit_array     :
+  {
+    KEEP (*(.preinit_array))
+  }
+  .fini_array     :
+  {
+    KEEP (*(.fini_array))
+    KEEP (*(SORT(.fini_array.*)))
+  }
+  .ctors          :
+  {
+    /*
+     * gcc uses crtbegin.o to find the start of the constructors, so we make
+     * sure it is first.  Because this is a wildcard, it doesn't matter if the
+     * user does not actually link against crtbegin.o; the linker won't look
+     * for a file to match a wildcard.  The wildcard also means that it
+     * doesn't matter which directory crtbegin.o is in.
+     * */
+  /*  KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))*/
+    /*
+     * We don't want to include the .ctor section from the crtend.o file until
+     * after the sorted ctors.  The .ctor section from the crtend file contains
+     * the end of ctors marker and it must be last
+     */
+    KEEP(*(_mark_ctors_start));
+    _ctors_start = .;
+    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    KEEP (*(.init_array)) /* list of constructors specific for ARM eabi */
+    _ctors_end = .;
+    KEEP(*(_mark_ctors_end));
+    
+  }
+  .dtors          :
+  {
+    PROVIDE(_dtors_start = .);
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    PROVIDE(_dtors_end = .);
+  }
+  .jcr            : { KEEP (*(.jcr)) }
+  .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro* .gnu.linkonce.d.rel.ro.*) } 
+
+  .data1          : { *(.data1) }
+  .dynamic        : { *(.dynamic) } : dynamic : rw
+  /* See: genode_dyn.ld */
+  .got            : { *(.got.plt) *(.got) }
+  /* Exception handling  */
+  .eh_frame :
+  {
+  	__eh_frame_start__ = .;
+    KEEP (*(.eh_frame))
+    LONG(0)
+  }
+  _edata = .; PROVIDE (edata = .);
+  __bss_start = .;
+  .bss            :
+  {
+   *(.dynbss)
+   *(.bss .bss.* .gnu.linkonce.b.*)
+   *(COMMON)
+
+   /*
+    * Align here to ensure that the .bss section occupies space up to
+    * _end.  Align after .bss to ensure correct alignment even if the
+    * .bss section disappears because there are no input sections.
+    *
+    * FIXME: Why do we need it? When there is no .bss section, we don't
+    * pad the .data section.
+    */
+   . = ALIGN(. != 0 ? 32 / 8 : 1);
+  }
+  . = ALIGN(32 / 8);
+  . = ALIGN(32 / 8);
+  _end = .; PROVIDE (end = .);
+  /* Stabs debugging sections.  */
+  .stab          0 : { *(.stab) }
+  .stabstr       0 : { *(.stabstr) }
+  .stab.excl     0 : { *(.stab.excl) }
+  .stab.exclstr  0 : { *(.stab.exclstr) }
+  .stab.index    0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment       0 : { *(.comment) }
+  /* DWARF debug sections.
+     Symbols in the DWARF debugging sections are relative to the beginning
+     of the section so we begin them at 0.  */
+  /* DWARF 1 */
+  .debug          0 : { *(.debug) }
+  .line           0 : { *(.line) }
+  /* GNU DWARF 1 extensions */
+  .debug_srcinfo  0 : { *(.debug_srcinfo) }
+  .debug_sfnames  0 : { *(.debug_sfnames) }
+  /* DWARF 1.1 and DWARF 2 */
+  .debug_aranges  0 : { *(.debug_aranges) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  /* DWARF 2 */
+  .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+  .debug_abbrev   0 : { *(.debug_abbrev) }
+  .debug_line     0 : { *(.debug_line) }
+  .debug_frame    0 : { *(.debug_frame) }
+  .debug_str      0 : { *(.debug_str) }
+  .debug_loc      0 : { *(.debug_loc) }
+  .debug_macinfo  0 : { *(.debug_macinfo) }
+  /* SGI/MIPS DWARF 2 extensions */
+  .debug_weaknames 0 : { *(.debug_weaknames) }
+  .debug_funcnames 0 : { *(.debug_funcnames) }
+  .debug_typenames 0 : { *(.debug_typenames) }
+  .debug_varnames  0 : { *(.debug_varnames) }
+  /* DWARF 3 */
+  .debug_pubtypes 0 : { *(.debug_pubtypes) }
+  .debug_ranges   0 : { *(.debug_ranges) }
+  .gnu.attributes 0 : { KEEP (*(.gnu.attributes)) }
+  /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) }
+}

--- a/bindings/genode/stubs.S
+++ b/bindings/genode/stubs.S
@@ -1,0 +1,13 @@
+.text; .global solo5_abort; .type solo5_abort,%function; solo5_abort:
+.text; .global solo5_block_info; .type solo5_block_info,%function; solo5_block_info:
+.text; .global solo5_block_read; .type solo5_block_read,%function; solo5_block_read:
+.text; .global solo5_block_write; .type solo5_block_write,%function; solo5_block_write:
+.text; .global solo5_clock_monotonic; .type solo5_clock_monotonic,%function; solo5_clock_monotonic:
+.text; .global solo5_clock_wall; .type solo5_clock_wall,%function; solo5_clock_wall:
+.text; .global solo5_console_write; .type solo5_console_write,%function; solo5_console_write:
+.text; .global solo5_exit; .type solo5_exit,%function; solo5_exit:
+.text; .global solo5_net_info; .type solo5_net_info,%function; solo5_net_info:
+.text; .global solo5_net_read; .type solo5_net_read,%function; solo5_net_read:
+.text; .global solo5_net_write; .type solo5_net_write,%function; solo5_net_write:
+.text; .global solo5_yield; .type solo5_yield,%function; solo5_yield:
+.text; .global solo5_app_main; movq solo5_app_main@GOTPCREL(%rip), %rax

--- a/configure.sh
+++ b/configure.sh
@@ -95,9 +95,11 @@ case $(uname -s) in
         if [ "${TARGET_ARCH}" = "x86_64" ]; then
             BUILD_VIRTIO="yes"
             BUILD_MUEN="yes"
+            BUILD_GENODE="yes"
         else
             BUILD_VIRTIO="no"
             BUILD_MUEN="no"
+            BUILD_GENODE="no"
         fi
         ;;
     FreeBSD)
@@ -127,6 +129,7 @@ case $(uname -s) in
         BUILD_HVT="yes"
         BUILD_VIRTIO="yes"
         BUILD_MUEN="yes"
+        BUILD_GENODE="yes"
         ;;
     OpenBSD)
         # On OpenBSD/clang we use -nostdlibinc which gives us access to the
@@ -158,6 +161,7 @@ case $(uname -s) in
         BUILD_HVT="yes"
         BUILD_VIRTIO="yes"
         BUILD_MUEN="yes"
+        BUILD_GENODE="yes"
         ;;
     *)
         die "Unsupported build OS: $(uname -s)"
@@ -169,6 +173,7 @@ cat <<EOM >Makeconf
 BUILD_HVT=${BUILD_HVT}
 BUILD_VIRTIO=${BUILD_VIRTIO}
 BUILD_MUEN=${BUILD_MUEN}
+BUILD_GENODE=${BUILD_GENODE}
 HOST_CFLAGS=${HOST_CFLAGS}
 HOST_LDFLAGS=${HOST_LDFLAGS}
 TEST_TARGET=${TARGET}

--- a/docs/building.md
+++ b/docs/building.md
@@ -34,8 +34,8 @@ To run the built-in self-tests:
     tests/run-tests.sh   # Root required to run network tests
 
 Note that Solo5 does not support cross-compilation; with the exception of the
-_muen_ target (which is not self-hosting), you should build Solo5 and
-unikernels on a system matching the host you will be running them on.
+_muen_ and _genode_ targets (which are not self-hosting), you should build
+Solo5 and unikernels on a system matching the host you will be running them on.
 
 ## Supported targets
 
@@ -58,6 +58,12 @@ Experimental:
 * _muen_: The Muen Separation Kernel, on the x86\_64 architecture. Please see
   this [article](https://muen.sk/articles.html#mirageos-unikernels) for
   Muen-specific instructions.
+* _genode_: The Genode Operating System Framework on the x86\_64 architecture.
+  Unikernels may be linked against a shared library containing Solo5 bindings
+  and executed as a native Genode component. The bindings library is provided
+  here in the form of a stub library that can be built using a stock C
+  toolchain along with the C++ implementation that must be built using the
+  Genode toolchain.
 
 Limited:
 

--- a/solo5-bindings-genode.opam
+++ b/solo5-bindings-genode.opam
@@ -1,24 +1,22 @@
 opam-version: "1.2"
-maintainer: "martin@lucina.net"
+maintainer: "ehmry@posteo.net"
 authors: [
-  "Dan Williams <djwillia@us.ibm.com>"
-  "Martin Lucina <martin@lucina.net>"
-  "Ricardo Koller <kollerr@us.ibm.com>"
+  "Emery Hemingway <ehmry@posteo.net>"
 ]
 homepage: "https://github.com/solo5/solo5"
 bug-reports: "https://github.com/solo5/solo5/issues"
 license: "ISC"
 dev-repo: "https://github.com/solo5/solo5.git"
-build: [make "virtio"]
-install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
-remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
+build: [make "genode"]
+install: [make "opam-genode-install" "PREFIX=%{prefix}%"]
+remove: [make "opam-genode-uninstall" "PREFIX=%{prefix}%"]
 depends: "conf-pkg-config"
 conflicts: [
-  "solo5-bindings-genode"
   "solo5-bindings-hvt"
   "solo5-bindings-muen"
+  "solo5-bindings-virtio"
 ]
 available: [
   ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
-  os != "darwin"
+  (os = "linux")
 ]

--- a/solo5-bindings-genode.pc.in
+++ b/solo5-bindings-genode.pc.in
@@ -1,0 +1,10 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+includedir=${prefix}/include/solo5-bindings-genode
+libdir=${exec_prefix}/lib/solo5-bindings-genode
+
+Name: solo5-bindings-genode
+Version: 0.4.0
+Description: Solo5 sandboxed execution environment (Genode target)
+Cflags: !CFLAGS! -fPIC -isystem ${includedir}/crt -I${includedir}/solo5
+Libs: !GENODE_APP_LDFLAGS! -T ${libdir}/genode_dyn.ld ${libdir}/solo5.lib.so

--- a/solo5-bindings-hvt.opam
+++ b/solo5-bindings-hvt.opam
@@ -21,8 +21,9 @@ depexts: [
   [["ubuntu"] ["linux-libc-dev"]]
 ]
 conflicts: [
-  "solo5-bindings-virtio"
+  "solo5-bindings-genode"
   "solo5-bindings-muen"
+  "solo5-bindings-virtio"
 ]
 available: [
   ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64" | arch = "aarch64") &

--- a/solo5-bindings-muen.opam
+++ b/solo5-bindings-muen.opam
@@ -14,6 +14,7 @@ install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 depends: "conf-pkg-config"
 conflicts: [
+  "solo5-bindings-genode"
   "solo5-bindings-hvt"
   "solo5-bindings-virtio"
 ]

--- a/tests/GNUmakefile
+++ b/tests/GNUmakefile
@@ -22,6 +22,7 @@ TESTDIRS=test_hello test_globals test_ping_serve test_blk \
 HVT_TESTS=$(subst test, _test_hvt, $(TESTDIRS))
 VIRTIO_TESTS=$(subst test, _test_virtio, $(TESTDIRS))
 MUEN_TESTS=$(subst test, _test_muen, $(TESTDIRS))
+GENODE_TESTS=$(subst test, _test_genode, $(TESTDIRS))
 CLEANS=$(subst test, _clean, $(TESTDIRS))
 
 all: $(HVT_TESTS) $(VIRTIO_TESTS) $(MUEN_TESTS)
@@ -31,6 +32,8 @@ hvt: $(HVT_TESTS)
 virtio: $(VIRTIO_TESTS)
 
 muen: $(MUEN_TESTS)
+
+genode: $(GENODE_TESTS)
 
 clean: $(CLEANS)
 
@@ -44,6 +47,9 @@ _test_virtio%: force_it
 
 _test_muen%: force_it
 	$(MAKE) -C $(subst _test_muen, test, $@) muen
+
+_test_genode%: force_it
+	$(MAKE) -C $(subst _test_genode, test, $@) genode
 
 _clean_%: force_it
 	$(MAKE) -C $(subst _clean, test, $@) clean

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -28,6 +28,9 @@ virtio:	$(VIRTIO_TARGETS)
 .PHONY: muen
 muen: $(MUEN_TARGETS)
 
+.PHONY: genode
+genode: $(GENODE_TARGETS)
+
 BINDINGS_DIR=$(TOP)/bindings
 SOLO5_HVT_SRC=$(TOP)/tenders/hvt
 
@@ -56,6 +59,14 @@ ifeq ($(BUILD_MUEN), yes)
 
 $(BINDINGS_DIR)/muen/solo5_muen.o:
 	$(MAKE) -C $(BINDINGS_DIR) muen
+endif
+
+ifeq ($(BUILD_GENODE), yes)
+%.genode: %.o $(BINDINGS_DIR)/genode/genode_dyn.ld $(BINDINGS_DIR)/genode/solo5_genode.lib.so
+	$(LD) -T $(BINDINGS_DIR)/genode/genode_dyn.ld $(GENODE_LDFLAGS) -o $@ $(BINDINGS_DIR)/genode/solo5.lib.so $< $(LDLIBS)
+
+$(BINDINGS_DIR)/genode/solo5_genode.lib.so:
+	$(MAKE) -C $(BINDINGS_DIR) genode
 endif
 
 %.virtio: %.o $(BINDINGS_DIR)/virtio/solo5_virtio.lds $(BINDINGS_DIR)/virtio/solo5_virtio.o

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -62,10 +62,10 @@ $(BINDINGS_DIR)/muen/solo5_muen.o:
 endif
 
 ifeq ($(BUILD_GENODE), yes)
-%.genode: %.o $(BINDINGS_DIR)/genode/genode_dyn.ld $(BINDINGS_DIR)/genode/solo5_genode.lib.so
+%.genode: %.o $(BINDINGS_DIR)/genode/genode_dyn.ld $(BINDINGS_DIR)/genode/solo5.lib.so
 	$(LD) -T $(BINDINGS_DIR)/genode/genode_dyn.ld $(GENODE_LDFLAGS) -o $@ $(BINDINGS_DIR)/genode/solo5.lib.so $< $(LDLIBS)
 
-$(BINDINGS_DIR)/genode/solo5_genode.lib.so:
+$(BINDINGS_DIR)/genode/solo5.lib.so:
 	$(MAKE) -C $(BINDINGS_DIR) genode
 endif
 

--- a/tests/test_abort/GNUmakefile
+++ b/tests/test_abort/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_abort.hvt solo5-hvt
 VIRTIO_TARGETS=test_abort.virtio
 MUEN_TARGETS=test_abort.muen
+GENODE_TARGETS=test_abort.genode
 HVT_MODULES=dumpcore
 
 include ../Makefile.tests

--- a/tests/test_blk/GNUmakefile
+++ b/tests/test_blk/GNUmakefile
@@ -18,6 +18,7 @@
 
 HVT_TARGETS=test_blk.hvt solo5-hvt
 VIRTIO_TARGETS=test_blk.virtio
+GENODE_TARGETS=test_blk.genode
 HVT_MODULES=blk
 
 include ../Makefile.tests

--- a/tests/test_exception/GNUmakefile
+++ b/tests/test_exception/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_exception.hvt solo5-hvt
 VIRTIO_TARGETS=test_exception.virtio
 MUEN_TARGETS=test_exception.muen
+GENODE_TARGETS=test_exception.genode
 HVT_MODULES=
 
 include ../Makefile.tests

--- a/tests/test_fpu/GNUmakefile
+++ b/tests/test_fpu/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_fpu.hvt solo5-hvt
 VIRTIO_TARGETS=test_fpu.virtio
 MUEN_TARGETS=test_fpu.muen
+GENODE_TARGETS=test_fpu.genode
 HVT_MODULES=
 
 include ../Makefile.tests

--- a/tests/test_globals/GNUmakefile
+++ b/tests/test_globals/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_globals.hvt solo5-hvt
 VIRTIO_TARGETS=test_globals.virtio
 MUEN_TARGETS=test_globals.muen
+GENODE_TARGETS=test_globals.genode
 HVT_MODULES=
 
 include ../Makefile.tests

--- a/tests/test_hello/GNUmakefile
+++ b/tests/test_hello/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_hello.hvt solo5-hvt
 VIRTIO_TARGETS=test_hello.virtio
 MUEN_TARGETS=test_hello.muen
+GENODE_TARGETS=test_hello.genode
 HVT_MODULES=gdb
 
 include ../Makefile.tests

--- a/tests/test_ping_serve/GNUmakefile
+++ b/tests/test_ping_serve/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_ping_serve.hvt solo5-hvt
 VIRTIO_TARGETS=test_ping_serve.virtio
 MUEN_TARGETS=test_ping_serve.muen
+GENODE_TARGETS=test_ping_serve.genode
 HVT_MODULES=net
 
 include ../Makefile.tests

--- a/tests/test_quiet/GNUmakefile
+++ b/tests/test_quiet/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_quiet.hvt solo5-hvt
 VIRTIO_TARGETS=test_quiet.virtio
 MUEN_TARGETS=test_quiet.muen
+GENODE_TARGETS=test_quiet.genode
 HVT_MODULES=
 
 include ../Makefile.tests

--- a/tests/test_time/GNUmakefile
+++ b/tests/test_time/GNUmakefile
@@ -19,6 +19,7 @@
 HVT_TARGETS=test_time.hvt solo5-hvt
 VIRTIO_TARGETS=test_time.virtio
 MUEN_TARGETS=test_time.muen
+GENODE_TARGETS=test_time.genode
 HVT_MODULES=
 
 include ../Makefile.tests


### PR DESCRIPTION
Bindings for linking Solo5 unikernels into Genode native components. The
bindings are provided as a shared library and may be built as a empty
stub library using the host toolchain or the C++ implementation may be
built using the Genode toolchain and build system. Now that there is a
mix of dynamic and static linked Solo5 implementations the "-static"
flag has been removed from the global LDFLAGS and is now explicitly
specified where required.

---
I am able to build the stub library and tests on Linux and FreeBSD, but I did not test building and linking with the whole Mirage stack on FreeBSD. In the near future I will look into creating small boot image for x86_64 that a Solo5 application can be patched into. If this PR clears then I will make a PR at the main Genode repository for a Solo5 package recipe, and we can build and publish the actual bindings library for Solo5 from code that is hosted here.

Ref https://github.com/genodelabs/genode/issues/2945
