### PR TITLE
solo5_yield() should return void

### DIFF
--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -422,7 +422,7 @@ struct Solo5::Platform
 	 ** Solo5 bindings **
 	 ********************/
 
-	bool
+	void
 	yield(solo5_time_t deadline_ns, solo5_handle_set_t *ready_set)
 	{
 		if (!nic_ready) {
@@ -451,10 +451,7 @@ struct Solo5::Platform
 				*ready_set = nic_ready;
 			}
 			nic_ready = 0;
-			return true;
 		}
-
-		return false;
 	}
 
 	solo5_result_t
@@ -535,11 +532,11 @@ solo5_time_t solo5_clock_wall(void)
 }
 
 
-bool
+void
 solo5_yield(solo5_time_t deadline,
             solo5_handle_set_t *ready_set)
 {
-	return Platform::instance->yield(deadline, ready_set);
+	Platform::instance->yield(deadline, ready_set);
 }
 
 

--- a/bindings/genode/stubs.c
+++ b/bindings/genode/stubs.c
@@ -6,7 +6,7 @@ void solo5_abort(void) { for(;;); }
 
 solo5_time_t solo5_clock_monotonic(void) { return ~0; }
 solo5_time_t solo5_clock_wall(void) { return ~0; }
-bool solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set) { return false; }
+void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set) { return; }
 
 solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *handle, struct solo5_net_info *info) { return SOLO5_R_EUNSPEC; }
 solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }

--- a/bindings/hvt/yield.c
+++ b/bindings/hvt/yield.c
@@ -20,7 +20,7 @@
 
 #include "bindings.h"
 
-bool solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
+void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
 {
     struct hvt_hc_poll t;
     uint64_t now;
@@ -33,5 +33,4 @@ bool solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
     hvt_do_hypercall(HVT_HYPERCALL_POLL, &t);
     if (ready_set != NULL)
         *ready_set = t.ready_set;
-    return t.ret;
 }

--- a/bindings/spt/net.c
+++ b/bindings/spt/net.c
@@ -85,7 +85,7 @@ solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf,
     return (nbytes == (int)size) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }
 
-bool solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
+void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
 {
     int nrevents;
     /*
@@ -127,5 +127,4 @@ bool solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
     assert(nrevents >= 0);
     if (ready_set != NULL)
         *ready_set = tmp_ready_set;
-    return (nrevents > 0);
 }

--- a/include/solo5/solo5.h
+++ b/include/solo5/solo5.h
@@ -161,11 +161,10 @@ typedef uint64_t solo5_handle_set_t;
  *   a) monotonic time reaches (deadline), or
  *   b) at least one network device is ready for input.
  *
- * Returns true if at least one network device is ready, otherwise false.
  * If (ready_set) is not NULL, it will be filled in with the set of
  * solo5_handle_t's ready for input.
  */
-bool solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set);
+void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set);
 
 /*
  * Console I/O.

--- a/tests/test_net/test_net.c
+++ b/tests/test_net/test_net.c
@@ -354,23 +354,17 @@ static bool ping_serve(void)
 #endif
 
     for (;;) {
-        bool io_ready = false;
         solo5_handle_set_t ready_set = 0;
 
-        io_ready = solo5_yield(solo5_clock_monotonic() + NSEC_PER_SEC,
-                &ready_set);
-        if (io_ready && (ready_set & 1U << ni[0].h))
+        solo5_yield(solo5_clock_monotonic() + NSEC_PER_SEC, &ready_set);
+        if (ready_set & 1U << ni[0].h)
             if (!handle_packet(0))
                 return false;
 #ifdef TWO_INTERFACES
-        if (io_ready && (ready_set & 1U << ni[1].h))
+        if (ready_set & 1U << ni[1].h)
             if (!handle_packet(1))
                 return false;
 #endif
-        if (!io_ready && ready_set != 0) {
-            puts("error: Yield returned false, but handles in set!\n");
-            return false;
-        }
         if (opt_limit && n_pings_received >= 100000) {
             puts("Limit reached, exiting\n");
             break;


### PR DESCRIPTION
Part of #372 / clean-up of #375 :

@hannesm pointed out to me that having `solo5_yield()` return both a `ready_set` and `bool` is redundant, so change the return type to `void`.

@ehmry I've updated the Genode bindings but not tested them.
@ricarkol #377 will need some changes to account for this.