### PR TITLE
hvt: arm64: minor fixes

### DIFF
--- a/bindings/cpu_aarch64.c
+++ b/bindings/cpu_aarch64.c
@@ -81,7 +81,7 @@ void cpu_trap_handler(struct regs *regs, int el, int mode, int is_valid)
 
     dump_registers(regs);
 
-    PANIC("PANIC", NULL);
+    PANIC("Fatal trap", NULL);
 }
 
 /* keeps track of cpu_intr_disable() depth */

--- a/tenders/hvt/hvt_cpu_aarch64.c
+++ b/tenders/hvt/hvt_cpu_aarch64.c
@@ -117,7 +117,7 @@ void aarch64_mem_size(size_t *mem_size) {
     assert (mem <= *mem_size);
     if (mem == 0)
         mem = AARCH64_GUEST_BLOCK_SIZE;
-    if (mem < *mem_size)
+    if (mem != *mem_size)
         warnx("adjusting memory to %zu bytes", mem);
     if (mem > AARCH64_MMIO_BASE)
         errx(1, "guest memory size %zu bytes exceeds the max size %lu bytes",


### PR DESCRIPTION
- panic with "Fatal trap" in CPU trap handler instead of just "PANIC"
(consistent with x86_64, helps tests)
- correctly report if guest memory size is adjusted to more than
requested value