### PR TITLE
For discussion only: Expose solo5_mem_alloc and solo5_mem_lock

### DIFF
--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
@@ -82,10 +82,9 @@ extern int cpu_intr_depth;
 void intr_register_irq(unsigned irq, int (*handler)(void *), void *arg);
 void intr_irq_handler(uint64_t irq);
 
-/* mem.c: low-level page alloc routines */
+/* mem.c: memory initialization */
 void mem_init(void);
-void *mem_ialloc_pages(size_t num);
-void mem_lock_heap(uintptr_t *start, size_t *size);
+void mem_info(struct solo5_start_info*);
 
 /* lib.c: minimal bits of stdc we need */
 void *memset(void *dest, int c, size_t n);
@@ -120,8 +119,8 @@ char *cmdline_parse(const char *cmdline);
 /* log.c: */
 typedef enum {
     ERROR=0,
-    WARN, 
-    INFO, 
+    WARN,
+    INFO,
     DEBUG,
 } log_level_t;
 int log(log_level_t level, const char *fmt, ...)

--- a/bindings/hvt/start.c
+++ b/bindings/hvt/start.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
@@ -42,6 +42,6 @@ void _start(void *arg)
     time_init(arg);
     net_init();
 
-    mem_lock_heap(&si.heap_start, &si.heap_size);
+    mem_info(&si);
     solo5_exit(solo5_app_main(&si));
 }

--- a/bindings/mem.c
+++ b/bindings/mem.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
@@ -21,22 +21,10 @@
 #include "bindings.h"
 
 static uint64_t heap_start;
+static const size_t stack_size = 4 * PAGE_SIZE;
 
-/* 
- * Locks the memory layout (by disabling mem_ialloc_pages()). Must be called
- * before passing control to the application via solo5_app_main().
- *
- * Returns the first usable memory address for application heap in (*start)
- * and the size of the heap in (*size).
- */
-static int mem_locked = 0;
-void mem_lock_heap(uintptr_t *start, size_t *size)
-{
-    assert(!mem_locked);
-
-    mem_locked = 1;
-    *start = heap_start;
-    *size = platform_mem_size() - heap_start;
+static uint64_t heap_end(void) {
+    return platform_mem_size() - stack_size;
 }
 
 void mem_init(void)
@@ -46,7 +34,7 @@ void mem_init(void)
 
     mem_size = platform_mem_size();
     heap_start = ((uint64_t)&_end + PAGE_SIZE - 1) & PAGE_MASK;
-    
+
     /*
      * Cowardly refuse to run with less than 512KB of free memory.
      */
@@ -63,21 +51,35 @@ void mem_init(void)
             (unsigned long long)_etext, (unsigned long long)_erodata-1);
     log(INFO, "Solo5:       data @ (0x%llx - 0x%llx)\n",
             (unsigned long long)_erodata, (unsigned long long)_end-1);
-    log(INFO, "Solo5:       heap >= 0x%llx < stack < 0x%llx\n",
-            (unsigned long long)heap_start, (unsigned long long)mem_size);
+    log(INFO, "Solo5:       heap @ (0x%llx - 0x%llx)\n",
+            (unsigned long long)heap_start, (unsigned long long)heap_end());
+    log(INFO, "Solo5:      stack @ (0x%llx - 0x%llx)\n",
+            (unsigned long long)(mem_size - stack_size), (unsigned long long)mem_size);
 }
 
-/* 
- * Allocate pages on the heap.  Should only be called on
- * initialization (before solo5_app_main).
- */
-void *mem_ialloc_pages(size_t num)
+void mem_info(struct solo5_start_info* si) {
+    si->stack_start = (uintptr_t)(platform_mem_size() - stack_size);
+    si->stack_size = stack_size;
+    si->mem_page = PAGE_SIZE;
+    si->mem_avail = (heap_end() - heap_start) / PAGE_SIZE;
+}
+
+static int mem_locked = 0;
+
+void *solo5_mem_alloc(size_t num)
 {
     assert(!mem_locked);
+    assert(heap_start < heap_end());
 
     uint64_t prev = heap_start;
     heap_start += num << PAGE_SHIFT;
     assert(heap_start < (uint64_t)&prev);
 
     return (void *)prev;
+}
+
+void solo5_mem_lock(void)
+{
+    assert(!mem_locked);
+    mem_locked = 1;
 }

