### PR TITLE
Port SPT to PowerPC64 (no TLS access for stack_guard)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,14 @@ addons:
             - qemu-system-x86
             - libseccomp-dev
 script: ./configure.sh && make && tests/run-tests.sh
+matrix:
+  include:
+    - env: _ARCH_ACTUAL=x86_64
+      os: linux
+    - env: _ARCH_ACTUAL=ppc64le CC=gcc-7
+      os: linux-ppc64le
+      sudo: required
+      before_script:
+        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        - sudo apt-get -y update
+        - sudo apt-get -y install gcc-7

--- a/AUTHORS
+++ b/AUTHORS
@@ -20,5 +20,6 @@ Martin Lucina (robur.io / Center for the Cultivation of Technology)
 Michael LeMay
 Nikhil AP
 Ricardo Koller (IBM)
+Stefan Berger (IBM)
 Waldir Pimenta
 Wei Chen (ARM)

--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -41,6 +41,8 @@
 #include "cpu_x86_64.h"
 #elif defined(__aarch64__)
 #include "cpu_aarch64.h"
+#elif defined(__powerpc64__)
+#include "cpu_ppc64.h"
 #else
 #error Unsupported architecture
 #endif

--- a/bindings/crt_init.h
+++ b/bindings/crt_init.h
@@ -24,6 +24,8 @@ extern uintptr_t SSP_GUARD;
 #define READ_CPU_TICKS cpu_rdtsc
 #elif defined(__aarch64__)
 #define READ_CPU_TICKS cpu_cntvct
+#elif defined(__powerpc64__)
+#define READ_CPU_TICKS cpu_cntvct
 #else
 #error Unsupported architecture
 #endif

--- a/bindings/spt/platform.c
+++ b/bindings/spt/platform.c
@@ -60,6 +60,9 @@ int platform_set_tls_base(uint64_t base)
 #elif defined(__aarch64__)
     cpu_set_tls_base(base);
     return 0;
+#elif defined(__powerpc64__)
+    cpu_set_tls_base(base);
+    return 0;
 #else
 #error Unsupported architecture
 #endif

--- a/bindings/spt/sys_linux_ppc64le.c
+++ b/bindings/spt/sys_linux_ppc64le.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2015-2018 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "bindings.h"
+
+/*
+ * The sys_ functions in this file are intentionally weakly typed as they only
+ * pass through values to/from the system call without interpretation. All
+ * integer values are passed as (long) and all pointer values are passed as
+ * (void *).
+ */
+
+#define SYS_read 3
+#define SYS_write 4
+#define SYS_pread64 179
+#define SYS_pwrite64 180
+#define SYS_clock_gettime 246
+#define SYS_exit_group 234
+#define SYS_epoll_pwait 303
+#define SYS_timerfd_settime 311
+
+long sys_read(long fd, void *buf, long size)
+{
+    register long r0 __asm__("r0") = SYS_read;
+    register long r3 __asm__("r3") = fd;
+    register long r4 __asm__("r4") = (long)buf;
+    register long r5 __asm__("r5") = size;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4), "r" (r5)
+            : "memory", "cc"
+    );
+
+    return r3;
+}
+
+long sys_write(long fd, const void *buf, long size)
+{
+    register long r0 __asm__("r0") = SYS_write;
+    register long r3 __asm__("r3") = fd;
+    register long r4 __asm__("r4") = (long)buf;
+    register long r5 __asm__("r5") = size;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4), "r" (r5)
+            : "memory", "cc"
+    );
+
+    return r3;
+}
+
+long sys_pread64(long fd, void *buf, long size, long pos)
+{
+    register long r0 __asm__("r0") = SYS_pread64;
+    register long r3 __asm__("r3") = fd;
+    register long r4 __asm__("r4") = (long)buf;
+    register long r5 __asm__("r5") = size;
+    register long r6 __asm__("r6") = pos;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4), "r" (r5), "r" (r6)
+            : "memory", "cc"
+    );
+
+    return r3;
+}
+
+long sys_pwrite64(long fd, const void *buf, long size, long pos)
+{
+    register long r0 __asm__("r0") = SYS_pwrite64;
+    register long r3 __asm__("r3") = fd;
+    register long r4 __asm__("r4") = (long)buf;
+    register long r5 __asm__("r5") = size;
+    register long r6 __asm__("r6") = pos;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4), "r" (r5), "r" (r6)
+            : "memory", "cc"
+    );
+
+    return r3;
+}
+
+void sys_exit_group(long status)
+{
+    register long r0 __asm__("r0") = SYS_exit_group;
+    register long r3 __asm__("r3") = status;
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r0)
+            : "r" (r0), "r" (r3)
+            : "memory", "cc"
+    );
+
+    for(;;);
+}
+
+long sys_clock_gettime(const long which, void *ts)
+{
+    register long r0 __asm__("r0") = SYS_clock_gettime;
+    register long r3 __asm__("r3") = which;
+    register long r4 __asm__("r4") = (long)ts;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4)
+            : "memory", "cc"
+    );
+
+    return r3;
+}
+
+long sys_epoll_pwait(long epfd, void *events, long maxevents, long timeout,
+        void *sigmask, long sigsetsize)
+
+{
+    register long r0 __asm__("r0") = SYS_epoll_pwait;
+    register long r3 __asm__("r3") = epfd;
+    register long r4 __asm__("r4") = (long)events;
+    register long r5 __asm__("r5") = maxevents;
+    register long r6 __asm__("r6") = timeout;
+    register long r7 __asm__("r7") = (long)sigmask;
+    register long r8 __asm__("r8") = sigsetsize;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4), "r" (r5), "r" (r6), "r" (r7), "r" (r8)
+            : "memory", "cc"
+    );
+
+    return r3;
+}
+
+long sys_timerfd_settime(long fd, long flags, const void *utmr, void *otmr)
+{
+    register long r0 __asm__("r0") = SYS_timerfd_settime;
+    register long r3 __asm__("r3") = fd;
+    register long r4 __asm__("r4") = flags;
+    register long r5 __asm__("r5") = (long)utmr;
+    register long r6 __asm__("r6") = (long)otmr;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3), "r" (r4), "r" (r5), "r" (r6)
+            : "memory", "cc"
+    );
+
+    return r3;
+}

