### PR TITLE
W^X: Add tests, enforce where working

### DIFF
--- a/tenders/hvt/GNUmakefile
+++ b/tenders/hvt/GNUmakefile
@@ -37,6 +37,8 @@ ifeq ($(CONFIG_HOST), Linux)
     hvt_SRCS += hvt_kvm.c hvt_kvm_$(CONFIG_ARCH).c
     hvt_debug_MODULES ?= gdb dumpcore
     all_TARGETS += solo5-hvt solo5-hvt-debug
+
+    HOSTLDFLAGS += -Wl,-z -Wl,noexecstack
 else ifeq ($(CONFIG_HOST), FreeBSD)
     hvt_SRCS += hvt_freebsd.c hvt_freebsd_$(CONFIG_ARCH).c
     hvt_debug_MODULES ?= gdb dumpcore

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <linux/kvm.h>
+#include <sys/personality.h>
 
 #include "hvt.h"
 #include "hvt_kvm.h"
@@ -98,7 +99,21 @@ struct hvt *hvt_init(size_t mem_size)
 void hvt_drop_privileges()
 {
     /*
-     * This function intentionally left blank for now (see #282).
+     * This function intentionally left mostly blank for now (see #282).
      */
+
+    /*
+     * Sooo... it turns out that at least on some distributions, the Linux
+     * "personality" flag READ_IMPLIES_EXEC is the default unless linked with
+     * -z noexecstack. This is bad, as it results in mmap() with PROT_READ
+     *  implying PROT_EXEC. Cowardly refuse to run on such systems.
+     */
+    int persona = -1;
+    persona = personality(0xffffffff);
+    assert(persona >= 0);
+    if (persona & READ_IMPLIES_EXEC)
+        errx(1, "Cowardly refusing to run with a sys_personality of "
+                "READ_IMPLIES_EXEC. Please report a bug, with details of your "
+                "Linux distribution and GCC version");
 }
 #endif

