### PR TITLE
Update virtio net and block to handle multiple devices

### DIFF
--- a/bindings/virtio/bindings.h
+++ b/bindings/virtio/bindings.h
@@ -58,15 +58,9 @@ struct pci_config_info {
     uint8_t irq;
 };
 
-void pci_enumerate(void);
+int pci_enumerate(struct mft *mft);
 
-/* virtio.c: mostly net for now */
-void virtio_config_network(struct pci_config_info *);
-void virtio_config_block(struct pci_config_info *);
-
-uint8_t *virtio_net_pkt_get(size_t *size);  /* get a pointer to recv'd data */
-void virtio_net_pkt_put(void);      /* we're done with recv'd data */
-int virtio_net_xmit_packet(const void *data, size_t len);
-int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
+int virtio_config_network(struct pci_config_info *, solo5_handle_t, struct mft *mft);
+int virtio_config_block(struct pci_config_info *, solo5_handle_t, struct mft *mft);
 
 #endif /* __VIRTIO_BINDINGS_H__ */

--- a/bindings/virtio/pci.c
+++ b/bindings/virtio/pci.c
@@ -53,44 +53,57 @@
 } while (0)
 
 
-static uint32_t net_devices_found;
-static uint32_t blk_devices_found;
-
+static solo5_handle_t mft_index = 0;
 #define PCI_CONF_SUBSYS_NET 1
 #define PCI_CONF_SUBSYS_BLK 2
 
-static void virtio_config(struct pci_config_info *pci)
+/*
+ * mft_index tracks the order in which devices are found (given by the
+ * PCI slots). This is used to map found devices to devices in the manifest.
+ */
+static int virtio_config(struct pci_config_info *pci, struct mft *mft)
 {
     /* we only support one net device and one blk device */
     switch (pci->subsys_id) {
     case PCI_CONF_SUBSYS_NET:
         log(INFO, "Solo5: PCI:%02x:%02x: virtio-net device, base=0x%x, irq=%u\n",
             pci->bus, pci->dev, pci->base, pci->irq);
-        if (!net_devices_found++)
-            virtio_config_network(pci);
-        else
-            log(WARN, "Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
-                pci->dev);
+        if (virtio_config_network(pci, mft_index, mft) != 0)
+            return -1;
+        mft_index++;
         break;
     case PCI_CONF_SUBSYS_BLK:
         log(INFO, "Solo5: PCI:%02x:%02x: virtio-block device, base=0x%x, irq=%u\n",
             pci->bus, pci->dev, pci->base, pci->irq);
-        if (!blk_devices_found++)
-            virtio_config_block(pci);
-        else
-            log(WARN, "Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
-                pci->dev);
+        if (virtio_config_block(pci, mft_index, mft) != 0)
+            return -1;
+        mft_index++;
         break;
     default:
+        /* Most likely this is something like a virtio_scsi device
+           that we can not handle. Let's not handle nor count it
+           in pci_virtio_index. */
         log(WARN, "Solo5: PCI:%02x:%02x: unknown virtio device (0x%x)\n",
             pci->bus, pci->dev, pci->subsys_id);
-        return;
     }
+    return 0;
 }
 
 #define VENDOR_QUMRANET_VIRTIO 0x1af4
 
-void pci_enumerate(void)
+/*
+ * Every PCI device found in pci_enumerate is attempted to be assigned to a
+ * device from the application manifest in the order in which they are found. This
+ * order is given by the PCI slot number which is controlled in
+ * solo5-virtio-run.sh.
+ * 
+ * This funtion can fail if the type of a device just found does not match the
+ * type of the next expected device in the manifest. Devices whose type (e.g.,
+ * virtio_scsi) is unknown is just skipped.
+ * 
+ * Returns 0 on success, -1 otherwise.
+ */
+int pci_enumerate(struct mft *mft)
 {
     uint32_t bus;
     uint8_t dev;
@@ -116,8 +129,10 @@ void pci_enumerate(void)
                 PCI_CONF_READ(uint16_t, &pci.base, config_addr, IOBAR);
                 PCI_CONF_READ(uint8_t, &pci.irq, config_addr, IRQ);
 
-                virtio_config(&pci);
+                if (virtio_config(&pci, mft) != 0)
+                    return -1;
             }
         }
     }
