### PR TITLE
Add solo5_set_tls_base for thread-local-storage

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -29,7 +29,7 @@ all_TARGETS :=
 $(V).SILENT:
 
 common_SRCS := abort.c cpu_$(CONFIG_ARCH).c cpu_vectors_$(CONFIG_ARCH).S \
-    crt.c printf.c intr.c lib.c mem.c exit.c log.c cmdline.c
+    crt.c printf.c intr.c lib.c mem.c exit.c log.c cmdline.c tls.c
 
 common_hvt_SRCS := hvt/start.c hvt/platform.c hvt/platform_intr.c hvt/time.c
 
@@ -37,7 +37,7 @@ hvt_SRCS := $(common_SRCS) $(common_hvt_SRCS) \
     hvt/platform_lifecycle.c hvt/yield.c hvt/tscclock.c hvt/console.c \
     hvt/net.c hvt/block.c
 
-spt_SRCS := abort.c crt.c printf.c lib.c mem.c exit.c log.c cmdline.c \
+spt_SRCS := abort.c crt.c printf.c lib.c mem.c exit.c log.c cmdline.c tls.c \
     spt/bindings.c spt/block.c spt/net.c spt/platform.c spt/start.c \
     spt/sys_linux_$(CONFIG_ARCH).c
 

--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -115,6 +115,7 @@ const char *platform_cmdline(void);
 uint64_t platform_mem_size(void);
 void platform_exit(int status, void *cookie) __attribute__((noreturn));
 int platform_puts(const char *buf, int n);
+int platform_set_tls_base(uint64_t base);
 
 /* platform_intr.c: platform-specific interrupt handling */
 void platform_intr_init(void);

--- a/bindings/cpu_aarch64.h
+++ b/bindings/cpu_aarch64.h
@@ -69,4 +69,9 @@ static inline uint64_t mul64_32(uint64_t a, uint32_t b, uint8_t s)
 }
 #endif /* !ASM_FILE */
 
+static inline void cpu_set_tls_base(uint64_t base)
+{
+    __asm__ __volatile("msr tpidr_el0, %0" :: "r"(base));
+}
+
 #endif /* __CPU_AARCH64_H__ */

--- a/bindings/cpu_x86_64.h
+++ b/bindings/cpu_x86_64.h
@@ -225,4 +225,13 @@ static inline uint64_t inq(uint16_t port_lo)
     return ((uint64_t)lo) | ((uint64_t)hi << 32);
 }
 
+static inline void cpu_set_tls_base(uint64_t base)
+{
+     __asm__ __volatile("wrmsr" ::
+         "c" (0xc0000100), /* IA32_FS_BASE */
+         "a" ((uint32_t)(base)),
+         "d" ((uint32_t)(base >> 32))
+     );
+}
+
 #endif /* !ASM_FILE */

--- a/bindings/crt_init.h
+++ b/bindings/crt_init.h
@@ -29,48 +29,9 @@ extern uintptr_t SSP_GUARD;
 #endif
 
 /*
- * These functions are responsible for performing early initialisation required
- * by the "C runtime". They must be inlined as early as possible once in C
- * code, before calling any other functions. The calling function must not
- * return.
- *
- * As crt_init_tls() currently requires that the bindings are running in CPU
- * Ring 0 or equivalent, this is split into a separate function so that
- * bindings such as "spt" can omit the call.
+ * This function must be inlined as early as possible once in C code, before
+ * calling any other functions. The calling function must not return.
  */
