### PR TITLE
SSP for OpenBSD, generic naming of symbols

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -75,11 +75,18 @@ all_TARGETS :=
 all_OBJS :=
 all_SRCS :=
 
+ifeq ($(CONFIG_HOST), OpenBSD)
+SSP_GUARD=__guard_local
+SSP_FAIL=__stack_smash_handler
+else
+SSP_GUARD=__stack_chk_guard
+SSP_FAIL=__stack_chk_fail
+endif
 define LINK.bindings
 	@echo "LD $@"
 	$(LD) -r $(LDFLAGS) $^ -o $@
 	@echo "OBJCOPY $@"
-	$(OBJCOPY) -w -G solo5_\* -G _start\* -G __stack_chk_\* $@ $@
+	$(OBJCOPY) -w -G solo5_\* -G _start\* -G $(SSP_GUARD) -G $(SSP_FAIL) $@ $@
 endef
 
 ifdef CONFIG_HVT

--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -52,6 +52,14 @@
 #define STR_EXPAND(y) #y
 #define STR(x) STR_EXPAND(x)
 
+#if defined(__OpenBSD__)
+#define SSP_GUARD __guard_local
+#define SSP_FAIL __stack_smash_handler
+#else
+#define SSP_GUARD __stack_chk_guard
+#define SSP_FAIL __stack_chk_fail
+#endif
+
 /* abort.c */
 void _assert_fail(const char *, const char *, const char *)
     __attribute__((noreturn));

--- a/bindings/crt.c
+++ b/bindings/crt.c
@@ -25,7 +25,7 @@
  * crt_init_early(), keep an easily recognisable "terminator" value here to
  * flag if that did not happen as expected.
  */
-uintptr_t __stack_chk_guard = 0x00deadbeef0d0a00;
+uintptr_t SSP_GUARD = 0x00deadbeef0d0a00;
 
 /*
  * Called by compiler-generated code when corruption of the canary value is
@@ -36,7 +36,7 @@ static const char
 stack_chk_fail_message[] = "Solo5: ABORT: Stack corruption detected\n";
 
 __attribute__((noreturn))
-void __stack_chk_fail(void)
+void SSP_FAIL(void)
 {
     platform_puts(stack_chk_fail_message, sizeof stack_chk_fail_message);
     platform_exit(SOLO5_EXIT_ABORT, NULL);

--- a/bindings/crt_init.h
+++ b/bindings/crt_init.h
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-extern uintptr_t __stack_chk_guard;
+extern uintptr_t SSP_GUARD;
 
 #if defined(__x86_64__)
 #define READ_CPU_TICKS cpu_rdtsc
@@ -77,6 +77,6 @@ __attribute__((always_inline)) static inline void crt_init_ssp(void)
     /*
      * Initialise the stack canary value.
      */
-    __stack_chk_guard = READ_CPU_TICKS() + (READ_CPU_TICKS() << 32UL);
-    __stack_chk_guard &= ~(uintptr_t)0xff00;
+    SSP_GUARD = READ_CPU_TICKS() + (READ_CPU_TICKS() << 32UL);
+    SSP_GUARD &= ~(uintptr_t)0xff00;
 }

--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -54,10 +54,10 @@ namespace Solo5 {
  * Naive SSP implementation
  */
 extern "C" {
-	Genode::addr_t __stack_chk_guard;
+	Genode::addr_t SSP_GUARD;
 
 	extern "C" __attribute__((noreturn))
-	void __stack_chk_fail (void)
+	void SSP_FAIL (void)
 	{
 		Genode::error("stack smashing detected");
 		solo5_abort();
@@ -595,7 +595,7 @@ void Component::construct(Genode::Env &env)
 	 * set a new stack canary, this is possible
 	 * because this procedure never returns
 	 */
-	__stack_chk_guard = generate_canary(inst.heap);
+	SSP_GUARD = generate_canary(inst.heap);
 
 	/* block for application then exit */
 	env.parent().exit(solo5_app_main(&si));

--- a/bindings/genode/stubs.c
+++ b/bindings/genode/stubs.c
@@ -16,5 +16,5 @@ void solo5_block_info(struct solo5_block_info *info) { }
 solo5_result_t solo5_block_write(solo5_off_t offset, const uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 solo5_result_t solo5_block_read(solo5_off_t offset, uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 
-uintptr_t __stack_chk_guard;
-void __stack_chk_fail (void) { }
+uintptr_t SSP_GUARD;
+void SSP_FAIL (void) { }

--- a/configure.sh
+++ b/configure.sh
@@ -202,7 +202,7 @@ case "${CONFIG_HOST}" in
         # clang-provided headers for compiler instrinsics. We copy the rest
         # (std*.h, cdefs.h and their dependencies) from the host.
         cc_is_clang || die "Only 'clang' is supported on OpenBSD"
-	[ "${CONFIG_ARCH}" = "x86_64" ] ||
+        [ "${CONFIG_ARCH}" = "x86_64" ] ||
             die "Only 'x86_64' is supported on OpenBSD"
         if ! ld_is_lld; then
             LD='/usr/bin/ld.lld'
@@ -223,22 +223,14 @@ case "${CONFIG_HOST}" in
         for f in ${SRCS_AMD64}; do cp -f ${INCDIR}/$f ${HOST_INCDIR}/amd64; done
         for f in ${SRCS}; do cp -f ${INCDIR}/$f ${HOST_INCDIR}; done
 
-        # Stack smashing protection:
-        #
-        # The OpenBSD toolchain has it's own idea of how SSP is implemented
-        # (see TargetLoweringBase::getIRStackGuard() in the LLVM source), which
-        # we don't support yet. Unfortunately LLVM does not support
-        # -mstack-protector-guard, so disable SSP on OpenBSD for the time
-        # being.
-        MAKECONF_CFLAGS="-fno-stack-protector -mno-retpoline -nostdlibinc"
-        warn "Stack protector (SSP) disabled on OpenBSD due to toolchain issues"
+        MAKECONF_CFLAGS="-mno-retpoline -fno-ret-protector -nostdlibinc"
         MAKECONF_LDFLAGS="-nopie"
 
         CONFIG_HVT=1
-	CONFIG_SPT=
-	[ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_VIRTIO=1
-	[ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_MUEN=1
-	CONFIG_GENODE=
+        CONFIG_SPT=
+        [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_VIRTIO=1
+        [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_MUEN=1
+        CONFIG_GENODE=
         ;;
     *)
         die "Unsupported build OS: ${CONFIG_HOST}"


### PR DESCRIPTION
OpenBSD use different symbols for __stack_chk_*

See the following mappings
__stack_chk_guard => __guard_local
__stack_chk_fail => __stack_smash_handler