### PR TITLE
Enable printf-style parameter check for log() function

### DIFF
--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -128,7 +128,8 @@ typedef enum {
     INFO, 
     DEBUG,
 } log_level_t;
-int log(log_level_t level, const char *fmt, ...);
+int log(log_level_t level, const char *fmt, ...)
+	__attribute__ ((format (printf, 2, 3)));
 void log_set_level(log_level_t level);
 
 /* compiler-only memory "barrier" */

--- a/bindings/hvt/tscclock.c
+++ b/bindings/hvt/tscclock.c
@@ -97,7 +97,7 @@ int tscclock_init(uint64_t tsc_freq)
             tsc_shift--;
     } while (tsc_shift > 0 && tsc_mult == 0L);
     assert(tsc_mult != 0L);
-    log(DEBUG, "Solo5: tscclock_init(): tsc_freq=%lu tsc_mult=%lu tsc_shift=%u\n",
+    log(DEBUG, "Solo5: tscclock_init(): tsc_freq=%lu tsc_mult=%u tsc_shift=%u\n",
         tsc_freq, tsc_mult, tsc_shift);
 
     /*

--- a/bindings/intr.c
+++ b/bindings/intr.c
@@ -66,7 +66,7 @@ void intr_irq_handler(uint64_t irq)
     }
 
     if (!handled)
-        log(ERROR, "Solo5: unhandled irq %d\n", irq);
+        log(ERROR, "Solo5: unhandled irq %lu\n", irq);
     else
         /* Only ACK the IRQ if handled; we only need to know about an unhandled
          * IRQ the first time round. */

--- a/bindings/mem.c
+++ b/bindings/mem.c
@@ -54,10 +54,10 @@ void mem_init(void)
 	PANIC("Not enough memory", NULL);
 
     log(INFO, "Solo5: Memory map: %lu MB addressable:\n", mem_size >> 20);
-    log(INFO, "Solo5:   reserved @ (0x0 - 0x%lx)\n", _stext-1);
-    log(INFO, "Solo5:       text @ (0x%lx - 0x%lx)\n", _stext, _etext-1);
-    log(INFO, "Solo5:     rodata @ (0x%lx - 0x%lx)\n", _etext, _erodata-1);
-    log(INFO, "Solo5:       data @ (0x%lx - 0x%lx)\n", _erodata, _end-1);
+    log(INFO, "Solo5:   reserved @ (0x0 - 0x%lx)\n", (uint64_t)_stext-1);
+    log(INFO, "Solo5:       text @ (0x%lx - 0x%lx)\n", (uint64_t)_stext, (uint64_t)_etext-1);
+    log(INFO, "Solo5:     rodata @ (0x%lx - 0x%lx)\n", (uint64_t)_etext, (uint64_t)_erodata-1);
+    log(INFO, "Solo5:       data @ (0x%lx - 0x%lx)\n", (uint64_t)_erodata, (uint64_t)_end-1);
     log(INFO, "Solo5:       heap >= 0x%lx < stack < 0x%lx\n", heap_start,
         mem_size);
 }

--- a/bindings/muen/muen-clock.c
+++ b/bindings/muen/muen-clock.c
@@ -88,7 +88,7 @@ int tscclock_init(uint64_t freq __attribute__((unused)))
     min_delta = (tsc_freq + (NSEC_PER_SEC - 1)) / NSEC_PER_SEC;
     time_base = 0;
     log(INFO, "Solo5: Clock source: Muen PV clock, TSC frequency %lu Hz\n",
-        (unsigned long long)tsc_freq);
+        tsc_freq);
     return 0;
 }
 

--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -130,7 +130,7 @@ void net_init(void)
     net_out = (struct muchannel *)(chan_out->data.mem.address);
     muen_channel_init_writer(net_out, MUENNET_PROTO, sizeof(struct net_msg),
                              chan_out->data.mem.size, epoch);
-    log(INFO, "Solo5: Net: Muen shared memory stream, protocol 0x%lx\n",
+    log(INFO, "Solo5: Net: Muen shared memory stream, protocol 0x%llx\n",
         MUENNET_PROTO);
     log(INFO, "Solo5: Net: Output channel @ 0x%lx, size 0x%lx, epoch 0x%lx\n",
         chan_out->data.mem.address, chan_out->data.mem.size, epoch);

--- a/bindings/virtio/tscclock.c
+++ b/bindings/virtio/tscclock.c
@@ -210,7 +210,7 @@ int tscclock_init(void) {
     i8254_delay(100000);
     tsc_freq = (cpu_rdtsc() - tsc_base) * 10;
     log(INFO, "Solo5: Clock source: TSC, frequency estimate is %lu Hz\n",
-        (unsigned long long)tsc_freq);
+        tsc_freq);
 
     /*
      * Calculate TSC scaling multiplier.

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -159,7 +159,7 @@ void virtio_config_block(struct pci_config_info *pci)
     outl(pci->base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
 
     virtio_blk_sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
-    log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%d sectors, "
+    log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%lu sectors, "
         "features=0x%x\n",
         pci->bus, pci->dev, virtio_blk_sectors, host_features);
 


### PR DESCRIPTION
1. Add attribute ((format (printf, 2, 3))) to log() function
   to enable printf-style parameter check;
2. Fix some invocations to match the updated definition.

Signed-off-by: Haibo Xu haibo.xu@arm.com