--- a/tenders/spt/spt_elf.c
+++ b/tenders/spt/spt_elf.c
@@ -90,7 +90,7 @@ static ssize_t pread_in_full(int fd, void *buf, size_t count, off_t offset)
 void spt_elf_load(const char *file, uint8_t *mem, size_t mem_size,
        uint64_t *p_entry, uint64_t *p_end)
 {
-    int fd_kernel;
+    int fd_kernel = -1;
     ssize_t numb;
     size_t buflen;
     Elf64_Off ph_off;
@@ -207,9 +207,11 @@ void spt_elf_load(const char *file, uint8_t *mem, size_t mem_size,
             prot |= PROT_WRITE;
         if (phdr[ph_i].p_flags & PF_X)
             prot |= PROT_EXEC;
-        if (prot & PROT_WRITE && prot & PROT_EXEC)
-            warnx("%s: Warning: phdr[%u] requests WRITE and EXEC permissions",
+        if (prot & PROT_WRITE && prot & PROT_EXEC) {
+            warnx("%s: Error: phdr[%u] requests WRITE and EXEC permissions",
                   file, ph_i);
+            goto out_invalid;
+        }
         if (mprotect(daddr, _end - paddr, prot) == -1)
             goto out_error;
     }
@@ -220,8 +222,16 @@ void spt_elf_load(const char *file, uint8_t *mem, size_t mem_size,
     return;
 
 out_error:
-    err(1, "%s", file);
+    warn("%s", file);
+    free (phdr);
+    if (fd_kernel != -1)
+        close (fd_kernel);
+    exit(1);
 
 out_invalid:
-    errx(1, "%s: Exec format error", file);
+    warnx("%s: Exec format error", file);
+    free (phdr);
+    if (fd_kernel != -1)
+        close (fd_kernel);
+    exit(1);
 }

--- a/tests/test_wnox/GNUmakefile
+++ b/tests/test_wnox/GNUmakefile
@@ -1,0 +1,23 @@
+# Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+#
+# This file is part of Solo5, a sandboxed execution environment.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+# OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+include $(TOPDIR)/Makefile.common
+
+test_NAME := test_wnox
+
+include ../Makefile.tests

--- a/tests/test_wnox/test_wnox.c
+++ b/tests/test_wnox/test_wnox.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "solo5.h"
+#include "../../bindings/lib.c"
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
+__attribute__((section (".data"), noinline)) void nothing(void)
+{
+    asm("");
+}
+
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
+{
+    puts("\n**** Solo5 standalone test_wnox ****\n\n");
+
+    /* Verify that writable data (in section .data) is not executable. */
+    nothing();
+
+    puts("FAILURE\n");
+
+    return SOLO5_EXIT_FAILURE;
+}

--- a/tests/test_xnow/GNUmakefile
+++ b/tests/test_xnow/GNUmakefile
@@ -1,0 +1,23 @@
+# Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+#
+# This file is part of Solo5, a sandboxed execution environment.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+# OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+include $(TOPDIR)/Makefile.common
+
+test_NAME := test_xnow
+
+include ../Makefile.tests

--- a/tests/test_xnow/test_xnow.c
+++ b/tests/test_xnow/test_xnow.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "solo5.h"
+#include "../../bindings/lib.c"
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
+__attribute__((noinline)) void nothing(void)
+{
+    asm ("");
+}
+
+int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
+{
+    puts("\n**** Solo5 standalone test_xnow ****\n\n");
+
+    /* Verify that executable code (in section .text) is not writable. */
+    uint64_t *addr_invalid = (uint64_t *)nothing;
+    *addr_invalid = 1;
+
+    puts("FAILURE\n");
+
+    return SOLO5_EXIT_FAILURE;
+}

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -51,7 +51,7 @@ setup() {
     HVT_TENDER_DEBUG=../tenders/hvt/solo5-hvt-debug
     ;;
   *virtio)
-    if [ "$(uname -s)" = "OpenBSD" ]; then
+    if [ "${CONFIG_HOST}" = "OpenBSD" ]; then
       skip "virtio tests not run for OpenBSD"
     fi
     [ -z "${CONFIG_VIRTIO}" ] && skip "virtio not configured"
@@ -191,6 +191,30 @@ virtio_expect_abort() {
   [ "$status" -eq 139 ] # SIGSEGV
 }
 
+@test "xnow hvt" {
+  if [ "${CONFIG_HOST}" != "Linux" ]; then
+    skip "not supported on ${CONFIG_HOST}"
+  fi
+  hvt_run test_xnow/test_xnow.hvt
+  [ "$status" -eq 1 ] && [[ "$output" == *"host/guest translation fault"* ]]
+}
+
+@test "xnow spt" {
+  spt_run test_xnow/test_xnow.spt
+  [ "$status" -eq 139 ] # SIGSEGV
+}
+
+@test "wnox hvt" {
+  skip "not supported on ${CONFIG_HOST}"
+  hvt_run test_wnox/test_wnox.hvt
+  expect_abort
+}
+
+@test "wnox spt" {
+  spt_run test_wnox/test_wnox.spt
+  [ "$status" -eq 139 ] # SIGSEGV
+}
+
 @test "notls hvt" {
   hvt_run test_notls/test_notls.hvt
   expect_abort
@@ -207,7 +231,7 @@ virtio_expect_abort() {
 }
 
 @test "tls hvt" {
-  if [ "$(uname -s)" = "OpenBSD" ]; then
+  if [ "${CONFIG_HOST}" = "OpenBSD" ]; then
     skip "tls tests not run for OpenBSD"
   fi
 
@@ -216,7 +240,7 @@ virtio_expect_abort() {
 }
 
 @test "tls virtio" {
-  if [ "$(uname -s)" = "OpenBSD" ]; then
+  if [ "${CONFIG_HOST}" = "OpenBSD" ]; then
     skip "tls tests not run for OpenBSD"
   fi
 
@@ -225,7 +249,7 @@ virtio_expect_abort() {
 }
 
 @test "tls spt" {
-  if [ "$(uname -s)" = "OpenBSD" ]; then
+  if [ "${CONFIG_HOST}" = "OpenBSD" ]; then
     skip "tls tests not run for OpenBSD"
   fi
 


### PR DESCRIPTION
Add tests for W^X, hook up those target/host combinations that are expected to work. Additionally, link solo5-hvt on Linux with `-z noexecstack` and check that sys_personality does not include `READ_IMPLIES_EXEC` at run time (copied from solo5-spt).