### PR TITLE
OpenBSD fixes for 'Enable printf-style parameter check for log() func…

### DIFF
--- a/bindings/cpu_x86_64.c
+++ b/bindings/cpu_x86_64.c
@@ -164,10 +164,11 @@ static char *traps[32] = {
 
 void cpu_trap_handler(uint64_t num, struct trap_regs *regs)
 {
-    log(INFO, "Solo5: trap: type=%s ec=0x%lx rip=0x%lx rsp=0x%lx rflags=0x%lx\n",
-        traps[num], regs->ec, regs->rip, regs->rsp, regs->rflags);
+    log(INFO, "Solo5: trap: type=%s ec=0x%llx rip=0x%llx rsp=0x%llx rflags=0x%llx\n",
+        traps[num], (unsigned long long)regs->ec, (unsigned long long)regs->rip,
+        (unsigned long long)regs->rsp, (unsigned long long)regs->rflags);
     if (num == 14)
-        log(INFO, "Solo5: trap: cr2=0x%lx\n", regs->cr2);
+        log(INFO, "Solo5: trap: cr2=0x%llx\n", (unsigned long long)regs->cr2);
     PANIC("Fatal trap", regs);
 }
 

--- a/bindings/hvt/tscclock.c
+++ b/bindings/hvt/tscclock.c
@@ -97,8 +97,8 @@ int tscclock_init(uint64_t tsc_freq)
             tsc_shift--;
     } while (tsc_shift > 0 && tsc_mult == 0L);
     assert(tsc_mult != 0L);
-    log(DEBUG, "Solo5: tscclock_init(): tsc_freq=%lu tsc_mult=%u tsc_shift=%u\n",
-        tsc_freq, tsc_mult, tsc_shift);
+    log(DEBUG, "Solo5: tscclock_init(): tsc_freq=%llu tsc_mult=%u tsc_shift=%u\n",
+        (unsigned long long)tsc_freq, tsc_mult, tsc_shift);
 
     /*
      * Monotonic time begins at tsc_base (first read of TSC before

--- a/bindings/intr.c
+++ b/bindings/intr.c
@@ -66,7 +66,7 @@ void intr_irq_handler(uint64_t irq)
     }
 
     if (!handled)
-        log(ERROR, "Solo5: unhandled irq %lu\n", irq);
+        log(ERROR, "Solo5: unhandled irq %llu\n", (unsigned long long)irq);
     else
         /* Only ACK the IRQ if handled; we only need to know about an unhandled
          * IRQ the first time round. */

--- a/bindings/mem.c
+++ b/bindings/mem.c
@@ -53,13 +53,18 @@ void mem_init(void)
     if (heap_start + 0x80000 > mem_size)
 	PANIC("Not enough memory", NULL);
 
