### PR TITLE
spt: Correct stack alignment on x86_64

### DIFF
--- a/tenders/spt/spt_launch_x86_64.S
+++ b/tenders/spt/spt_launch_x86_64.S
@@ -27,10 +27,5 @@ ENTRY(spt_launch)
 	movq %rdi, %rsp
 	movq %rdx, %rdi
 
-	pushq $0x0
-	pushq $0x0
-
-	call *%rsi
-
-        ret
+	jmp *%rsi
 END(spt_launch)

--- a/tests/test_fpu/test_fpu.c
+++ b/tests/test_fpu/test_fpu.c
@@ -39,9 +39,9 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 
 #if defined(__x86_64__)
      __asm__ (
-         "movups %0,%%xmm1;"
+         "movaps %0,%%xmm1;"
          "mulps %%xmm1, %%xmm1;"
-         "movups %%xmm1, %0"
+         "movaps %%xmm1, %0"
          : "=m" (c)
          : "m" (c)
          : "xmm1"


### PR DESCRIPTION
Use correct stack alignment on x86_64 in spt_launch. The ABI requires
that (((rsp + 8) % 16) == 0 at entry. This was causing #GP faults in SSE
code.

Modify test_fpu to use aligned variants of SSE instructions, which would
have caught this error.