### PR TITLE
spt/hvt: limit default memory to 32MB (instead of 512MB)

### DIFF
--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -107,7 +107,7 @@ static void usage(const char *prog)
     fprintf(stderr, "KERNEL is the filename of the unikernel to run.\n");
     fprintf(stderr, "ARGS are optional arguments passed to the unikernel.\n");
     fprintf(stderr, "Core options:\n");
-    fprintf(stderr, "  [ --mem=512 ] (guest memory in MB)\n");
+    fprintf(stderr, "  [ --mem=512 ] (guest memory in MB, default: 32MB)\n");
     fprintf(stderr, "    --help (display this help)\n");
     fprintf(stderr, "Compiled-in modules: ");
     for (struct hvt_module *m = &__start_modules; m < &__stop_modules; m++) {
@@ -130,7 +130,7 @@ static void usage(const char *prog)
 
 int main(int argc, char **argv)
 {
-    size_t mem_size = 0x20000000;
+    size_t mem_size = 0x2000000;
     hvt_gpa_t gpa_ep, gpa_kend;
     const char *prog;
     const char *elffile;

--- a/tenders/spt/spt_main.c
+++ b/tenders/spt/spt_main.c
@@ -98,7 +98,7 @@ static void usage(const char *prog)
     fprintf(stderr, "KERNEL is the filename of the unikernel to run.\n");
     fprintf(stderr, "ARGS are optional arguments passed to the unikernel.\n");
     fprintf(stderr, "Core options:\n");
-    fprintf(stderr, "  [ --mem=512 ] (guest memory in MB)\n");
+    fprintf(stderr, "  [ --mem=512 ] (guest memory in MB, default: 32MB)\n");
     fprintf(stderr, "    --help (display this help)\n");
     fprintf(stderr, "Compiled-in modules: ");
     for (struct spt_module **m = spt_core_modules; *m; m++) {
@@ -121,7 +121,7 @@ static void usage(const char *prog)
 
 int main(int argc, char **argv)
 {
-    size_t mem_size = 0x20000000;
+    size_t mem_size = 0x2000000;
     uint64_t p_entry, p_end;
     const char *prog;
     const char *elffile;


### PR DESCRIPTION
in my opinion this is more reasonable and allows me to not have to pass `--mem=xx` during development. changing a default value is always a breaking change, but I think it is worth it.

I run several solo5-based unikernels with memory ranging between 16 and 128MB in production -- a more conservative would be to use 64 or 128MB memory...