### PR TITLE
capsicum(4) sandbox solo5 on FreeBSD

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -187,6 +187,9 @@ config_host_freebsd()
     # default on x86_64, so there is nothing special we need to do here.
     MAKECONF_CFLAGS="-nostdlibinc"
 
+    # enable capsicum(4) sandbox if FreeBSD kernel is new enough
+    [ "$(uname -K)" -ge 1200086 ] && CONFIG_HVT_FREEBSD_ENABLE_CAPSICUM=1
+
     [ -n "${OPT_ONLY_TOOLS}" ] && return
     CONFIG_HVT=1
     CONFIG_SPT=
@@ -292,6 +295,7 @@ MAKECONF_LDFLAGS=
 MAKECONF_SPT_CFLAGS=
 MAKECONF_SPT_LDLIBS=
 CONFIG_SPT_NO_PIE=
+CONFIG_HVT_FREEBSD_ENABLE_CAPSICUM=
 
 case "${CONFIG_HOST}" in
     Linux)
@@ -342,6 +346,7 @@ MAKECONF_LD=${LD}
 MAKECONF_SPT_CFLAGS=${MAKECONF_SPT_CFLAGS}
 MAKECONF_SPT_LDLIBS=${MAKECONF_SPT_LDLIBS}
 CONFIG_SPT_NO_PIE=${CONFIG_SPT_NO_PIE}
+CONFIG_HVT_FREEBSD_ENABLE_CAPSICUM=${CONFIG_HVT_FREEBSD_ENABLE_CAPSICUM}
 EOM
 
 echo "${prog_NAME}: Configured for ${CC_MACHINE}."

--- a/tenders/GNUmakefile
+++ b/tenders/GNUmakefile
@@ -68,6 +68,10 @@ else ifeq ($(CONFIG_HOST), FreeBSD)
     hvt_SRCS += hvt/hvt_freebsd.c hvt/hvt_freebsd_$(CONFIG_ARCH).c
     hvt_debug_MODULES ?= gdb dumpcore
     all_TARGETS += hvt/solo5-hvt hvt/solo5-hvt-debug
+ifeq ($(CONFIG_HVT_FREEBSD_ENABLE_CAPSICUM), 1)
+    HOSTLDLIBS += -lnv
+    CFLAGS += -DDHVT_FREEBSD_ENABLE_CAPSICUM=1
+endif
 else ifeq ($(CONFIG_HOST), OpenBSD)
     hvt_SRCS += hvt/hvt_openbsd.c hvt/hvt_openbsd_$(CONFIG_ARCH).c
     all_TARGETS += hvt/solo5-hvt

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -82,7 +82,6 @@ static void cleanup_vm(void)
     }
 }
 
-
 static void cleanup_vmfd(void)
 {
     if (cleanup_hvt != NULL && cleanup_hvt->b->vmfd != -1)

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -25,9 +25,7 @@
 
 #include <assert.h>
 #include <err.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <pwd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -44,8 +44,6 @@
 #include <sys/cpuset.h>
 #include <machine/vmm_dev.h>
 
-#include <osreldate.h>
-
 #if HVT_FREEBSD_ENABLE_CAPSICUM
 #include <sys/capsicum.h>
 #include <sys/nv.h>

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -156,9 +156,9 @@ struct hvt *hvt_init(size_t mem_size)
                                  VM_SET_REGISTER, VM_GET_REGISTER,
                                  VM_ACTIVATE_CPU };
     cap_rights_init(&rights, CAP_IOCTL, CAP_MMAP_RW);
-    if (cap_rights_limit(hvb->vmfd, &rights) == -1 && errno != ENOSYS)
+    if (cap_rights_limit(hvb->vmfd, &rights) == -1)
         err(1, "cap_rights_limit() failed");
-    if (cap_ioctls_limit(hvb->vmfd, cmds, nitems(cmds)) == -1 && errno != ENOSYS)
+    if (cap_ioctls_limit(hvb->vmfd, cmds, nitems(cmds)) == -1)
         err(1, "cap_ioctls_limit() failed");
 
     cap_channel_t *capcas;
@@ -191,7 +191,7 @@ void hvt_drop_privileges()
 {
 #if HVT_FREEBSD_ENABLE_CAPSICUM
     if (caph_enter() == -1)
-        err(1, "cap_enter() failed");
+        err(1, "Unable to enter sandbox: cap_enter() failed");
 #endif
 }
 #endif

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -32,7 +32,6 @@
 #include <unistd.h>
 
 #if HVT_FREEBSD_ENABLE_CAPSICUM
