### PR TITLE
fix build, 'git_t gid' should be 'gid_t gid'

### DIFF
--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -141,7 +141,7 @@ void hvt_drop_privileges()
     if (pw == NULL)
         err(1, "can't get _vmd user");
     uid_t uid = pw->pw_uid;
-    git_t gid = pw->pw_gid;
+    gid_t gid = pw->pw_gid;
 
     if (chroot(pw->pw_dir) == -1)
         err(1, "chroot(%s)", pw->pw_dir);


### PR DESCRIPTION
Solo5 fails to build on OpenBSD, quick fix changing  `git_t gid` to `gid_t gid`