### PR TITLE
 OpenBSD: add -mno-retpoline to HOST_CFLAGS to allow MirageOS Unikernels to run

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -203,7 +203,7 @@ case $(uname -s) in
         # we don't support yet. Unfortunately LLVM does not support
         # -mstack-protector-guard, so disable SSP on OpenBSD for the time
         # being.
-        HOST_CFLAGS="-fno-stack-protector -nostdlibinc"
+        HOST_CFLAGS="-fno-stack-protector -mno-retpoline -nostdlibinc"
         warn "Stack protector (SSP) disabled on OpenBSD due to toolchain issues"
         HOST_LDFLAGS="-nopie"
         BUILD_HVT="yes"


### PR DESCRIPTION
closes #336

retpoline was [enabled by default](https://marc.info/?l=openbsd-cvs&m=154621129329314&w=2) at the end of December last year.

The fix for now is to add ` -mno-retpoline` to `HOST_CFLAGS` 