--- a/bindings/spt/start.c
+++ b/bindings/spt/start.c
@@ -39,6 +39,6 @@ void _start(void *arg)
     block_init(arg);
     net_init(arg);
 
-    mem_lock_heap(&si.heap_start, &si.heap_size);
+    mem_info(&si);
     solo5_exit(solo5_app_main(&si));
 }

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
@@ -63,6 +63,6 @@ static void _start2(void *arg __attribute__((unused)))
     pci_enumerate();
     cpu_intr_enable();
 
-    mem_lock_heap(&si.heap_start, &si.heap_size);
+    mem_info(&si);
     solo5_exit(solo5_app_main(&si));
 }

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -167,7 +167,7 @@ void virtio_config_block(struct pci_config_info *pci)
     virtq_init_rings(pci->base, &blkq, 0);
 
     pgs = (((blkq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    blkq.bufs = mem_ialloc_pages(pgs);
+    blkq.bufs = solo5_mem_alloc(pgs);
     assert(blkq.bufs);
     memset(blkq.bufs, 0, pgs << PAGE_SHIFT);
 

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
@@ -139,7 +139,7 @@ void virtio_config_network(struct pci_config_info *pci)
 
     /*
      * 2. Set the ACKNOWLEDGE status bit: the guest OS has notice the device.
-     * 3. Set the DRIVER status bit: the guest OS knows how to drive the device. 
+     * 3. Set the DRIVER status bit: the guest OS knows how to drive the device.
      */
 
     outb(pci->base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_ACK);
@@ -149,7 +149,7 @@ void virtio_config_network(struct pci_config_info *pci)
      * 4. Read device feature bits, and write the subset of feature bits
      * understood by the OS and driver to the device. During this step the
      * driver MAY read (but MUST NOT write) the device-specific configuration
-     * fields to check that it can support the device before accepting it. 
+     * fields to check that it can support the device before accepting it.
      */
 
     host_features = inl(pci->base + VIRTIO_PCI_HOST_FEATURES);
@@ -184,12 +184,12 @@ void virtio_config_network(struct pci_config_info *pci)
     virtq_init_rings(pci->base, &xmitq, VIRTQ_XMIT);
 
     pgs = (((recvq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    recvq.bufs = mem_ialloc_pages(pgs);
+    recvq.bufs = solo5_mem_alloc(pgs);
     assert(recvq.bufs);
     memset(recvq.bufs, 0, pgs << PAGE_SHIFT);
 
     pgs = (((recvq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    xmitq.bufs = mem_ialloc_pages(pgs);
+    xmitq.bufs = solo5_mem_alloc(pgs);
     assert(xmitq.bufs);
     memset(xmitq.bufs, 0, pgs << PAGE_SHIFT);
 

--- a/bindings/virtio/virtio_ring.c
+++ b/bindings/virtio/virtio_ring.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
@@ -88,13 +88,13 @@ void virtq_init_rings(uint16_t pci_base, struct virtq *vq, int selector)
 {
     uint8_t *data;
     size_t pgs;
-    
+
     outw(pci_base + VIRTIO_PCI_QUEUE_SEL, selector);
     vq->last_used = vq->next_avail = 0;
     vq->num = vq->num_avail = inw(pci_base + VIRTIO_PCI_QUEUE_SIZE);
 
     pgs = ((VIRTQ_SIZE(vq->num) - 1) >> PAGE_SHIFT) + 1;
-    data = mem_ialloc_pages(pgs);
+    data = solo5_mem_alloc(pgs);
     assert(data);
     memset(data, 0, pgs << PAGE_SHIFT);
 


### PR DESCRIPTION
This would open the door for multiple separate randomized stack and heap memory regions. Given separate regions the stack would not be able to overwrite parts of the heap.

Downsides:
* More API and exposed complexity
* Requires the application to lock the memory layout after an initialization phase
* The initial stack size is fixed, however applications could also allocate larger memory regions and use those as stack.

Mailing list thread: https://www.mail-archive.com/solo5@lists.h3q.com/msg00064.html. Please discuss there, not here, to avoid splitting the discussion.