+    return 0;
 }

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -208,8 +208,8 @@ int virtio_config_block(struct pci_config_info *pci,
     struct mft_entry *e = mft_get_by_index(virtio_mft, mft_index,
             MFT_BLOCK_BASIC);
     if (e == NULL) {
-        log(WARN, "Solo5: Virtio blk: Index %lu not declared in manifest\n",
-             mft_index);
+        log(WARN, "Solo5: Virtio blk: PCI:%02x:%02x not in manifest\n",
+             pci->bus, pci->dev);
         return -1;
     }
 

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -36,8 +36,6 @@
 #define VIRTIO_BLK_S_IOERR  1
 #define VIRTIO_BLK_S_UNSUPP 2
 
-static uint64_t virtio_blk_sectors;
-
 #define VIRTIO_BLK_SECTOR_SIZE    512
 
 struct virtio_blk_hdr {
@@ -46,31 +44,37 @@ struct virtio_blk_hdr {
     uint64_t sector;
 };
 
-static struct virtq blkq;
+static struct mft *virtio_mft;
+
 #define VIRTQ_BLK  0
+struct virtio_blk_desc {
+    uint16_t pci_base; /* base in PCI config space */
+    struct virtq blkq;
+    uint64_t sectors;
+    uint16_t sector_size;
+};
 
-static uint16_t virtio_blk_pci_base; /* base in PCI config space */
+#define VIRTIO_BLK_MAX_ENTRIES  MFT_MAX_ENTRIES
+static struct virtio_blk_desc bd_table[VIRTIO_BLK_MAX_ENTRIES];
+static unsigned bd_num_entries = 0;
 
-static bool blk_configured;
-static bool blk_acquired;
-static solo5_handle_t blk_handle;
-extern struct mft_note __solo5_manifest_note;
 
 /* Returns the index to the head of the buffers chain. */
-static uint16_t virtio_blk_op(uint32_t type,
+static uint16_t virtio_blk_op(struct virtio_blk_desc *bd,
+                              uint32_t type,
                               uint64_t sector,
                               void *data, size_t len)
 {
-    uint16_t mask = blkq.num - 1;
+    uint16_t mask = bd->blkq.num - 1;
     struct virtio_blk_hdr hdr;
     struct io_buffer *head_buf, *data_buf, *status_buf;
-    uint16_t head = blkq.next_avail & mask;
+    uint16_t head = bd->blkq.next_avail & mask;
 
     assert(len <= VIRTIO_BLK_SECTOR_SIZE);
 
-    head_buf = &blkq.bufs[head];
-    data_buf = &blkq.bufs[(head + 1) & mask];
-    status_buf = &blkq.bufs[(head + 2) & mask];
+    head_buf = &bd->blkq.bufs[head];
+    data_buf = &bd->blkq.bufs[(head + 1) & mask];
+    status_buf = &bd->blkq.bufs[(head + 2) & mask];
 
     hdr.type = type;
     hdr.ioprio = 0;
@@ -93,9 +97,9 @@ static uint16_t virtio_blk_op(uint32_t type,
     status_buf->len = sizeof(uint8_t);
     status_buf->extra_flags = VIRTQ_DESC_F_WRITE;
 
-    assert(virtq_add_descriptor_chain(&blkq, head, 3) == 0);
+    assert(virtq_add_descriptor_chain(&bd->blkq, head, 3) == 0);
 
-    outw(virtio_blk_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_BLK);
+    outw(bd->pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_BLK);
 
     return head;
 }
@@ -107,33 +111,34 @@ static uint16_t virtio_blk_op(uint32_t type,
  * time.  That is true as long as we use only synchronous IO calls, and if
  * there is just a sync call at a time (which is true for solo5).
  */
-static int virtio_blk_op_sync(uint32_t type,
+static int virtio_blk_op_sync(struct virtio_blk_desc *bd,
+                              uint32_t type,
                               uint64_t sector,
                               void *data, size_t len)
 {
-    uint16_t mask = blkq.num - 1;
+    uint16_t mask = bd->blkq.num - 1;
     uint16_t head;
     struct io_buffer *data_buf, *status_buf;
     uint8_t status;
 
-    head = virtio_blk_op(type, sector, data, len);
-    data_buf = &blkq.bufs[(head + 1) & mask];
-    status_buf = &blkq.bufs[(head + 2) & mask];
+    head = virtio_blk_op(bd, type, sector, data, len);
+    data_buf = &bd->blkq.bufs[(head + 1) & mask];
+    status_buf = &bd->blkq.bufs[(head + 2) & mask];
 
     /* Loop until the device used all of our descriptors. */
-    while (blkq.used->idx != blkq.avail->idx)
+    while (bd->blkq.used->idx != bd->blkq.avail->idx)
         ;
 
     /* Consume all the recently used descriptors. */
-    for (; blkq.used->idx != blkq.last_used; blkq.last_used++) {
+    for (; bd->blkq.used->idx != bd->blkq.last_used; bd->blkq.last_used++) {
         struct virtq_used_elem *e;
 
         /* Assert that the used descriptor matches the descriptor of the
          * IO we started at the start of this function. */
-        e = &(blkq.used->ring[blkq.last_used & mask]);
+        e = &(bd->blkq.used->ring[bd->blkq.last_used & mask]);
         assert(head == e->id);
 
-        blkq.num_avail += 3; /* 3 descriptors per chain */
+        bd->blkq.num_avail += 3; /* 3 descriptors per chain */
     }
 
     status = (*(uint8_t *)status_buf);
@@ -146,7 +151,8 @@ static int virtio_blk_op_sync(uint32_t type,
     return 0;
 }
 
-void virtio_config_block(struct pci_config_info *pci)
+static void virtio_blk_config(struct virtio_blk_desc *bd,
+        struct pci_config_info *pci)
 {
     uint8_t ready_for_init = VIRTIO_PCI_STATUS_ACK | VIRTIO_PCI_STATUS_DRIVER;
     uint32_t host_features, guest_features;
@@ -160,61 +166,77 @@ void virtio_config_block(struct pci_config_info *pci)
     guest_features = 0;
     outl(pci->base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
 
-    virtio_blk_sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
+    bd->sector_size = VIRTIO_BLK_SECTOR_SIZE;
+    bd->sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
     log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%llu sectors, "
         "features=0x%x\n",
-        pci->bus, pci->dev, (unsigned long long)virtio_blk_sectors,
+        pci->bus, pci->dev, (unsigned long long)bd->sectors,
         host_features);
 
-    virtq_init_rings(pci->base, &blkq, 0);
+    virtq_init_rings(pci->base, &bd->blkq, 0);
 
-    pgs = (((blkq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    blkq.bufs = mem_ialloc_pages(pgs);
-    assert(blkq.bufs);
-    memset(blkq.bufs, 0, pgs << PAGE_SHIFT);
+    pgs = (((bd->blkq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
+    bd->blkq.bufs = mem_ialloc_pages(pgs);
+    assert(bd->blkq.bufs);
+    memset(bd->blkq.bufs, 0, pgs << PAGE_SHIFT);
 
-    virtio_blk_pci_base = pci->base;
-    blk_configured = 1;
+    bd->pci_base = pci->base;
 
     /*
      * We don't need to get interrupts every time the device uses our
      * descriptors.
      */
 
-    blkq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
+    bd->blkq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
 
     outb(pci->base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
 }
 
-/*
- * FIXME: This is a single-device implementation of the new manifest-based
- * APIs. On virtio, this call has the following semantics:
- *
- * 1. The first call to solo5_block_acquire() asking for a handle to a valid
- *    block device (one specified in the application manifest) will succeed,
- *    and return a handle for the sole virtio block device.
- * 2. All subsequent calls will return an error.
- *
- * Note that the presence of a virtio block device is registered during boot
- * in (blk_configured), and the initial acquisition by solo5_block_acquire() is
- * registered in (blk_acquired).
- */
+int virtio_config_block(struct pci_config_info *pci,
+        solo5_handle_t mft_index, struct mft *mft)
+{
+    unsigned bd_index = bd_num_entries;
+
+    virtio_mft = mft;
+
+    if (bd_index >= VIRTIO_BLK_MAX_ENTRIES) {
+        log(WARN, "Solo5: Virtio blk: PCI:%02x:%02x not configured: "
+            "too many devices.\n", pci->bus, pci->dev);
+        return -1;
+    }
+
+    struct mft_entry *e = mft_get_by_index(virtio_mft, mft_index,
+            MFT_BLOCK_BASIC);
+    if (e == NULL) {
+        log(WARN, "Solo5: Virtio blk: Index %lu not declared in manifest\n",
+             mft_index);
+        return -1;
+    }
+
+    struct virtio_blk_desc *bd = &bd_table[bd_index];
+
+    virtio_blk_config(bd, pci);
+    e->hostfd = bd_index;
+    e->u.block_basic.capacity = bd->sectors;
+    e->u.block_basic.block_size = bd->sector_size;
+    e->attached = true;
+
+    bd_num_entries++;
+    return 0;
+}
+
 solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *h,
         struct solo5_block_info *info)
 {
-    if (!blk_configured || blk_acquired)
-        return SOLO5_R_EUNSPEC;
-
     unsigned mft_index;
-    struct mft_entry *mft_e = mft_get_by_name(&__solo5_manifest_note.m, name,
-        MFT_BLOCK_BASIC, &mft_index);
+    struct mft_entry *mft_e = mft_get_by_name(virtio_mft, name, MFT_BLOCK_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;
-    blk_handle = (solo5_handle_t)mft_index;
-    blk_acquired = true;
+    assert(mft_e->attached);
+    assert(mft_e->hostfd < VIRTIO_BLK_MAX_ENTRIES);
 
     info->block_size = VIRTIO_BLK_SECTOR_SIZE;
-    info->capacity = virtio_blk_sectors * VIRTIO_BLK_SECTOR_SIZE;
+    info->capacity = mft_e->u.block_basic.capacity * VIRTIO_BLK_SECTOR_SIZE;
     *h = (solo5_handle_t)mft_index;
     log(INFO, "Solo5: Application acquired '%s' as block device\n", name);
     return SOLO5_R_OK;
@@ -223,8 +245,11 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *h,
 solo5_result_t solo5_block_write(solo5_handle_t h, solo5_off_t offset,
         const uint8_t *buf, size_t size)
 {
-    if (!blk_acquired || h != blk_handle)
+    struct mft_entry *e = mft_get_by_index(virtio_mft, h, MFT_BLOCK_BASIC);
+    if (e == NULL)
         return SOLO5_R_EINVAL;
+    assert(e->attached);
+    assert(e->hostfd < VIRTIO_BLK_MAX_ENTRIES);
 
     /*
      * XXX: This does not check for writes ending past the end of the device,
@@ -233,24 +258,30 @@ solo5_result_t solo5_block_write(solo5_handle_t h, solo5_off_t offset,
      */
     uint64_t sector = offset / VIRTIO_BLK_SECTOR_SIZE;
     if ((offset % VIRTIO_BLK_SECTOR_SIZE != 0) ||
-        (sector >= virtio_blk_sectors) ||
+        (sector >= e->u.block_basic.capacity) ||
         (size != VIRTIO_BLK_SECTOR_SIZE))
         return SOLO5_R_EINVAL;
+
+    struct virtio_blk_desc *bd = &bd_table[e->hostfd];
 
     /*
      * XXX: removing the const qualifier from buf here is fine with the current
      * implementation which does a memcpy() on VIRTIO_BLK_T_OUT, however the
      * internal interfaces should be refactored to reflect this.
      */
-    int rv = virtio_blk_op_sync(VIRTIO_BLK_T_OUT, sector, (uint8_t *)buf, size);
+    int rv = virtio_blk_op_sync(bd, VIRTIO_BLK_T_OUT, sector,
+            (uint8_t *)buf, size);
     return (rv == 0) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }
 
 solo5_result_t solo5_block_read(solo5_handle_t h, solo5_off_t offset,
         uint8_t *buf, size_t size)
 {
-    if (!blk_acquired || h != blk_handle)
+    struct mft_entry *e = mft_get_by_index(virtio_mft, h, MFT_BLOCK_BASIC);
+    if (e == NULL)
         return SOLO5_R_EINVAL;
+    assert(e->attached);
+    assert(e->hostfd < VIRTIO_BLK_MAX_ENTRIES);
 
     /*
      * XXX: This does not check for reads ending past the end of the device,
@@ -259,10 +290,12 @@ solo5_result_t solo5_block_read(solo5_handle_t h, solo5_off_t offset,
      */
     uint64_t sector = offset / VIRTIO_BLK_SECTOR_SIZE;
     if ((offset % VIRTIO_BLK_SECTOR_SIZE != 0) ||
-        (sector >= virtio_blk_sectors) ||
+        (sector >= e->u.block_basic.capacity) ||
         (size != VIRTIO_BLK_SECTOR_SIZE))
         return SOLO5_R_EINVAL;
 
-    int rv = virtio_blk_op_sync(VIRTIO_BLK_T_IN, sector, buf, size);
+    struct virtio_blk_desc *bd = &bd_table[e->hostfd];
+
+    int rv = virtio_blk_op_sync(bd, VIRTIO_BLK_T_IN, sector, buf, size);
     return (rv == 0) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -315,8 +315,8 @@ int virtio_config_network(struct pci_config_info *pci,
     struct mft_entry *e = mft_get_by_index(virtio_mft,
             mft_index, MFT_NET_BASIC);
     if (e == NULL) {
-        log(WARN, "Solo5: Virtio net: Index %lu not declared in manifest\n",
-             mft_index);
+        log(WARN, "Solo5: Virtio net: PCI:%02x:%02x not in manifest\n",
+             pci->bus, pci->dev);
         return -1;
     }
 

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -28,9 +28,28 @@
 #define VIRTIO_NET_F_MAC (1 << 5) /* Host has given MAC address. */
 
 #define PKT_BUFFER_LEN 1526
+#define VIRTIO_NET_MTU 1500
 
-static struct virtq recvq;
-static struct virtq xmitq;
+static struct mft *virtio_mft;
+
+struct virtio_net_desc {
+    uint16_t pci_base; /* base in PCI config space */
+    struct virtq xmitq;
+    struct virtq recvq;
+    uint8_t net_mac[6];
+    uint16_t mtu;
+    solo5_handle_t handle;
+};
+
+#define VIRTIO_NET_MAX_ENTRIES  MFT_MAX_ENTRIES
+static struct virtio_net_desc nd_table[VIRTIO_NET_MAX_ENTRIES];
+static unsigned nd_num_entries = 0;
+
+#if MFT_MAX_ENTRIES > 64
+#error "Can not hold more than 64 devices in virtio_set_t"
+#endif
+
+typedef uint64_t virtio_set_t;
 
 #define VIRTQ_RECV 0
 #define VIRTQ_XMIT 1
@@ -56,25 +75,20 @@ struct __attribute__((__packed__)) virtio_net_hdr {
     uint16_t csum_offset;        /* Offset after that to place checksum */
 };
 
-static uint16_t virtio_net_pci_base; /* base in PCI config space */
-
-static uint8_t virtio_net_mac[6];
-static char virtio_net_mac_str[18];
-
 static bool net_configured;
-static bool net_acquired;
-static solo5_handle_t net_handle;
-extern struct mft_note __solo5_manifest_note;
 
 static int handle_virtio_net_interrupt(void *);
 
 /* WARNING: called in interrupt context */
-int handle_virtio_net_interrupt(void *arg __attribute__((unused)))
+int handle_virtio_net_interrupt(void *arg)
 {
+    struct virtio_net_desc *nd = (struct virtio_net_desc *)arg;
     uint8_t isr_status;
 
+    assert(nd != NULL);
+
     if (net_configured) {
-        isr_status = inb(virtio_net_pci_base + VIRTIO_PCI_ISR);
+        isr_status = inb(nd->pci_base + VIRTIO_PCI_ISR);
         if (isr_status & VIRTIO_PCI_ISR_HAS_INTR) {
             /* This interrupt is just to kick the application out of any
              * solo5_poll() that may be running. */
@@ -84,38 +98,39 @@ int handle_virtio_net_interrupt(void *arg __attribute__((unused)))
     return 0;
 }
 
-static void recv_setup(void)
+static void recv_setup(struct virtio_net_desc *nd)
 {
-    uint16_t mask = recvq.num - 1;
+    uint16_t mask = nd->recvq.num - 1;
     do {
         struct io_buffer *buf; /* header and data in a single descriptor */
-        buf = &recvq.bufs[recvq.next_avail & mask];
+        buf = &nd->recvq.bufs[nd->recvq.next_avail & mask];
         memset(buf->data, 0, PKT_BUFFER_LEN);
         buf->len = PKT_BUFFER_LEN;
         buf->extra_flags = VIRTQ_DESC_F_WRITE;
-        assert(virtq_add_descriptor_chain(&recvq,
-                                          recvq.next_avail & mask, 1) == 0);
-    } while ((recvq.next_avail & mask) != 0);
+        assert(virtq_add_descriptor_chain(&nd->recvq,
+                   nd->recvq.next_avail & mask, 1) == 0);
+    } while ((nd->recvq.next_avail & mask) != 0);
 
-    outw(virtio_net_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_RECV);
+    outw(nd->pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_RECV);
 }
 
 /* performance note: we perform a copy into the xmit buffer */
-int virtio_net_xmit_packet(const void *data, size_t len)
+static int virtio_net_xmit_packet(struct virtio_net_desc *nd,
+                                  const void *data, size_t len)
 {
-    uint16_t mask = xmitq.num - 1;
+    uint16_t mask = nd->xmitq.num - 1;
     uint16_t head;
     struct io_buffer *head_buf, *data_buf;
     int r;
 
     /* Consume used descriptors from all the previous tx'es. */
-    for (; xmitq.last_used != xmitq.used->idx; xmitq.last_used++)
-        xmitq.num_avail += 2; /* 2 descriptors per chain */
+    for (; nd->xmitq.last_used != nd->xmitq.used->idx; nd->xmitq.last_used++)
+        nd->xmitq.num_avail += 2; /* 2 descriptors per chain */
 
     /* next_avail is incremented by virtq_add_descriptor_chain below. */
-    head = xmitq.next_avail & mask;
-    head_buf = &xmitq.bufs[head];
-    data_buf = &xmitq.bufs[(head + 1) & mask];
+    head = nd->xmitq.next_avail & mask;
+    head_buf = &nd->xmitq.bufs[head];
+    data_buf = &nd->xmitq.bufs[(head + 1) & mask];
 
     /* The header buf */
     memset(head_buf->data, 0, sizeof(struct virtio_net_hdr));
@@ -128,16 +143,18 @@ int virtio_net_xmit_packet(const void *data, size_t len)
     data_buf->len = len;
     data_buf->extra_flags = 0;
 
-    r = virtq_add_descriptor_chain(&xmitq, head, 2);
+    r = virtq_add_descriptor_chain(&nd->xmitq, head, 2);
 
-    outw(virtio_net_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_XMIT);
+    outw(nd->pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_XMIT);
 
     return r;
 }
 
-void virtio_config_network(struct pci_config_info *pci)
+static void virtio_net_config(struct virtio_net_desc *nd,
+        struct pci_config_info *pci)
 {
     uint32_t host_features, guest_features;
+    char net_mac_str[18];
     size_t pgs;
 
     /*
@@ -163,19 +180,19 @@ void virtio_config_network(struct pci_config_info *pci)
     outl(pci->base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
 
     for (int i = 0; i < 6; i++) {
-        virtio_net_mac[i] = inb(pci->base + VIRTIO_PCI_CONFIG_OFF + i);
+        nd->net_mac[i] = inb(pci->base + VIRTIO_PCI_CONFIG_OFF + i);
     }
-    snprintf(virtio_net_mac_str,
-             sizeof(virtio_net_mac_str),
+    snprintf(net_mac_str,
+             sizeof(net_mac_str),
              "%02x:%02x:%02x:%02x:%02x:%02x",
-             virtio_net_mac[0],
-             virtio_net_mac[1],
-             virtio_net_mac[2],
-             virtio_net_mac[3],
-             virtio_net_mac[4],
-             virtio_net_mac[5]);
+             nd->net_mac[0],
+             nd->net_mac[1],
+             nd->net_mac[2],
+             nd->net_mac[3],
+             nd->net_mac[4],
+             nd->net_mac[5]);
     log(INFO, "Solo5: PCI:%02x:%02x: configured, mac=%s, features=0x%x\n",
-        pci->bus, pci->dev, virtio_net_mac_str, host_features);
+        pci->bus, pci->dev, net_mac_str, host_features);
 
     /*
      * 7. Perform device-specific setup, including discovery of virtqueues for
@@ -183,23 +200,24 @@ void virtio_config_network(struct pci_config_info *pci)
      * device's virtio configuration space, and population of virtqueues.
      */
 
-    virtq_init_rings(pci->base, &recvq, VIRTQ_RECV);
-    virtq_init_rings(pci->base, &xmitq, VIRTQ_XMIT);
+    virtq_init_rings(pci->base, &nd->recvq, VIRTQ_RECV);
+    virtq_init_rings(pci->base, &nd->xmitq, VIRTQ_XMIT);
 
-    pgs = (((recvq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    recvq.bufs = mem_ialloc_pages(pgs);
-    assert(recvq.bufs);
-    memset(recvq.bufs, 0, pgs << PAGE_SHIFT);
+    pgs = (((nd->recvq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
+    nd->recvq.bufs = mem_ialloc_pages(pgs);
+    assert(nd->recvq.bufs);
+    memset(nd->recvq.bufs, 0, pgs << PAGE_SHIFT);
 
-    pgs = (((recvq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    xmitq.bufs = mem_ialloc_pages(pgs);
-    assert(xmitq.bufs);
-    memset(xmitq.bufs, 0, pgs << PAGE_SHIFT);
+    pgs = (((nd->recvq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
+    nd->xmitq.bufs = mem_ialloc_pages(pgs);
+    assert(nd->xmitq.bufs);
+    memset(nd->xmitq.bufs, 0, pgs << PAGE_SHIFT);
 
-    virtio_net_pci_base = pci->base;
+    nd->pci_base = pci->base;
+    nd->mtu = VIRTIO_NET_MTU;
     net_configured = 1;
-    intr_register_irq(pci->irq, handle_virtio_net_interrupt, NULL);
-    recv_setup();
+    intr_register_irq(pci->irq, handle_virtio_net_interrupt, nd);
+    recv_setup(nd);
 
     /*
      * We don't need to get interrupts every time the device uses our
@@ -208,7 +226,7 @@ void virtio_config_network(struct pci_config_info *pci)
      * Interrupt").
      */
 
-    xmitq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
+    nd->xmitq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
 
     /*
      * 8. Set the DRIVER_OK status bit. At this point the device is "live".
@@ -217,26 +235,35 @@ void virtio_config_network(struct pci_config_info *pci)
     outb(pci->base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
 }
 
-/* Returns 1 if there is a pending used descriptor for us to read. */
-int virtio_net_pkt_poll(void)
+/* Returns 1 if there is one or more used descriptors for us to read. */
+static int virtio_net_pkt_poll(virtio_set_t *ready_set)
 {
+    unsigned idx;
+
     if (!net_configured)
         return 0;
 
-    /* The device increments used->idx whenever it uses a packet (i.e. it put
-     * a packet on our receive queue) and if it's ahead of last_used it means
-     * that we have a pending packet. */
-    if (recvq.last_used == recvq.used->idx)
-        return 0;
-    else
-        return 1;
+    *ready_set = 0;
+
+    assert(nd_num_entries < VIRTIO_NET_MAX_ENTRIES);
+
+    for (idx = 0; idx < nd_num_entries; idx++) {
+        struct virtio_net_desc *nd = &nd_table[idx];
+        /* The device increments used->idx whenever it uses a packet (i.e. it
+         * put a packet on our receive queue) and if it's ahead of last_used
+         * it means that we have a pending packet. */
+        if (nd->recvq.last_used != nd->recvq.used->idx)
+            *ready_set |= 1ULL << idx;
+    }
+    return *ready_set != 0;
 }
 
 /* Get the data from the next_avail (top-most) receive buffer/descriptpr in
  * the available ring. */
-uint8_t *virtio_net_recv_pkt_get(size_t *size)
+static uint8_t *virtio_net_recv_pkt_get(struct virtio_net_desc *nd,
+        size_t *size)
 {
-    uint16_t mask = recvq.num - 1;
+    uint16_t mask = nd->recvq.num - 1;
     struct virtq_used_elem *e;
     struct io_buffer *buf;
     uint16_t desc_idx;
@@ -244,13 +271,13 @@ uint8_t *virtio_net_recv_pkt_get(size_t *size)
     /* The device increments used->idx whenever it uses a packet (i.e. it put
      * a packet on our receive queue) and if it's ahead of last_used it means
      * that we have a pending packet. */
-    if (recvq.last_used == recvq.used->idx)
+    if (nd->recvq.last_used == nd->recvq.used->idx)
         return NULL;
 
-    e = &(recvq.used->ring[recvq.last_used & mask]);
+    e = &(nd->recvq.used->ring[nd->recvq.last_used & mask]);
     desc_idx = e->id;
 
-    buf = (struct io_buffer *) recvq.desc[desc_idx].addr;
+    buf = (struct io_buffer *) nd->recvq.desc[desc_idx].addr;
     buf->len = e->len;
 
     /* Remove the virtio_net_hdr */
@@ -260,55 +287,100 @@ uint8_t *virtio_net_recv_pkt_get(size_t *size)
 
 /* Return the next_avail (top-most) receive buffer/descriptor to the available
  * ring. */
-void virtio_net_recv_pkt_put(void)
+static void virtio_net_recv_pkt_put(struct virtio_net_desc *nd)
 {
-    uint16_t mask = recvq.num - 1;
-    recvq.bufs[recvq.next_avail & mask].len = PKT_BUFFER_LEN;
-    recvq.bufs[recvq.next_avail & mask].extra_flags = VIRTQ_DESC_F_WRITE;
+    uint16_t mask = nd->recvq.num - 1;
+    nd->recvq.bufs[nd->recvq.next_avail & mask].len = PKT_BUFFER_LEN;
+    nd->recvq.bufs[nd->recvq.next_avail & mask].extra_flags = VIRTQ_DESC_F_WRITE;
 
     /* This sets the returned descriptor to be ready for incoming packets, and
      * advances the next_avail index. */
-    assert(virtq_add_descriptor_chain(&recvq, recvq.next_avail & mask, 1) == 0);
-    outw(virtio_net_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_RECV);
+    assert(virtq_add_descriptor_chain(&nd->recvq, nd->recvq.next_avail & mask, 1) == 0);
+    outw(nd->pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_RECV);
 }
 
-/*
- * FIXME: This is a single-device implementation of the new manifest-based
- * APIs. On virtio, this call has the following semantics:
- *
- * 1. The first call to solo5_net_acquire() asking for a handle to a valid
- *    network device (one specified in the application manifest) will succeed,
- *    and return a handle for the sole virtio network device.
- * 2. All subsequent calls will return an error.
- *
- * Note that the presence of a virtio network device is registered during boot
- * in (net_configured), and the initial acquisition by solo5_net_acquire() is
- * registered in (net_acquired).
- */
+int virtio_config_network(struct pci_config_info *pci,
+        solo5_handle_t mft_index, struct mft *mft)
+{
+    unsigned nd_index = nd_num_entries;
+
+    virtio_mft = mft;
+
+    if (nd_index >= MFT_MAX_ENTRIES) {
+        log(WARN, "Solo5: Virtio net: PCI:%02x:%02x not configured: "
+            "too many devices\n", pci->bus, pci->dev);
+        return -1;
+    }
+
+    struct mft_entry *e = mft_get_by_index(virtio_mft,
+            mft_index, MFT_NET_BASIC);
+    if (e == NULL) {
+        log(WARN, "Solo5: Virtio net: Index %lu not declared in manifest\n",
+             mft_index);
+        return -1;
+    }
+
+    struct virtio_net_desc *nd = &nd_table[nd_index];
+
+    virtio_net_config(nd, pci);
+    e->u.net_basic.mtu = nd->mtu;
+    e->hostfd = nd_index;
+    memcpy(e->u.net_basic.mac, nd->net_mac, sizeof e->u.net_basic.mac);
+    /*
+     * We need to map virtio net descriptors to solo5 handles in order to
+     * convert virtio ready sets to solo5 ready sets (in virtio_to_handle_set).
+     */
+    nd->handle = mft_index;
+    e->attached = true;
+
+    nd_num_entries++;
+    return 0;
+}
+
 solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *h,
         struct solo5_net_info *info)
 {
-    if (!net_configured || net_acquired)
+    unsigned mft_index;
+    struct mft_entry *mft_e;
+
+    if (!net_configured)
         return SOLO5_R_EUNSPEC;
 
-    unsigned mft_index;
-    struct mft_entry *mft_e = mft_get_by_name(&__solo5_manifest_note.m, name,
-            MFT_NET_BASIC, &mft_index);
+    mft_e = mft_get_by_name(virtio_mft, name, MFT_NET_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;
-    net_handle = (solo5_handle_t)mft_index;
-    net_acquired = true;
 
-    memcpy(info->mac_address, virtio_net_mac, sizeof info->mac_address);
-    info->mtu = 1500;
+    memcpy(info->mac_address, mft_e->u.net_basic.mac, sizeof info->mac_address);
+    info->mtu = mft_e->u.net_basic.mtu;
     *h = (solo5_handle_t)mft_index;
     log(INFO, "Solo5: Application acquired '%s' as network device\n", name);
     return SOLO5_R_OK;
 }
 
+/*
+ * Convert the set of virtio devices to a set of solo5 handles.
+ * XXX: consider filtering out the handles that were not acquired.
+ */
+solo5_handle_set_t virtio_to_handle_set(virtio_set_t virtio_set)
+{
+    solo5_handle_set_t handle_set = 0;
+    unsigned idx;
+
+    assert(nd_num_entries < VIRTIO_NET_MAX_ENTRIES);
+
+    for (idx = 0; idx < nd_num_entries; idx++) {
+        if (virtio_set & (1ULL << idx)) {
+            solo5_handle_t handle = nd_table[idx].handle;
+            handle_set |= 1ULL << handle;
+        }
+    }
+    return handle_set;
+}
+
 void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
 {
-    solo5_handle_set_t tmp_ready_set = 0;
+    bool rc = false;
+    virtio_set_t virtio_set;
 
     /*
      * cpu_block() as currently implemented will only poll for the maximum time
@@ -317,17 +389,22 @@ void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
      */
     cpu_intr_disable();
     do {
-        if (net_acquired && virtio_net_pkt_poll()) {
-            tmp_ready_set |= 1UL << net_handle;
+        if (virtio_net_pkt_poll(&virtio_set)) {
+            rc = true;
             break;
         }
 
         cpu_block(deadline);
     } while (solo5_clock_monotonic() < deadline);
-    if (!tmp_ready_set && net_acquired && virtio_net_pkt_poll())
-        tmp_ready_set |= 1UL << net_handle;
+    if (!rc)
+        rc = virtio_net_pkt_poll(&virtio_set);
     cpu_intr_enable();
 
+    solo5_handle_set_t tmp_ready_set;
+    if (rc)
+        tmp_ready_set = virtio_to_handle_set(virtio_set);
+    else
+        tmp_ready_set = 0;
     if (ready_set)
         *ready_set = tmp_ready_set;
 }
@@ -335,31 +412,33 @@ void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
 solo5_result_t solo5_net_write(solo5_handle_t h, const uint8_t *buf,
         size_t size)
 {
-    if (!net_acquired || h != net_handle)
+    struct mft_entry *e = mft_get_by_index(virtio_mft, h, MFT_NET_BASIC);
+    if (e == NULL)
         return SOLO5_R_EINVAL;
 
-    int rv = virtio_net_xmit_packet(buf, size);
+    assert(e->attached);
+    assert(e->hostfd < VIRTIO_NET_MAX_ENTRIES);
+
+    int rv = virtio_net_xmit_packet(&nd_table[e->hostfd], buf, size);
     return (rv == 0) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }
 
-solo5_result_t solo5_net_read(solo5_handle_t h, uint8_t *buf, size_t size,
-        size_t *read_size)
+/* Returns 0 if a packet was read, -1 if there is there is no pending packet. */
+static int virtio_net_recv(struct virtio_net_desc *nd, uint8_t *buf,
+        size_t size, size_t *read_size)
 {
     uint8_t *pkt;
     size_t len = size;
 
-    if (!net_acquired || h != net_handle)
-        return SOLO5_R_EINVAL;
-
     /* We only need interrupts to wake up the application when it's sleeping
      * and waiting for incoming packets. The app is definitely not doing that
      * now (as we are here), so disable them. */
-    recvq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
+    nd->recvq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
 
-    pkt = virtio_net_recv_pkt_get(&len);
+    pkt = virtio_net_recv_pkt_get(nd, &len);
     if (!pkt) {
-        recvq.avail->flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
-        return SOLO5_R_AGAIN;
+        nd->recvq.avail->flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
+        return -1;
     }
 
     assert(len <= size);
@@ -370,12 +449,26 @@ solo5_result_t solo5_net_read(solo5_handle_t h, uint8_t *buf, size_t size,
     memcpy(buf, pkt, len);
 
     /* Consume the recently used descriptor. */
-    recvq.last_used++;
-    recvq.num_avail++;
+    nd->recvq.last_used++;
+    nd->recvq.num_avail++;
 
-    virtio_net_recv_pkt_put();
+    virtio_net_recv_pkt_put(nd);
 
-    recvq.avail->flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
+    nd->recvq.avail->flags &= ~VIRTQ_AVAIL_F_NO_INTERRUPT;
 
-    return SOLO5_R_OK;
+    return 0;
+}
+
+solo5_result_t solo5_net_read(solo5_handle_t h, uint8_t *buf,
+        size_t size, size_t *read_size)
+{
+    struct mft_entry *e = mft_get_by_index(virtio_mft, h, MFT_NET_BASIC);
+    if (e == NULL)
+        return SOLO5_R_EINVAL;
+
+    assert(e->attached);
+    assert(e->hostfd < VIRTIO_NET_MAX_ENTRIES);
+
+    int rv = virtio_net_recv(&nd_table[e->hostfd], buf, size, read_size);
+    return (rv == 0) ? SOLO5_R_OK : SOLO5_R_AGAIN;
 }

--- a/scripts/virtio-run/solo5-virtio-run.sh
+++ b/scripts/virtio-run/solo5-virtio-run.sh
@@ -58,20 +58,77 @@ is_quiet ()
     [ -n "${QUIET}" ]
 }
 
+qemu_add_device ()
+{
+    DEVICE=$1
+    PCI_SLOT=$2
+    PS_HEX=$(printf "%x" ${PCI_SLOT})
+
+    OLDIFS=$IFS
+    IFS=:
+    set -- ${D}
+    IFS=$OLDIFS
+
+    TYPE=$1
+    NAME="$2"
+    shift; shift
+
+    case $TYPE in
+    BLK)
+        hv_addargs -drive id=drive${PCI_SLOT},file="${NAME}",if=none,format=raw
+        hv_addargs -device virtio-blk,drive=drive${PCI_SLOT},addr=0x${PS_HEX},bus=pci.0
+        ;;
+    NET)
+        hv_addargs -device virtio-net,netdev=n${PCI_SLOT},addr=0x${PS_HEX},bus=pci.0
+        hv_addargs -netdev tap,id=n${PCI_SLOT},ifname="${NAME}",script=no,downscript=no
+        ;;
+    *)
+        die "Unknown device type"
+        ;;
+    esac
+}
+
+bhyve_add_device ()
+{
+    DEVICE=$1
+    PCI_SLOT=$2
+
+    OLDIFS=$IFS
+    IFS=:
+    set -- ${D}
+    IFS=$OLDIFS
+
+    TYPE=$1
+    NAME="$2"
+    shift; shift
+
+    case $TYPE in
+    BLK)
+        hv_addargs -s ${PCI_SLOT}:0,virtio-blk,"${NAME}"
+        ;;
+    NET)
+        hv_addargs -s ${PCI_SLOT}:0,virtio-net,"${NAME}"
+        ;;
+    *)
+        die "Unknown device type"
+        ;;
+    esac
+}
+
 # Parse command line arguments.
 ARGS=$(getopt d:m:n:qH: $*)
 [ $? -ne 0 ] && usage
 set -- $ARGS
 MEM=128
 HV=best
-NETIF=
-BLKIMG=
+DEVICES=
 QUIET=
 while true; do
     case "$1" in
     -d)
         BLKIMG=$(readlink -f $2)
         [ -f ${BLKIMG} ] || die "not found: ${BLKIMG}"
+        DEVICES="${DEVICES} BLK:${BLKIMG}"
         shift; shift
         ;;
     -m)
@@ -87,6 +144,7 @@ while true; do
         ip a show ${NETIF} >/dev/null 2>&1 ||
             ifconfig ${NETIF} >/dev/null 2>&1 ||
             die "no such network interface: ${NETIF}"
+	DEVICES="${DEVICES} NET:${NETIF}"
         shift; shift
         ;;
     -q)
@@ -154,15 +212,15 @@ kvm|qemu)
     # solo5-hvt.
     hv_addargs -display none -serial stdio
 
-    # Network
-    if [ -n "${NETIF}" ]; then
-        hv_addargs -device virtio-net,netdev=n0
-        hv_addargs -netdev tap,id=n0,ifname=${NETIF},script=no,downscript=no
-    fi
-    # Disk
-    if [ -n "${BLKIMG}" ]; then
-        hv_addargs -drive file=${BLKIMG},if=virtio,format=raw
-    fi
+    # Slots 0 and 1 are already used.
+    PCI_SLOT=2
+
+    for D in ${DEVICES}; do
+        qemu_add_device $D ${PCI_SLOT}
+	# The maximum PCI slot is 31. We don't check this as qemu will fail
+	# with a more helpful message.
+        PCI_SLOT=$((PCI_SLOT+1))
+    done
 
     # Used by automated tests on QEMU (see kernel/virtio/platform.c).
     hv_addargs -device isa-debug-exit
@@ -197,15 +255,16 @@ bhyve)
     TTYA=/dev/nmdm$$A
     TTYB=/dev/nmdm$$B
     hv_addargs -l com1,${TTYB}
-    
-    # Network
-    if [ -n "${NETIF}" ]; then
-        hv_addargs -s 2:0,virtio-net,${NETIF}
-    fi
-    # Disk
-    if [ -n "${BLKIMG}" ]; then
-        hv_addargs -s 3:0,virtio-blk,${BLKIMG}
-    fi
+
+    # Slots 0 and 1 are already used.
+    PCI_SLOT=2
+
+    for D in ${DEVICES}; do
+        bhyve_add_device $D ${PCI_SLOT}
+	# The maximum PCI slot is 31. We don't check this as bhyve will fail
+	# with a more helpful message.
+        PCI_SLOT=$((PCI_SLOT+1))
+    done
 
     hv_addargs ${VMNAME}
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -359,6 +359,17 @@ virtio_expect_abort() {
   expect_success
 }
 
+@test "net_2if virtio" {
+  [ $(id -u) -ne 0 ] && skip "Need root to run this test, for ping -f"
+  [ "${CONFIG_HOST}" = "OpenBSD" ] && skip "breaks on OpenBSD due to #374"
+
+  ( sleep 2; ${TIMEOUT} 60s ping -fq -c 50000 ${NET0_IP} ) &
+  ( sleep 2; ${TIMEOUT} 60s ping -fq -c 50000 ${NET1_IP} ) &
+  virtio_run -n ${NET0} -n ${NET1} -- \
+      test_net_2if/test_net_2if.virtio limit
+  virtio_expect_success
+}
+
 @test "net_2if spt" {
   [ $(id -u) -ne 0 ] && skip "Need root to run this test, for ping -f"
 


### PR DESCRIPTION
This PR is really 2 changes: virtio changes to support multiple devices, and dealing with the application manifest. Dealing with the application manifest is tricky as PCI devices have no names.
The easiest solution would be to have the user explicitely map devices to PCI slots in the manifest: `{ ..."type": "NET_BASIC", "PCI":"bus1:0x4:0"}`. But this would be a pain as not much people use the virtio backend. Moreover, most cloud providers don't give enough control to users to define what buses and PCI addresses to use. They just allow users to define the ordering of devices. So, that's what this PR uses: the ordering of devices. For example, `virtio-run -n tap1 -d /p/D1 -n tap2` maps to the following manifest like this:

```
    "devices": [
        { "name": "service1", "type": "NET_BASIC" },	--> tap1
        { "name": "disk1", "type": "BLK_BASIC" },	--> /p/D1
        { "name": "service2", "type": "NET_BASIC" }	--> tap2
    ]
```

A second PR after this will add a new virtio-run tool which would take the same arguments as the tenders (`--net:service1=tap1 ...`). This tool would read the manifest from the application and use it to define the PCI slots of all the devices passed by the user.

These are all the changes:

- virtio/pci.c and virtio/start.c:
    PCI devices found in pci_enumerate are assigned to devices from the application
    manifest in the order in which they are found. This order is given by the PCI
    slot numbers which are controlled in solo5-virtio-run.sh.  The application
    fails (during PCI enumeration) if the type of a device just found does not
    match the type of the next expected device in the manifest.  Devices whose type
    (e.g., virtio_scsi) are unknown are just skipped. We do not fail in this case
    because GCE always includes virtio_scsi devices (can't control that).
    
- virtio/virtio_net.c and virtio_blk.c:
    Moved all device specific objects, like the virtio queues and the PCI base
    address, to `virtio_[blk|net]_desc` structures.  These are initialized at config
    time and stored in a table (bd_table and nd_table) indexed by their respective
    solo5_handle's hostfd.  Also moved all virtio specific code to `static
    virtio_[blk|net]_*` functions.  These functions only deal with
    `virtio_[blk|net]_desc` structures.  All the other ones, like `solo5_block_read`,
    translate `solo5_handles` using the hostfd field in the handle.

- solo5-virtio-run.sh:
    As a first version, add the ability to have multiple -d DISK and -n NETIF
    arguments. The order of the arguments is used as the PCI slot number (starting
    at 2 as those are reserved).