### PR TITLE
Dumping data abort address for Arm64

### DIFF
--- a/bindings/cpu_aarch64.h
+++ b/bindings/cpu_aarch64.h
@@ -17,11 +17,38 @@
  * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+#ifndef __CPU_AARCH64_H__
+#define __CPU_AARCH64_H__
 
 /* memory defines */
-#define PAGE_SIZE               4096
-#define PAGE_SHIFT              12
-#define PAGE_MASK               ~(0xfff)
+#define PAGE_SIZE   4096
+#define PAGE_SHIFT  12
+#define PAGE_MASK   ~(0xfff)
+
+#ifndef _BITUL
+
+#ifdef ASM_FILE
+#define _AC(X,Y)    X
+#define _AT(T,X)    X
+#else
+#define __AC(X,Y)   (X##Y)
+#define _AC(X,Y)    __AC(X,Y)
+#define _AT(T,X)    ((T)(X))
+#endif
+
+#define _BITUL(x)   (_AC(1,UL) << (x))
+#define _BITULL(x)  (_AC(1,ULL) << (x))
+
+#endif
+
+#define ESR_EC_IABT_LOW	_AC(0x20, UL)
+#define ESR_EC_IABT_CUR	_AC(0x21, UL)
+#define ESR_EC_DABT_LOW	_AC(0x24, UL)
+#define ESR_EC_DABT_CUR	_AC(0x25, UL)
+
+#define ESR_EC_SHIFT    _AC(26, UL)
+#define ESR_EC_MASK     (_AC(0x3F, UL) << ESR_EC_SHIFT)
+#define ESR_EC(esr)     (((esr) & ESR_EC_MASK) >> ESR_EC_SHIFT)
 
 #ifndef ASM_FILE
 
@@ -41,3 +68,5 @@ static inline uint64_t mul64_32(uint64_t a, uint32_t b, uint8_t s)
     return (a * b) >> s;
 }
 #endif /* !ASM_FILE */
+
+#endif /* __CPU_AARCH64_H__ */


### PR DESCRIPTION
Dumping data abort virtual address is good for debug.

**** Solo5 standalone test_zeropage ****

```Solo5: Trap: EL1 Synchronous Abort caught```
**Data Abort Address: 0x0000000000000008**
```
Solo5: Dump registers:
         ESR    : 0x0000000096000047
         PC     : 0x0000000000103038
         LR     : 0x000000000010302c
         PSTATE : 0x00000000800003c5
         x00 ~ x03: 0x0000000000000001 0x0000000000000001 0x0000000000000008 0x000000001fffffa8
         x04 ~ x07: 0x00000000ffffffff 0x0000000000000000 0x0000000000000001 0x0000000000000001
         x08 ~ x11: 0x0000000000105000 0x0000000000000000 0x0000000000000020 0x0000000000104488
         x12 ~ x15: 0x000000001ffffc40 0x0000000000105008 0x0000000000000020 0x0000000000000000
         x16 ~ x19: 0x0000000000000000 0x0000000000000000 0x0000000000000000 0x0000000000106000
         x20 ~ x23: 0x0000000000010000 0x0000000000000000 0x0000000000000000 0x0000000000000000
         x24 ~ x27: 0x0000000000000000 0x0000000000000000 0x0000000000000000 0x0000000000000000
         x28 ~ x29: 0x0000000000000000 0x000000001fffffc0
Solo5: ABORT: cpu_aarch64.c:84: PANIC

```