### PR TITLE
Migrate to OPAM 2

### DIFF
--- a/solo5-bindings-genode.opam
+++ b/solo5-bindings-genode.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "ehmry@posteo.net"
 authors: [
   "Emery Hemingway <ehmry@posteo.net>"
@@ -6,7 +6,7 @@ authors: [
 homepage: "https://github.com/solo5/solo5"
 bug-reports: "https://github.com/solo5/solo5/issues"
 license: "ISC"
-dev-repo: "https://github.com/solo5/solo5.git"
+dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "genode"]
 install: [make "opam-genode-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-genode-uninstall" "PREFIX=%{prefix}%"]
@@ -17,6 +17,19 @@ conflicts: [
   "solo5-bindings-virtio"
 ]
 available: [
-  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
-  (os = "linux")
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+synopsis: "Solo5 sandboxed execution environment (genode target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "genode" target. The resulting
+unikernels can then be deployed directly on a host running the
+Genode Operating System Framework.
+
+Building the "genode" target is supported on 64-bit Linux, FreeBSD
+and OpenBSD systems."""

--- a/solo5-bindings-hvt.opam
+++ b/solo5-bindings-hvt.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "martin@lucina.net"
 authors: [
   "Dan Williams <djwillia@us.ibm.com>"
@@ -8,7 +8,7 @@ authors: [
 homepage: "https://github.com/solo5/solo5"
 bug-reports: "https://github.com/solo5/solo5/issues"
 license: "ISC"
-dev-repo: "https://github.com/solo5/solo5.git"
+dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "hvt"]
 install: [make "opam-hvt-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
@@ -26,6 +26,19 @@ conflicts: [
   "solo5-bindings-virtio"
 ]
 available: [
-  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64" | arch = "aarch64") &
+  (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+synopsis: "Solo5 sandboxed execution environment (hvt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the "hvt" target, including the
+"solo5-hvt" tender source code, and "solo5-hvt-configure" script
+used to specialize the tender at MirageOS unikernel build time.
+
+The "hvt" target is supported on 64-bit Linux, FreeBSD and
+OpenBSD systems with hardware virtualization."""

--- a/solo5-bindings-muen.opam
+++ b/solo5-bindings-muen.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "martin@lucina.net"
 authors: [
   "Dan Williams <djwillia@us.ibm.com>"
@@ -8,7 +8,7 @@ authors: [
 homepage: "https://github.com/solo5/solo5"
 bug-reports: "https://github.com/solo5/solo5/issues"
 license: "ISC"
-dev-repo: "https://github.com/solo5/solo5.git"
+dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "muen"]
 install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
@@ -19,6 +19,19 @@ conflicts: [
   "solo5-bindings-virtio"
 ]
 available: [
-  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
+  arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+synopsis: "Solo5 sandboxed execution environment (muen target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "muen" target. The resulting
+unikernels can then be deployed directly on a host running the
+Muen Separation Kernel.
+
+Building the "muen" target is supported on 64-bit Linux, FreeBSD
+and OpenBSD systems."""

--- a/solo5-bindings-virtio.opam
+++ b/solo5-bindings-virtio.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "martin@lucina.net"
 authors: [
   "Dan Williams <djwillia@us.ibm.com>"
@@ -8,7 +8,7 @@ authors: [
 homepage: "https://github.com/solo5/solo5"
 bug-reports: "https://github.com/solo5/solo5/issues"
 license: "ISC"
-dev-repo: "https://github.com/solo5/solo5.git"
+dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "virtio"]
 install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
@@ -19,6 +19,23 @@ conflicts: [
   "solo5-bindings-muen"
 ]
 available: [
-  ocaml-version >= "4.02.3" & (arch = "x86_64" | arch = "amd64") &
-  os != "darwin"
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+synopsis: "Solo5 sandboxed execution environment (virtio target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels using the "virtio" target.
+
+The "virtio" target is supported on 64-bit Linux and FreeBSD
+systems with hardware virtualization, and produces unikernels
+suitable for running on any virtio-compliant hypervisor (e.g.
+QEMU/KVM).
+
+Note that the "virtio" target provides limited support for
+current and future Solo5 features and abstractions. We recommend
+that you use the "hvt" target instead."""


### PR DESCRIPTION
- Drop OCaml version dependency entirely (handled by ocaml-freestanding,
nothing compiler-dependent here).
- Normalize 'arch'.
- 'os' availability is based on the build systems we support, standardise
on Linux/FreeBSD/OpenBSD throughout.
- Add existing 'synopsis', 'description' and new ones for Genode.
- Fix 'dev-repo' to use git+https://...