-
-__attribute__((always_inline)) static inline void crt_init_tls(void)
-{
-    /*
-     * Explicitly disable any accidental use of TLS by zeroing the relevant
-     * CPU registers, thus causing TLS access to point to the zero page.
-     *
-     * On x86_64 these MSRs "should" technically be zero on hvt VM entry, but
-     * this is not actually specified anywhere. For virtio the bootloader
-     * and/or platform may have likewise clobbered the values.
-     *
-     * On aarch64 the defaults seen in practice on KVM appear to be garbage
-     * values. Note that we are running at EL1, but based on practical
-     * investigation TPIDR_EL0 is the register that the compiler would use to
-     * point to TLS.
-     */
-#if defined(__x86_64__)
-     __asm__ __volatile("wrmsr" ::
-         "c" (0xc0000100), /* IA32_FS_BASE */
-         "a" (0x0),
-         "d" (0x0)
-     );
-     __asm__ __volatile("wrmsr" ::
-         "c" (0xc0000101), /* IA32_GS_BASE */
-         "a" (0x0),
-         "d" (0x0)
-     );
-#elif defined(__aarch64__)
-     __asm__ __volatile("msr tpidr_el0, xzr");
-#else
-#error Unsupported architecture
-#endif
-}
 
 __attribute__((always_inline)) static inline void crt_init_ssp(void)
 {
@@ -79,4 +40,14 @@ __attribute__((always_inline)) static inline void crt_init_ssp(void)
      */
     SSP_GUARD = READ_CPU_TICKS() + (READ_CPU_TICKS() << 32UL);
     SSP_GUARD &= ~(uintptr_t)0xff00;
+}
+
+/*
+ * Explicitly disable any accidental use of TLS by setting the arch-specific
+ * TLS base to zero, thus causing TLS access to point to the zero page.
+ */
+
+__attribute__((always_inline)) static inline void crt_init_tls(void)
+{
+    (void)platform_set_tls_base(0);
 }

--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -557,6 +557,11 @@ solo5_result_t solo5_block_read(solo5_off_t offset,
 	return _platform->block_read(offset, buf, size);
 }
 
+solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+{
+    return SOLO5_R_EUNSPEC;
+}
+
 } // extern "C"
 
 

--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -557,7 +557,7 @@ solo5_result_t solo5_block_read(solo5_off_t offset,
 	return _platform->block_read(offset, buf, size);
 }
 
-solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+solo5_result_t solo5_set_tls_base(uintptr_t base)
 {
     return SOLO5_R_EUNSPEC;
 }