--- a/configure.sh
+++ b/configure.sh
@@ -92,6 +92,10 @@ case ${CC_MACHINE} in
         CONFIG_ARCH=aarch64 CONFIG_HOST=Linux
         CONFIG_GUEST_PAGE_SIZE=0x1000
         ;;
+    powerpc64le-*linux*)
+        CONFIG_ARCH=ppc64le CONFIG_HOST=Linux
+        CONFIG_GUEST_PAGE_SIZE=0x10000
+        ;;
     x86_64-*freebsd*)
         CONFIG_ARCH=x86_64 CONFIG_HOST=FreeBSD
         CONFIG_GUEST_PAGE_SIZE=0x1000
@@ -141,7 +145,7 @@ case "${CONFIG_HOST}" in
         # Any GCC configured for a Linux/x86_64 target (actually, any
         # glibc-based target) will use a TLS slot to address __stack_chk_guard.
         # Disable this behaviour and use an ordinary global variable instead.
-        if [ "${CONFIG_ARCH}" = "x86_64" ]; then
+        if [ "${CONFIG_ARCH}" = "x86_64" ] || [ "${CONFIG_ARCH}" = "ppc64le" ]; then
             gcc_check_option -mstack-protector-guard=global || \
                 die "GCC 4.9.0 or newer is required for -mstack-protector-guard= support"
             MAKECONF_CFLAGS="${MAKECONF_CFLAGS} -mstack-protector-guard=global"