-#include <errno.h>
 #include <sys/capsicum.h>
 #endif
 
@@ -150,7 +149,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
 #if HVT_FREEBSD_ENABLE_CAPSICUM
     cap_rights_t rights;
     cap_rights_init(&rights, CAP_READ, CAP_WRITE, CAP_SEEK);
-    if (cap_rights_limit(diskfd, &rights) == -1 && errno != ENOSYS)
+    if (cap_rights_limit(diskfd, &rights) == -1)
        err(1, "cap_rights_limit() failed");
 #endif
 

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -31,6 +31,11 @@
 #include <string.h>
 #include <unistd.h>
 
+#if HVT_FREEBSD_ENABLE_CAPSICUM
+#include <errno.h>
+#include <sys/capsicum.h>
+#endif
+
 #include "../common/block_attach.h"
 #include "hvt.h"
 #include "solo5.h"
@@ -141,6 +146,13 @@ static int setup(struct hvt *hvt, struct mft *mft)
                 hypercall_block_write) == 0);
     assert(hvt_core_register_hypercall(HVT_HYPERCALL_BLOCK_READ,
                 hypercall_block_read) == 0);
+
+#if HVT_FREEBSD_ENABLE_CAPSICUM
+    cap_rights_t rights;
+    cap_rights_init(&rights, CAP_READ, CAP_WRITE, CAP_SEEK);
+    if (cap_rights_limit(diskfd, &rights) == -1 && errno != ENOSYS)
+       err(1, "cap_rights_limit() failed");
+#endif
 
     return 0;
 }

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -56,7 +56,6 @@ typedef unsigned char *host_mvec_t;
 #include "hvt_dumpcore_freebsd_x86_64.c"
 #define EM_HOST EM_X86_64
 typedef char *host_mvec_t;
-static int dir;
 
 #elif defined(__OpenBSD__) && defined(__x86_64__)
 

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -266,7 +266,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
 #if HVT_FREEBSD_ENABLE_CAPSICUM
     cap_rights_t rights;
     cap_rights_init(&rights, CAP_CREATE, CAP_WRITE, CAP_LOOKUP, CAP_SEEK);
-    if (cap_rights_limit(dir, &rights) == -1 && errno != ENOSYS)
+    if (cap_rights_limit(dir, &rights) == -1)
         err(1, "cap_rights_limit() failed");
 #endif
 

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -50,9 +50,13 @@ typedef unsigned char *host_mvec_t;
 
 #elif defined(__FreeBSD__) && defined(__x86_64__)
 
+#if HVT_FREEBSD_ENABLE_CAPSICUM
+#include <sys/capsicum.h>
+#endif
 #include "hvt_dumpcore_freebsd_x86_64.c"
 #define EM_HOST EM_X86_64
 typedef char *host_mvec_t;
+static int dir;
 
 #elif defined(__OpenBSD__) && defined(__x86_64__)
 
@@ -259,6 +263,13 @@ static int setup(struct hvt *hvt, struct mft *mft)
 
     if (hvt_dumpcore_supported() == -1)
         errx(1, "dumpcore: not implemented for this backend/architecture");
+
+#if HVT_FREEBSD_ENABLE_CAPSICUM
+    cap_rights_t rights;
+    cap_rights_init(&rights, CAP_CREATE, CAP_WRITE, CAP_LOOKUP, CAP_SEEK);
+    if (cap_rights_limit(dir, &rights) == -1 && errno != ENOSYS)
+        err(1, "cap_rights_limit() failed");
+#endif
 
     return 0;
 }

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -173,7 +173,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
 #if HVT_FREEBSD_ENABLE_CAPSICUM
     cap_rights_t rights;
     cap_rights_init(&rights, CAP_EVENT, CAP_WRITE, CAP_READ);
-    if (cap_rights_limit(netfd, &rights) == -1 && errno != ENOSYS)
+    if (cap_rights_limit(netfd, &rights) == -1)
         err(1, "cap_rights_limit() failed");
 #endif
 


### PR DESCRIPTION
- cap_sysctl(3) provides access to the sysctl namespace (restricted
  to hw.vmm.destroy)
- hvt_module_dumpcore was changed to use openat(2} and file creation
  restricted to the current working directory
- block, net, stdio file descriptors and ioctls have been restricted
  as in bhyve(8)

the ppoll(2) capsicum whitelist change was included in the 12-STABLE
branch and will be part of the FreeBSD-12.1 release (scheduled for
Nov 2019)