### PR TITLE
Rename test_abort to test_dumpcore

### DIFF
--- a/tests/test_dumpcore/GNUmakefile
+++ b/tests/test_dumpcore/GNUmakefile
@@ -18,6 +18,6 @@
 
 include $(TOPDIR)/Makefile.common
 
-test_NAME := test_abort
+test_NAME := test_dumpcore
 
 include ../Makefile.tests

--- a/tests/test_dumpcore/test_dumpcore.c
+++ b/tests/test_dumpcore/test_dumpcore.c
@@ -28,7 +28,7 @@ static void puts(const char *s)
 
 int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
-    puts("\n**** Solo5 standalone test_abort ****\n\n");
+    puts("\n**** Solo5 standalone test_dumpcore ****\n\n");
     solo5_abort();
     return SOLO5_EXIT_SUCCESS;
 }

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -290,7 +290,7 @@ virtio_expect_abort() {
   expect_success
 }
 
-@test "abort hvt" {
+@test "dumpcore hvt" {
   [ "${CONFIG_ARCH}" = "x86_64" ] || skip "not implemented for ${CONFIG_ARCH}"
   case "${CONFIG_HOST}" in
     Linux|FreeBSD)
@@ -301,7 +301,7 @@ virtio_expect_abort() {
   esac
 
   run ${TIMEOUT} --foreground 60s ${HVT_TENDER_DEBUG} \
-      --dumpcore test_abort/test_abort.hvt
+      --dumpcore test_dumpcore/test_dumpcore.hvt
   [ "$status" -eq 255 ]
   CORE=`echo "$output" | grep -o "core\.solo5-hvt\.[0-9]*$"`
   [ -f "$CORE" ]


### PR DESCRIPTION
This more accurately reflects what is being tested (the hvt dumpcore
module).