### PR TITLE
tenders/hvt: Arm64: Remove redundant parameter in the log message.

### DIFF
--- a/bindings/cpu_aarch64.c
+++ b/bindings/cpu_aarch64.c
@@ -69,7 +69,7 @@ void cpu_trap_handler(struct regs *regs, int el, int mode, int is_valid)
     const uint32_t exception_cls = ESR_EC(regs->esr_el1);
 
     log(INFO, "Solo5: Trap: EL%d %s%s caught\n",
-        el, is_valid ? "" : "Invalid ", exception_modes[mode], el);
+        el, is_valid ? "" : "Invalid ", exception_modes[mode]);
 
     if (exception_cls == ESR_EC_DABT_LOW ||
         exception_cls == ESR_EC_DABT_CUR) {


### PR DESCRIPTION
It seems that the log() function doesn't care about the actual
parameter count during parsing the message string.

Signed-off-by: Haibo Xu <haibo.xu@arm.com>