### PR TITLE
hvt: Basic hvt_drop_privileges on FreeBSD

### DIFF
--- a/tenders/hvt/hvt_freebsd.h
+++ b/tenders/hvt/hvt_freebsd.h
@@ -25,6 +25,9 @@
 #ifndef HVT_HV_FREEBSD_H
 #define HVT_HV_FREEBSD_H
 
+#define VMM_USER      "nobody"
+#define VMM_CHROOT    "/var/empty"
+
 struct hvt_b {
     char *vmname;
     int vmfd;


### PR DESCRIPTION
chroot to /var/empty
drop to nobody

See #282, #284 