-    log(INFO, "Solo5: Memory map: %lu MB addressable:\n", mem_size >> 20);
-    log(INFO, "Solo5:   reserved @ (0x0 - 0x%lx)\n", (uint64_t)_stext-1);
-    log(INFO, "Solo5:       text @ (0x%lx - 0x%lx)\n", (uint64_t)_stext, (uint64_t)_etext-1);
-    log(INFO, "Solo5:     rodata @ (0x%lx - 0x%lx)\n", (uint64_t)_etext, (uint64_t)_erodata-1);
-    log(INFO, "Solo5:       data @ (0x%lx - 0x%lx)\n", (uint64_t)_erodata, (uint64_t)_end-1);
-    log(INFO, "Solo5:       heap >= 0x%lx < stack < 0x%lx\n", heap_start,
-        mem_size);
+    log(INFO, "Solo5: Memory map: %llu MB addressable:\n",
+            (unsigned long long)mem_size >> 20);
+    log(INFO, "Solo5:   reserved @ (0x0 - 0x%llx)\n",
+            (unsigned long long)_stext-1);
+    log(INFO, "Solo5:       text @ (0x%llx - 0x%llx)\n",
+            (unsigned long long)_stext, (unsigned long long)_etext-1);
+    log(INFO, "Solo5:     rodata @ (0x%llx - 0x%llx)\n",
+            (unsigned long long)_etext, (unsigned long long)_erodata-1);
+    log(INFO, "Solo5:       data @ (0x%llx - 0x%llx)\n",
+            (unsigned long long)_erodata, (unsigned long long)_end-1);
+    log(INFO, "Solo5:       heap >= 0x%llx < stack < 0x%llx\n",
+            (unsigned long long)heap_start, (unsigned long long)mem_size);
 }
 
 /* 

--- a/bindings/muen/muen-clock.c
+++ b/bindings/muen/muen-clock.c
@@ -87,8 +87,8 @@ int tscclock_init(uint64_t freq __attribute__((unused)))
     tsc_mult = (NSEC_PER_SEC << 32) / tsc_freq;
     min_delta = (tsc_freq + (NSEC_PER_SEC - 1)) / NSEC_PER_SEC;
     time_base = 0;
-    log(INFO, "Solo5: Clock source: Muen PV clock, TSC frequency %lu Hz\n",
-        tsc_freq);
+    log(INFO, "Solo5: Clock source: Muen PV clock, TSC frequency %llu Hz\n",
+        (unsigned long long)tsc_freq);
     return 0;
 }
 

--- a/bindings/muen/muen-console.c
+++ b/bindings/muen/muen-console.c
@@ -84,6 +84,7 @@ void console_init(void)
     channel_out  = (struct muchannel *)(channel->data.mem.address);
     muen_channel_init_writer(channel_out, DEBUGLOG_PROTO, sizeof(struct log_msg),
                              channel->data.mem.size, epoch);
-    log(INFO, "Solo5: Console: Muen Channel @ 0x%lx, size 0x%lx, epoch 0x%lx\n",
-        channel->data.mem.address, channel->data.mem.size, epoch);
+    log(INFO, "Solo5: Console: Muen Channel @ 0x%llx, size 0x%llx, epoch 0x%llx\n",
+        (unsigned long long)channel->data.mem.address,
+        (unsigned long long)channel->data.mem.size, (unsigned long long)epoch);
 }

--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -132,8 +132,9 @@ void net_init(void)
                              chan_out->data.mem.size, epoch);
     log(INFO, "Solo5: Net: Muen shared memory stream, protocol 0x%llx\n",
         MUENNET_PROTO);
-    log(INFO, "Solo5: Net: Output channel @ 0x%lx, size 0x%lx, epoch 0x%lx\n",
-        chan_out->data.mem.address, chan_out->data.mem.size, epoch);
+    log(INFO, "Solo5: Net: Output channel @ 0x%llx, size 0x%llx, epoch 0x%llx\n",
+        (unsigned long long)chan_out->data.mem.address,
+        (unsigned long long)chan_out->data.mem.size, (unsigned long long)epoch);
 
     if (!chan_in) {
         log(WARN, "Solo5: Net: No input channel\n");
@@ -151,8 +152,9 @@ void net_init(void)
 
     net_in = (struct muchannel *)(chan_in->data.mem.address);
     muen_channel_init_reader(&net_rdr, MUENNET_PROTO);
-    log(INFO, "Solo5: Net: Input  channel @ 0x%lx, size 0x%lx\n",
-        chan_in->data.mem.address, chan_in->data.mem.size);
+    log(INFO, "Solo5: Net: Input  channel @ 0x%llx, size 0x%llx\n",
+        (unsigned long long)chan_in->data.mem.address,
+        (unsigned long long)chan_in->data.mem.size);
 
     generate_mac_addr(mac_addr);
     snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",

--- a/bindings/virtio/tscclock.c
+++ b/bindings/virtio/tscclock.c
@@ -209,8 +209,8 @@ int tscclock_init(void) {
     tsc_base = cpu_rdtsc();
     i8254_delay(100000);
     tsc_freq = (cpu_rdtsc() - tsc_base) * 10;
-    log(INFO, "Solo5: Clock source: TSC, frequency estimate is %lu Hz\n",
-        tsc_freq);
+    log(INFO, "Solo5: Clock source: TSC, frequency estimate is %llu Hz\n",
+        (unsigned long long)tsc_freq);
 
     /*
      * Calculate TSC scaling multiplier.

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -159,9 +159,10 @@ void virtio_config_block(struct pci_config_info *pci)
     outl(pci->base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
 
     virtio_blk_sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
-    log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%lu sectors, "
+    log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%llu sectors, "
         "features=0x%x\n",
-        pci->bus, pci->dev, virtio_blk_sectors, host_features);
+        pci->bus, pci->dev, (unsigned long long)virtio_blk_sectors,
+        host_features);
 
     virtq_init_rings(pci->base, &blkq, 0);
 


### PR DESCRIPTION
…tion #308'

OpenBSD is a little more strict, uint64_t is a unsigned long long, which requires 'llu' or 'llx' when loggin.