@@ -165,6 +169,7 @@ case "${CONFIG_HOST}" in
         [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_VIRTIO=1
         [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_MUEN=1
         [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_GENODE=1
+        [ "${CONFIG_ARCH}" = "ppc64le" ] && CONFIG_HVT=
         ;;
     FreeBSD)
         # On FreeBSD/clang we use -nostdlibinc which gives us access to the

--- a/tenders/common/elf.c
+++ b/tenders/common/elf.c
@@ -81,6 +81,9 @@ static ssize_t pread_in_full(int fd, void *buf, size_t count, off_t offset)
 #elif defined(__aarch64__)
 #define EM_TARGET EM_AARCH64
 #define EM_PAGE_SIZE 0x1000
+#elif defined(__powerpc64__)
+#define EM_TARGET EM_PPC64
+#define EM_PAGE_SIZE 0x10000
 #else
 #error Unsupported target
 #endif

--- a/tenders/spt/spt_core.c
+++ b/tenders/spt/spt_core.c
@@ -203,6 +203,11 @@ void spt_run(struct spt *spt, uint64_t p_entry)
     uint64_t sp = spt->mem_size - 0x8;
 #elif defined(__aarch64__)
     uint64_t sp = spt->mem_size - 0x10;
+#elif defined(__powerpc64__)
+    /*
+     * Stack alignment on PPC64 is 0x10, minimum stack frame size is 112 bytes.
+     */
+    uint64_t sp = spt->mem_size - 112;
 #else
 #error Unsupported architecture
 #endif

--- a/tenders/spt/spt_launch_ppc64le.S
+++ b/tenders/spt/spt_launch_ppc64le.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ * Copyright (c) 2019 Contributors as noted in the AUTHORS file
  *
  * This file is part of Solo5, a sandboxed execution environment.
  *
@@ -18,30 +18,17 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "solo5.h"
-#include "../../bindings/lib.c"
+#define ENTRY(x) .text; .globl x; .type x,%function; x:
+#define END(x)   .size x, . - x
 
-static void puts(const char *s)
-{
-    solo5_console_write(s, strlen(s));
-}
-
-int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
-{
-    puts("\n**** Solo5 standalone test_notls ****\n\n");
-
-#if defined(__x86_64__)
-    __asm__ __volatile("movq %%fs:0x28, %%rax" : : : "rax");
-#elif defined(__aarch64__)
-    __asm__ __volatile("mrs x0, tpidr_el0; "
-                       "add x0, x0, #0x10; "
-                       "ldr w1, [x0]"
-                       : : : "x0", "w1");
-#elif defined(__powerpc64__)
-    __asm__ __volatile("ld 3,-28672(13)" : : : "r3", "r13");
-#else
-#error Unsupported architecture
-#endif
-
-    return SOLO5_EXIT_FAILURE;
-}
+/*
+ * r3: stack pointer to use
+ * r4: function to call
+ * r5: argument to pass to function
+ */
+ENTRY(spt_launch)
+	mr %r1, %r3       // load stack pointer
+	mr %r3, %r5       // parameter to pass to function goes into r3
+	mtlr %r4          // move address of function to call into link register
+	blr               // call function via link register
+END(spt_launch)

--- a/tests/test_fpu/test_fpu.c
+++ b/tests/test_fpu/test_fpu.c
@@ -56,6 +56,21 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
         : "m" (c)
         : "q0", "q1", "v0"
     );
+#elif defined(__powerpc64__)
+#define DOMUL(VAR) 			\
+    __asm__(				\
+        "lfs %%f0, %0\n"		\
+        "fmuls %%f0, %%f0, %%f0\n"	\
+        "stfs %%f0, %0\n"		\
+        : "=m" (VAR)			\
+        : "m" (VAR)			\
+        : "memory"			\
+    )
+    DOMUL(c[0]);
+    DOMUL(c[1]);
+    DOMUL(c[2]);
+    DOMUL(c[3]);
+#undef DOMUL
 #else
 #error Unsupported architecture
 #endif

--- a/tests/test_seccomp/test_seccomp.c
+++ b/tests/test_seccomp/test_seccomp.c
@@ -49,6 +49,16 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
             "svc 0"
             : "=r" (x0) : "r" (x8), "r" (x1) : "cc", "memory"
     );
+#elif defined(__powerpc__)
+    register long r0 __asm__("r0") = 41;
+    register long r3 __asm__("r3") = 0;
+
+    __asm__ __volatile__ (
+            "sc"
+            : "=r" (r3)
+            : "r" (r0), "r" (r3)
+            : "cc", "memory"
+    );
 #else
 #error Unsupported architecture
 #endif

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -21,12 +21,15 @@
 #include "solo5.h"
 #include "../../bindings/lib.c"
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__powerpc64__)
 /* Variant II */
 struct tcb {
     volatile uint64_t _data;
     void *tp;
 };
+
+#define PPC64_TLS_OFFSET 0x7000
+
 #elif defined(__aarch64__)
 /* Variant I */
 struct tcb {
@@ -67,8 +70,13 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_tls ****\n\n");
 
+#if defined (__powerpc64__)
+    tcb1.tp = (void *)&tcb1._data + PPC64_TLS_OFFSET;
+    tcb2.tp = (void *)&tcb2._data + PPC64_TLS_OFFSET;
+#else
     tcb1.tp = &tcb1.tp;
     tcb2.tp = &tcb2.tp;
+#endif
 
     if (solo5_set_tls_base((uintptr_t)tcb1.tp) != SOLO5_R_OK)
         return 1;


### PR DESCRIPTION
This series of patches ports SPT to PowerPC64. We eliminate the access to the thead-local storage's stack_guard by compiling with `-mstack-protector-guard=global`. All libraries and applications have to use the same option and must never use `-fstack-protector-strong` since we do not have a valid TLS.