--- a/bindings/genode/stubs.c
+++ b/bindings/genode/stubs.c
@@ -16,7 +16,7 @@ void solo5_block_info(struct solo5_block_info *info) { }
 solo5_result_t solo5_block_write(solo5_off_t offset, const uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 solo5_result_t solo5_block_read(solo5_off_t offset, uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 
-solo5_result_t solo5_set_arch_tls_base(uint64_t base) { return SOLO5_R_EUNSPEC; }
+solo5_result_t solo5_set_tls_base(uintptr_t base) { return SOLO5_R_EUNSPEC; }
 
 uintptr_t SSP_GUARD;
 void SSP_FAIL (void) { }

--- a/bindings/genode/stubs.c
+++ b/bindings/genode/stubs.c
@@ -16,5 +16,7 @@ void solo5_block_info(struct solo5_block_info *info) { }
 solo5_result_t solo5_block_write(solo5_off_t offset, const uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 solo5_result_t solo5_block_read(solo5_off_t offset, uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 
+solo5_result_t solo5_set_arch_tls_base(uint64_t base) { return SOLO5_R_EUNSPEC; }
+
 uintptr_t SSP_GUARD;
 void SSP_FAIL (void) { }

--- a/bindings/hvt/platform.c
+++ b/bindings/hvt/platform.c
@@ -40,3 +40,9 @@ uint64_t platform_mem_size(void)
 {
     return mem_size;
 }
+
+solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+{
+    cpu_set_tls_base(base);
+    return SOLO5_R_OK;
+}

--- a/bindings/hvt/platform.c
+++ b/bindings/hvt/platform.c
@@ -41,7 +41,7 @@ uint64_t platform_mem_size(void)
     return mem_size;
 }
 
-solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+solo5_result_t solo5_set_tls_base(uintptr_t base)
 {
     cpu_set_tls_base(base);
     return SOLO5_R_OK;

--- a/bindings/hvt/platform.c
+++ b/bindings/hvt/platform.c
@@ -41,8 +41,8 @@ uint64_t platform_mem_size(void)
     return mem_size;
 }
 
-solo5_result_t solo5_set_tls_base(uintptr_t base)
+int platform_set_tls_base(uint64_t base)
 {
     cpu_set_tls_base(base);
-    return SOLO5_R_OK;
+    return 0;
 }

--- a/bindings/spt/bindings.c
+++ b/bindings/spt/bindings.c
@@ -46,3 +46,9 @@ solo5_time_t solo5_clock_wall(void)
     assert(rc == 0);
     return (ts.tv_sec * NSEC_PER_SEC) + ts.tv_nsec;
 }
+
+solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+{
+    int rc = platform_set_arch_tls_base(base);
+    return (rc == 0) ? SOLO5_R_OK : SOLO5_R_EINVAL;
+}

--- a/bindings/spt/bindings.c
+++ b/bindings/spt/bindings.c
@@ -47,7 +47,7 @@ solo5_time_t solo5_clock_wall(void)
     return (ts.tv_sec * NSEC_PER_SEC) + ts.tv_nsec;
 }
 
-solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+solo5_result_t solo5_set_tls_base(uintptr_t base)
 {
     int rc = platform_set_arch_tls_base(base);
     return (rc == 0) ? SOLO5_R_OK : SOLO5_R_EINVAL;

--- a/bindings/spt/bindings.c
+++ b/bindings/spt/bindings.c
@@ -49,6 +49,6 @@ solo5_time_t solo5_clock_wall(void)
 
 solo5_result_t solo5_set_tls_base(uintptr_t base)
 {
-    int rc = platform_set_arch_tls_base(base);
+    int rc = platform_set_tls_base(base);
     return (rc == 0) ? SOLO5_R_OK : SOLO5_R_EINVAL;
 }

--- a/bindings/spt/bindings.c
+++ b/bindings/spt/bindings.c
@@ -47,8 +47,4 @@ solo5_time_t solo5_clock_wall(void)
     return (ts.tv_sec * NSEC_PER_SEC) + ts.tv_nsec;
 }
 
-solo5_result_t solo5_set_tls_base(uintptr_t base)
-{
-    int rc = platform_set_tls_base(base);
-    return (rc == 0) ? SOLO5_R_OK : SOLO5_R_EINVAL;
-}
+/* solo5_set_tls_base is in tls.c */

--- a/bindings/spt/bindings.h
+++ b/bindings/spt/bindings.h
@@ -69,7 +69,4 @@ long sys_arch_prctl(long code, long addr);
 void block_init(struct spt_boot_info *arg);
 void net_init(struct spt_boot_info *arg);
 
-int platform_set_tls_base(uint64_t base);
-void platform_init_tls(void);
-
 #endif /* __SPT_BINDINGS_H__ */

--- a/bindings/spt/bindings.h
+++ b/bindings/spt/bindings.h
@@ -62,7 +62,15 @@ struct sys_pollfd {
 
 long sys_ppoll(void *fds, long nfds, void *ts);
 
+#define ARCH_SET_GS		0x1001
+#define ARCH_SET_FS		0x1002
+
+int sys_arch_prctl(int code, unsigned long addr);
+
 void block_init(struct spt_boot_info *arg);
 void net_init(struct spt_boot_info *arg);
+
+int platform_set_arch_tls_base(uint64_t base);
+void platform_init_tls(void);
 
 #endif /* __SPT_BINDINGS_H__ */

--- a/bindings/spt/bindings.h
+++ b/bindings/spt/bindings.h
@@ -62,10 +62,9 @@ struct sys_pollfd {
 
 long sys_ppoll(void *fds, long nfds, void *ts);
 
-#define ARCH_SET_GS		0x1001
-#define ARCH_SET_FS		0x1002
+#define SYS_ARCH_SET_FS		0x1002
 
-int sys_arch_prctl(int code, unsigned long addr);
+long sys_arch_prctl(long code, long addr);
 
 void block_init(struct spt_boot_info *arg);
 void net_init(struct spt_boot_info *arg);

--- a/bindings/spt/bindings.h
+++ b/bindings/spt/bindings.h
@@ -69,7 +69,7 @@ long sys_arch_prctl(long code, long addr);
 void block_init(struct spt_boot_info *arg);
 void net_init(struct spt_boot_info *arg);
 
-int platform_set_arch_tls_base(uint64_t base);
+int platform_set_tls_base(uint64_t base);
 void platform_init_tls(void);
 
 #endif /* __SPT_BINDINGS_H__ */

--- a/bindings/spt/platform.c
+++ b/bindings/spt/platform.c
@@ -52,7 +52,7 @@ int platform_puts(const char *buf, int n)
     return n;
 }
 
-int platform_set_arch_tls_base(uint64_t base)
+int platform_set_tls_base(uint64_t base)
 {
 #if defined(__x86_64__)
     /* In x86 we need to ask the host kernel to change %fs for us. */
@@ -67,6 +67,6 @@ int platform_set_arch_tls_base(uint64_t base)
 
 void platform_init_tls(void)
 {
-    int rc = platform_set_arch_tls_base(0);
+    int rc = platform_set_tls_base(0);
     assert(rc == 0);
 }

--- a/bindings/spt/platform.c
+++ b/bindings/spt/platform.c
@@ -64,9 +64,3 @@ int platform_set_tls_base(uint64_t base)
 #error Unsupported architecture
 #endif
 }
-
-void platform_init_tls(void)
-{
-    int rc = platform_set_tls_base(0);
-    assert(rc == 0);
-}

--- a/bindings/spt/platform.c
+++ b/bindings/spt/platform.c
@@ -51,3 +51,22 @@ int platform_puts(const char *buf, int n)
     (void)sys_write(SYS_STDOUT, buf, n);
     return n;
 }
+
+int platform_set_arch_tls_base(uint64_t base)
+{
+#if defined(__x86_64__)
+    /* In x86 we need to ask the host kernel to change %fs for us. */
+    return sys_arch_prctl(ARCH_SET_FS, base);
+#elif defined(__aarch64__)
+    cpu_set_tls_base(base);
+    return 0;
+#else
+#error Unsupported architecture
+#endif
+}
+
+void platform_init_tls(void)
+{
+    int rc = platform_set_arch_tls_base(0);
+    assert(rc == 0);
+}

--- a/bindings/spt/platform.c
+++ b/bindings/spt/platform.c
@@ -56,7 +56,7 @@ int platform_set_arch_tls_base(uint64_t base)
 {
 #if defined(__x86_64__)
     /* In x86 we need to ask the host kernel to change %fs for us. */
-    return sys_arch_prctl(ARCH_SET_FS, base);
+    return sys_arch_prctl(SYS_ARCH_SET_FS, base);
 #elif defined(__aarch64__)
     cpu_set_tls_base(base);
     return 0;

--- a/bindings/spt/start.c
+++ b/bindings/spt/start.c
@@ -23,8 +23,8 @@
 
 void _start(void *arg)
 {
-    platform_init_tls();
     crt_init_ssp();
+    crt_init_tls();
 
     static struct solo5_start_info si;
 

--- a/bindings/spt/start.c
+++ b/bindings/spt/start.c
@@ -23,6 +23,7 @@
 
 void _start(void *arg)
 {
+    platform_init_tls();
     crt_init_ssp();
 
     static struct solo5_start_info si;

--- a/bindings/spt/sys_linux_x86_64.c
+++ b/bindings/spt/sys_linux_x86_64.c
@@ -34,6 +34,7 @@
 #define SYS_write         1
 #define SYS_pread64       17
 #define SYS_pwrite64      18
+#define SYS_arch_prctl    158
 #define SYS_clock_gettime 228
 #define SYS_exit_group    231
 #define SYS_ppoll         271
@@ -133,6 +134,20 @@ long sys_ppoll(void *fds, long nfds, void *ts)
             : "=a" (ret)
             : "a" (SYS_ppoll), "D" (fds), "S" (nfds), "d" (ts),
               "r" (r10) /* sigmask */, "r" (r8) /* sigsetsize */
+            : "rcx", "r11", "memory"
+    );
+
+    return ret;
+}
+
+int sys_arch_prctl(int code, unsigned long addr)
+{
+    int ret;
+
+    __asm__ __volatile__ (
+            "syscall"
+            : "=a" (ret)
+            : "a" (SYS_arch_prctl), "D" (code), "S" (addr)
             : "rcx", "r11", "memory"
     );
 

--- a/bindings/spt/sys_linux_x86_64.c
+++ b/bindings/spt/sys_linux_x86_64.c
@@ -142,7 +142,7 @@ long sys_ppoll(void *fds, long nfds, void *ts)
 
 long sys_arch_prctl(long code, long addr)
 {
-    int ret;
+    long ret;
 
     __asm__ __volatile__ (
             "syscall"

--- a/bindings/spt/sys_linux_x86_64.c
+++ b/bindings/spt/sys_linux_x86_64.c
@@ -140,7 +140,7 @@ long sys_ppoll(void *fds, long nfds, void *ts)
     return ret;
 }
 
-int sys_arch_prctl(int code, unsigned long addr)
+long sys_arch_prctl(long code, long addr)
 {
     int ret;
 

--- a/bindings/tls.c
+++ b/bindings/tls.c
@@ -19,29 +19,9 @@
  */
 
 #include "bindings.h"
-#include "../crt_init.h"
 
-void _start(void *arg)
+solo5_result_t solo5_set_tls_base(uintptr_t base)
 {
-    crt_init_ssp();
-    crt_init_tls();
-
-    static struct solo5_start_info si;
-
-    console_init();
-    cpu_init();
-    platform_init(arg);
-    si.cmdline = cmdline_parse(platform_cmdline());
-
-    log(INFO, "            |      ___|\n");
-    log(INFO, "  __|  _ \\  |  _ \\ __ \\\n");
-    log(INFO, "\\__ \\ (   | | (   |  ) |\n");
-    log(INFO, "____/\\___/ _|\\___/____/\n");
-
-    mem_init();
-    time_init(arg);
-    net_init();
-
-    mem_lock_heap(&si.heap_start, &si.heap_size);
-    solo5_exit(solo5_app_main(&si));
+    int rc = platform_set_tls_base(base);
+    return (rc == 0) ? SOLO5_R_OK : SOLO5_R_EINVAL;
 }

--- a/bindings/virtio/platform.c
+++ b/bindings/virtio/platform.c
@@ -130,7 +130,7 @@ void solo5_console_write(const char *buf, size_t size)
     (void)platform_puts(buf, size);
 }
 
-solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+solo5_result_t solo5_set_tls_base(uintptr_t base)
 {
     cpu_set_tls_base(base);
     return SOLO5_R_OK;

--- a/bindings/virtio/platform.c
+++ b/bindings/virtio/platform.c
@@ -130,8 +130,8 @@ void solo5_console_write(const char *buf, size_t size)
     (void)platform_puts(buf, size);
 }
 
-solo5_result_t solo5_set_tls_base(uintptr_t base)
+int platform_set_tls_base(uint64_t base)
 {
     cpu_set_tls_base(base);
-    return SOLO5_R_OK;
+    return 0;
 }

--- a/bindings/virtio/platform.c
+++ b/bindings/virtio/platform.c
@@ -129,3 +129,9 @@ void solo5_console_write(const char *buf, size_t size)
 {
     (void)platform_puts(buf, size);
 }
+
+solo5_result_t solo5_set_arch_tls_base(uint64_t base)
+{
+    cpu_set_tls_base(base);
+    return SOLO5_R_OK;
+}

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -26,8 +26,8 @@ static void _start2(void *arg) __attribute__((noreturn));
 
 void _start(void *arg)
 {
-    crt_init_tls();
     crt_init_ssp();
+    crt_init_tls();
 
     volatile int gdb = 1;
 

--- a/include/solo5/solo5.h
+++ b/include/solo5/solo5.h
@@ -277,4 +277,14 @@ solo5_result_t solo5_block_write(solo5_off_t offset, const uint8_t *buf,
  */
 solo5_result_t solo5_block_read(solo5_off_t offset, uint8_t *buf, size_t size);
 
+/*
+ * Set the TLS base register. This sets the %fs segment register in
+ * x86_64 or the TPIDR_EL0 register in aarch64.
+ *
+ * This function fails in "spt" with SOLO5_R_EINVAL when "base"
+ * points to an invalid address. Virtio and hvt always return
+ * SOLO5_R_OK.
+ */
+solo5_result_t solo5_set_arch_tls_base(uint64_t base);
+
 #endif

--- a/include/solo5/solo5.h
+++ b/include/solo5/solo5.h
@@ -278,13 +278,12 @@ solo5_result_t solo5_block_write(solo5_off_t offset, const uint8_t *buf,
 solo5_result_t solo5_block_read(solo5_off_t offset, uint8_t *buf, size_t size);
 
 /*
- * Set the TLS base register. This sets the %fs segment register in
- * x86_64 or the TPIDR_EL0 register in aarch64.
+ * Set the TLS base register. This sets the %fs segment register on
+ * x86_64 or the TPIDR_EL0 register on aarch64.
  *
- * This function fails in "spt" with SOLO5_R_EINVAL when "base"
- * points to an invalid address. Virtio and hvt always return
- * SOLO5_R_OK.
+ * Solo5 implementations may return SOLO5_R_EINVAL if the (base) does not
+ * satisfy arch-specific requirements.
  */
-solo5_result_t solo5_set_arch_tls_base(uint64_t base);
+solo5_result_t solo5_set_tls_base(uintptr_t base);
 
 #endif

--- a/tenders/spt/spt_core.c
+++ b/tenders/spt/spt_core.c
@@ -39,7 +39,6 @@
 
 #if defined(__x86_64__)
 #include <asm/prctl.h>
-#include <sys/prctl.h>
 #endif
 
 #include "spt.h"
@@ -225,16 +224,11 @@ static int setup(struct spt *spt)
     if (rc != 0)
         errx(1, "seccomp_rule_add(clock_gettime, CLOCK_REALTIME) failed: %s",
                 strerror(-rc));
-
-    /*
-     * The TLS register in aarch64 can be set in user space. So, we only need
-     * to open a hole for x86_64.
-     */
 #if defined(__x86_64__)
     rc = seccomp_rule_add(spt->sc_ctx, SCMP_ACT_ALLOW, SCMP_SYS(arch_prctl),
             1, SCMP_A0(SCMP_CMP_EQ, ARCH_SET_FS));
     if (rc != 0)
-        errx(1, "seccomp_rule_add(clock_gettime, CLOCK_REALTIME) failed: %s",
+        errx(1, "seccomp_rule_add(arch_prctl, ARCH_SET_FS) failed: %s",
                 strerror(-rc));
 #endif
 

--- a/tests/test_tls/GNUmakefile
+++ b/tests/test_tls/GNUmakefile
@@ -1,0 +1,23 @@
+# Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+#
+# This file is part of Solo5, a sandboxed execution environment.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+# OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+include $(TOPDIR)/Makefile.common
+
+test_NAME := test_tls
+
+include ../Makefile.tests

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -22,11 +22,13 @@
 #include "../../bindings/lib.c"
 
 #if defined(__x86_64__)
+/* Variant II */
 struct tcb {
     volatile uint64_t _data;
     void *tp;
 };
 #elif defined(__aarch64__)
+/* Variant I */
 struct tcb {
     void *tp;
     void *pad;
@@ -44,7 +46,12 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
+#if defined(__OpenBSD__)
+/* __thread is not supported in OpenBSD (this test fails on it). */
+volatile uint64_t _data;
+#else
 __thread volatile uint64_t _data;
+#endif
 
 uint64_t __attribute__ ((noinline)) get_data()
 {

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "solo5.h"
+#include "../../bindings/lib.c"
+
+volatile long data_thread_1 = 0;
+volatile long data_thread_2 = 0;
+
+static void tls_store_long(long data)
+{
+#if defined(__x86_64__)
+    __asm__ __volatile("mov %0, %%fs:0x0" : : "r" (data));
+#elif defined(__aarch64__)
+    __asm__ __volatile("mrs x0, tpidr_el0; "
+                       "str %0, [x0]"
+                       : : "r" (data) : "x0");
+#else
+#error Unsupported architecture
+#endif
+}
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
+{
+    puts("\n**** Solo5 standalone test_tls ****\n\n");
+
+    solo5_set_arch_tls_base((uint64_t)&data_thread_1);
+    tls_store_long(-12345);
+
+    solo5_set_arch_tls_base((uint64_t)&data_thread_2);
+    tls_store_long(56789);
+
+    if (data_thread_1 != -12345)
+        return SOLO5_EXIT_FAILURE;
+
+    if (data_thread_2 != 56789)
+        return SOLO5_EXIT_FAILURE;
+
+    puts("SUCCESS\n");
+    return SOLO5_EXIT_SUCCESS;
+}

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -46,17 +46,19 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_tls ****\n\n");
 
-    solo5_set_arch_tls_base((uint64_t)&data_thread_1);
+    if (solo5_set_tls_base((uintptr_t)&data_thread_1) != SOLO5_R_OK)
+        return 1;
     tls_store_long(-12345);
 
-    solo5_set_arch_tls_base((uint64_t)&data_thread_2);
+    if (solo5_set_tls_base((uintptr_t)&data_thread_2) != SOLO5_R_OK)
+        return 2;
     tls_store_long(56789);
 
     if (data_thread_1 != -12345)
-        return SOLO5_EXIT_FAILURE;
+        return 3;
 
     if (data_thread_2 != 56789)
-        return SOLO5_EXIT_FAILURE;
+        return 4;
 
     puts("SUCCESS\n");
     return SOLO5_EXIT_SUCCESS;

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -70,19 +70,23 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
     tcb1.tp = &tcb1.tp;
     tcb2.tp = &tcb2.tp;
 
-    solo5_set_tls_base((uint64_t)tcb1.tp);
+    if (solo5_set_tls_base((uintptr_t)tcb1.tp) != SOLO5_R_OK)
+        return 1;
     set_data(1);
 
-    solo5_set_tls_base((uint64_t)tcb2.tp);
+    if (solo5_set_tls_base((uintptr_t)tcb2.tp) != SOLO5_R_OK)
+        return 2;
     set_data(2);
 
-    solo5_set_tls_base((uint64_t)tcb1.tp);
+    if (solo5_set_tls_base((uintptr_t)tcb1.tp) != SOLO5_R_OK)
+        return 3;
     if (get_data() != 1)
-        return 1;
+        return 4;
 
-    solo5_set_tls_base((uint64_t)tcb2.tp);
+    if (solo5_set_tls_base((uintptr_t)tcb2.tp) != SOLO5_R_OK)
+        return 5;
     if (get_data() != 2)
-        return 2;
+        return 6;
 
     puts("SUCCESS\n");
     return SOLO5_EXIT_SUCCESS;

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -25,12 +25,12 @@ __thread volatile uint64_t data;
 
 
 #if defined(__x86_64__)
-struct tcb {
+struct __attribute__((aligned(8),packed))  tcb {
     volatile uint64_t data;
     void *tp;
 };
 #elif defined(__aarch64__)
-struct tcb {
+struct __attribute__((aligned(8),packed))  tcb {
     void *tp;
     void *pad;
     volatile uint64_t data;
@@ -50,6 +50,17 @@ static void puts(const char *s)
 int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_tls ****\n\n");
+
+    memset(&tcb1, sizeof(tcb1), 0);
+    memset(&tcb2, sizeof(tcb2), 0);
+
+#if defined(__x86_64__)
+    if (sizeof(struct tcb) != (8 * 2))
+        return 7;
+#else
+    if (sizeof(struct tcb) != (8 * 3))
+        return 8;
+#endif
 
     tcb1.data = 1;
     solo5_set_tls_base((uint64_t)&tcb1.tp);

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -22,13 +22,13 @@
 #include "../../bindings/lib.c"
 
 #if defined(__x86_64__)
-struct __attribute__((aligned(8),packed))  tcb {
+struct tcb {
     volatile uint64_t _data;
-    volatile void *tp;
+    void *tp;
 };
 #elif defined(__aarch64__)
-struct __attribute__((aligned(8),packed))  tcb {
-    volatile void *tp;
+struct tcb {
+    void *tp;
     void *pad;
     volatile uint64_t _data;
 };
@@ -60,17 +60,20 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_tls ****\n\n");
 
-    solo5_set_tls_base((uint64_t)&tcb1.tp);
+    tcb1.tp = &tcb1.tp;
+    tcb2.tp = &tcb2.tp;
+
+    solo5_set_tls_base((uint64_t)tcb1.tp);
     set_data(1);
 
-    solo5_set_tls_base((uint64_t)&tcb2.tp);
+    solo5_set_tls_base((uint64_t)tcb2.tp);
     set_data(2);
 
-    solo5_set_tls_base((uint64_t)&tcb1.tp);
+    solo5_set_tls_base((uint64_t)tcb1.tp);
     if (get_data() != 1)
         return 1;
 
-    solo5_set_tls_base((uint64_t)&tcb2.tp);
+    solo5_set_tls_base((uint64_t)tcb2.tp);
     if (get_data() != 2)
         return 2;
 

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -46,12 +46,12 @@ static void puts(const char *s)
 
 __thread volatile uint64_t _data;
 
-uint64_t get_data()
+uint64_t __attribute__ ((noinline)) get_data()
 {
     return _data;
 }
 
-void set_data(uint64_t data)
+void __attribute__ ((noinline)) set_data(uint64_t data)
 {
     _data = data;
 }

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -99,6 +99,10 @@ expect_abort() {
   [ "$status" -eq 255 ] && [[ "$output" == *"ABORT"* ]]
 }
 
+expect_segfault() {
+  [ "$status" -eq 139 ]
+}
+
 virtio_expect_abort() {
   [ "$status" -eq 0 -o "$status" -eq 2 -o "$status" -eq 83 ] && \
     [[ "$output" == *"ABORT"* ]]
@@ -198,7 +202,8 @@ virtio_expect_abort() {
 }
 
 @test "notls spt" {
-  skip "not supported on spt yet"
+  spt_run test_notls/test_notls.spt
+  expect_segfault
 }
 
 @test "ssp hvt" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -206,6 +206,21 @@ virtio_expect_abort() {
   expect_segfault
 }
 
+@test "tls hvt" {
+  hvt_run test_tls/test_tls.hvt
+  expect_success
+}
+
+@test "tls virtio" {
+  virtio_run test_tls/test_tls.virtio
+  virtio_expect_success
+}
+
+@test "tls spt" {
+  spt_run test_tls/test_tls.spt
+  expect_success
+}
+
 @test "ssp hvt" {
   hvt_run test_ssp/test_ssp.hvt
   expect_abort

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -207,16 +207,28 @@ virtio_expect_abort() {
 }
 
 @test "tls hvt" {
+  if [ "$(uname -s)" = "OpenBSD" ]; then
+    skip "tls tests not run for OpenBSD"
+  fi
+
   hvt_run test_tls/test_tls.hvt
   expect_success
 }
 
 @test "tls virtio" {
+  if [ "$(uname -s)" = "OpenBSD" ]; then
+    skip "tls tests not run for OpenBSD"
+  fi
+
   virtio_run test_tls/test_tls.virtio
   virtio_expect_success
 }
 
 @test "tls spt" {
+  if [ "$(uname -s)" = "OpenBSD" ]; then
+    skip "tls tests not run for OpenBSD"
+  fi
+
   spt_run test_tls/test_tls.spt
   expect_success
 }


### PR DESCRIPTION
The need for this function was first mentioned in #310.

Some unikernels and language runtimes use thread-local-storage (TLS), like includeos and golang in rumprun. The issue is that these unikernels cannot run on spt because user-level processes do not have enough privileges to set the TLS base registers (%fs in x86_64). To solve this, this PR adds a new `solo5_set_arch_tls_base` function which directly sets the TLS register in virtio/hvt/muen and does an `arch_prctl(SET_FS)` system call in spt (`x86_64`). Setting the `tpidr_el0` register in aarch64 can be done in userspace directly, so no need to call the host, even for spt.

Enabled the `test_notls` test for spt in both `x86_64` and `aarch64`. Tested these changes with this unikernel (https://gist.github.com/ricarkol/9ebd3b260216dbbdbe3957ecb426459d) which tests TLS using the `__thread` keyword (only for linux `x86_64`). Didn't include this test as part of this PR, but can do it if needed.

Did not test muen nor genode. And, left the genode implementation empty: help needed for that please.