### PR TITLE
bindings: Reload segment selectors in gdt_init()

### DIFF
--- a/bindings/cpu_x86_64.h
+++ b/bindings/cpu_x86_64.h
@@ -75,19 +75,16 @@
 /*
  * GDT layout
  *
- * This should be kept consistent with the layout used by the hvt tender (as
- * defined in tenders/hvt/hvt_cpu_x86_64.h.
  */
 #define GDT_DESC_NULL           0
 #define GDT_DESC_CODE           1
-#define GDT_DESC_CODE32         2 /* Used by boot.S on virtio targets */
-#define GDT_DESC_DATA           3
-#define GDT_DESC_TSS_LO         4
-#define GDT_DESC_TSS_HI         5
+#define GDT_DESC_DATA           2
+#define GDT_DESC_TSS_LO         3
+#define GDT_DESC_TSS_HI         4
 #define GDT_DESC_TSS            GDT_DESC_TSS_LO
 
 #define GDT_DESC_OFFSET(n)      ((n) * 0x8)
-#define GDT_NUM_ENTRIES         6
+#define GDT_NUM_ENTRIES         5
 
 #define GDT_DESC_CODE_VAL       0x00af99000000ffff
 #define GDT_DESC_DATA_VAL       0x00cf93000000ffff


### PR DESCRIPTION
Until now we were running the (V)CPU slightly out of spec. While this
has not been affecting any current users of Solo5, it was pointed out in
handlers, should someone want to do so.

Fixed by reloading CS, DS, ES, SS in gdt_init() after reloading the GDT.
Fixes #327.

@ricarkol Please double-check this, it seems fine for me.
/cc @Pusnow