### PR TITLE
Allow for differing guest page size

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -34,13 +34,15 @@ CFLAGS := -std=gnu99 -Wall -Wextra -Werror -O2 -g
 CFLAGS += -ffreestanding -fstack-protector-strong $(MAKECONF_CFLAGS)
 CPPFLAGS := -isystem $(TOPDIR)/include/crt -I$(TOPDIR)/include/solo5
 LD := $(MAKECONF_LD)
-LDFLAGS := -nostdlib -z max-page-size=0x1000 -static $(MAKECONF_LDFLAGS)
+LDFLAGS := -nostdlib -z max-page-size=$(CONFIG_GUEST_PAGE_SIZE) -static \
+    $(MAKECONF_LDFLAGS)
 OBJCOPY := objcopy
 
 # Genode application compiling and linking is a special case
 GENODE_APP_CFLAGS := $(CFLAGS) -fPIC
-GENODE_APP_LDFLAGS := -nostdlib -z max-page-size=0x1000 -shared -gc-sections \
-    --eh-frame-hdr -Ttext=0x01000000 --dynamic-linker=ld.lib.so -rpath-link=.
+GENODE_APP_LDFLAGS := -nostdlib -z max-page-size=$(CONFIG_GUEST_PAGE_SIZE) \
+    -shared -gc-sections --eh-frame-hdr -Ttext=0x01000000 \
+    --dynamic-linker=ld.lib.so -rpath-link=.
 
 # Also used by the HOST_ rules below.
 DEPFLAGS = -MT $@ -MMD -MP -MF $*.Td

--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -138,8 +138,8 @@ ifdef CONFIG_GENODE
 
 $(genode_OBJS): CFLAGS += -Wno-unused-parameter
 
-GENODE_LDFLAGS := -nostdlib -z max-page-size=0x1000 -shared -gc-sections \
-    --eh-frame-hdr --entry=0x0 -T genode/genode_rel.ld
+GENODE_LDFLAGS := -nostdlib -z max-page-size=$(CONFIG_GUEST_PAGE_SIZE) -shared \
+    -gc-sections --eh-frame-hdr --entry=0x0 -T genode/genode_rel.ld
 genode/solo5.lib.so: $(genode_OBJS)
 	@echo "LD $@"
 	$(LD) $(GENODE_LDFLAGS) $^ -o $@

--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -12,7 +12,7 @@ SECTIONS {
         *(.text.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
 
     /* Read-only data */
@@ -26,7 +26,7 @@ SECTIONS {
         *(.eh_frame)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
     /* Read-write data (initialized) */
@@ -41,7 +41,7 @@ SECTIONS {
         *(.data.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
@@ -51,7 +51,7 @@ SECTIONS {
         *(COMMON)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
 }

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -12,7 +12,7 @@ SECTIONS {
         *(.text.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
 
     /* Read-only data */
@@ -26,7 +26,7 @@ SECTIONS {
         *(.eh_frame)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
     /* Read-write data (initialized) */
@@ -41,7 +41,7 @@ SECTIONS {
         *(.data.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
@@ -51,7 +51,7 @@ SECTIONS {
         *(COMMON)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
 }

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -12,7 +12,7 @@ SECTIONS {
         *(.text.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
 
     /* Read-only data */
@@ -26,7 +26,7 @@ SECTIONS {
         *(.eh_frame)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
     /* Read-write data (initialized) */
@@ -41,7 +41,7 @@ SECTIONS {
         *(.data.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
@@ -51,7 +51,7 @@ SECTIONS {
         *(COMMON)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
 }

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -13,7 +13,7 @@ SECTIONS {
         *(.text.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
 
     /* Read-only data */
@@ -27,7 +27,7 @@ SECTIONS {
         *(.eh_frame)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
     /* Read-write data (initialized) */
@@ -42,7 +42,7 @@ SECTIONS {
         *(.data.*)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
@@ -52,7 +52,7 @@ SECTIONS {
         *(COMMON)
     }
 
-    . = ALIGN(0x1000);
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
 }

--- a/configure.sh
+++ b/configure.sh
@@ -86,15 +86,19 @@ CC_MACHINE=$(${CC} -dumpmachine)
 case ${CC_MACHINE} in
     x86_64-*linux*)
         CONFIG_ARCH=x86_64 CONFIG_HOST=Linux
+        CONFIG_GUEST_PAGE_SIZE=0x1000
         ;;
     aarch64-*linux*)
         CONFIG_ARCH=aarch64 CONFIG_HOST=Linux
+        CONFIG_GUEST_PAGE_SIZE=0x1000
         ;;
     x86_64-*freebsd*)
         CONFIG_ARCH=x86_64 CONFIG_HOST=FreeBSD
+        CONFIG_GUEST_PAGE_SIZE=0x1000
         ;;
     amd64-*openbsd*)
         CONFIG_ARCH=x86_64 CONFIG_HOST=OpenBSD
+        CONFIG_GUEST_PAGE_SIZE=0x1000
         ;;
     *)
         die "Unsupported toolchain target: ${CC_MACHINE}"
@@ -265,6 +269,7 @@ MAKECONF_CFLAGS=${MAKECONF_CFLAGS}
 MAKECONF_LDFLAGS=${MAKECONF_LDFLAGS}
 CONFIG_ARCH=${CONFIG_ARCH}
 CONFIG_HOST=${CONFIG_HOST}
+CONFIG_GUEST_PAGE_SIZE=${CONFIG_GUEST_PAGE_SIZE}
 MAKECONF_CC=${CC}
 MAKECONF_LD=${LD}
 CONFIG_SPT_NO_PIE=${CONFIG_SPT_NO_PIE}


### PR DESCRIPTION
Some architectures do not/cannot use 4k pages, so allow for changing the target-specific "guest page size", i.e. the value passed as -z max-page-size to the linker. Update the linker scripts to take this value from the linker rather than hard-coding it.

NOTE: This is a test to see if this approach is portable to the BSDs, specifically if the LLVM linker is happy with `CONSTANT(MAXPAGESIZE)`.