### PR TITLE
ELF loader: Generic NOTE loading

### DIFF
--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -21,9 +21,10 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    .note.solo5 :
+    /* For Hvt, the manifest NOTE(s) are read-only. */
+    .note.solo5.manifest :
     {
-        *(.note.solo5*)
+        *(.note.solo5.manifest*)
     }
     .eh_frame :
     {

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -21,10 +21,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    .note.solo5 :
-    {
-        *(.note.solo5*)
-    }
     .eh_frame :
     {
         *(.eh_frame)
@@ -43,6 +39,12 @@ SECTIONS {
     {
         *(.data)
         *(.data.*)
+    }
+    /* For Muen, the manifest NOTE(s) must be in a read-write section, as they
+     * may be modified in-place by the bindings. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
     }
     .tdata :
     {

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -21,9 +21,10 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    .note.solo5 :
+    /* For Spt, the manifest NOTE(s) are read-only. */
+    .note.solo5.manifest :
     {
-        *(.note.solo5*)
+        *(.note.solo5.manifest*)
     }
     .eh_frame :
     {

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -22,10 +22,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    .note.solo5 :
-    {
-        *(.note.solo5*)
-    }
     .eh_frame :
     {
         *(.eh_frame)
@@ -44,6 +40,12 @@ SECTIONS {
     {
         *(.data)
         *(.data.*)
+    }
+    /* For Virtio, the manifest NOTE(s) must be in a read-write section, as they
+     * may be modified in-place by the bindings. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
     }
     .tdata :
     {

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -47,7 +47,12 @@ void _start(void *arg)
     _newstack(platform_mem_size(), _start2, 0);
 }
 
-extern struct mft_note __solo5_manifest_note;
+extern struct mft1_note __solo5_mft1_note;
+/*
+ * Will be initialised at start-up, and used by bindings to access (and
+ * modify!) the in-built manifest.
+ */
+struct mft *virtio_manifest = NULL;
 
 static void _start2(void *arg __attribute__((unused)))
 {
@@ -65,12 +70,20 @@ static void _start2(void *arg __attribute__((unused)))
     pci_enumerate();
     cpu_intr_enable();
 
-    struct mft *mft = &__solo5_manifest_note.m;
-    size_t mft_size = __solo5_manifest_note.h.descsz;
+    /*
+     * Get the built-in manifest "out of" the ELF NOTE and validate it. Note
+     * that the size must be adjusted from n_descsz to remove any internal
+     * alignment. Once validated, it is available for access globally by the
+     * bindings.
+     */
+    struct mft *mft = &__solo5_mft1_note.m;
+    size_t mft_size = __solo5_mft1_note.h.n_descsz -
+        (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
     if (mft_validate(mft, mft_size) != 0) {
 	log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
 	solo5_abort();
     }
+    virtio_manifest = mft;
 
     mem_lock_heap(&si.heap_start, &si.heap_size);
     solo5_exit(solo5_app_main(&si));

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -54,7 +54,7 @@ static uint16_t virtio_blk_pci_base; /* base in PCI config space */
 static bool blk_configured;
 static bool blk_acquired;
 static solo5_handle_t blk_handle;
-extern struct mft_note __solo5_manifest_note;
+extern struct mft *virtio_manifest;
 
 /* Returns the index to the head of the buffers chain. */
 static uint16_t virtio_blk_op(uint32_t type,
@@ -206,7 +206,7 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *h,
         return SOLO5_R_EUNSPEC;
 
     unsigned mft_index;
-    struct mft_entry *mft_e = mft_get_by_name(&__solo5_manifest_note.m, name,
+    struct mft_entry *mft_e = mft_get_by_name(virtio_manifest, name,
         MFT_DEV_BLOCK_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -64,7 +64,7 @@ static char virtio_net_mac_str[18];
 static bool net_configured;
 static bool net_acquired;
 static solo5_handle_t net_handle;
-extern struct mft_note __solo5_manifest_note;
+extern struct mft *virtio_manifest;
 
 static int handle_virtio_net_interrupt(void *);
 
@@ -292,7 +292,7 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *h,
         return SOLO5_R_EUNSPEC;
 
     unsigned mft_index;
-    struct mft_entry *mft_e = mft_get_by_name(&__solo5_manifest_note.m, name,
+    struct mft_entry *mft_e = mft_get_by_name(virtio_manifest, name,
             MFT_DEV_NET_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;

--- a/mfttool/mfttool.c
+++ b/mfttool/mfttool.c
@@ -70,7 +70,7 @@ static const char out_header[] = \
     "#define MFT_ENTRIES %d\n"
     "#include \"mft_abi.h\"\n"
     "\n"
-    "MFT_NOTE_BEGIN\n"
+    "MFT1_NOTE_DECLARE_BEGIN\n"
     "{\n"
     "  .version = MFT_VERSION, .entries = %d,\n"
     "  .e = {\n"
@@ -82,7 +82,7 @@ static const char out_entry[] = \
 static const char out_footer[] = \
     "  }\n"
     "}\n"
-    "MFT_NOTE_END\n";
+    "MFT1_NOTE_DECLARE_END\n";
 
 static void usage(const char *prog)
 {
@@ -187,7 +187,11 @@ static int mfttool_dump(const char *binary)
 {
     struct mft *mft;
     size_t mft_size;
-    elf_load_mft(binary, &mft, &mft_size);
+    if (elf_load_note(binary, MFT1_NOTE_TYPE, MFT1_NOTE_ALIGN,
+                MFT1_NOTE_MAX_SIZE, (void **)&mft, &mft_size) == -1) {
+        warnx("%s: No Solo5 manifest found in executable", binary);
+        return EXIT_FAILURE;
+    }
     if (mft_validate(mft, mft_size) == -1) {
         free(mft);
         warnx("%s: Manifest validation failed", binary);

--- a/tenders/common/elf.h
+++ b/tenders/common/elf.h
@@ -25,21 +25,37 @@
 #ifndef COMMON_ELF_H
 #define COMMON_ELF_H
 
-#include "mft_abi.h"
-
 /*
  * Load an ELF binary from (file) into (mem_size) bytes of memory at (*mem).
- * (p_min_loadaddr) is the lowest allowed load address within (*mem). Returns
- * the entry point (p_entry) and last address used by the binary (p_end).
+ * (p_min_loadaddr) is the lowest allowed load address within (*mem). 
+ *
+ * If successful, returns the entry point (*p_entry) and last address used by
+ * the binary (*p_end).
+ *
+ * If the executable is invalid, or on any other error, reports to stderr and
+ * terminates the program.
  */
 void elf_load(const char *file, uint8_t *mem, size_t mem_size,
         uint64_t p_min_loadaddr, uint64_t *p_entry, uint64_t *p_end);
 
 /*
- * Load the Solo5 manifest from the ELF binary (file). Memory for the manifest
- * is allocated with malloc() and returned as (mft), with the manifest size as
- * defined in the ELF binary returned in (mft_size).
+ * Load the Solo5-owned NOTE of (note_type) from the ELF binary (file).
+ * Internal alignment of the note descriptor (content) will be adjusted to
+ * (note_align), and a descriptor with a descsz larger than (max_note_size)
+ * will cause the executable to be rejected.
+ *
+ * Returns / error handling:
+ *
+ * On success: Returns 0 and memory for the note descriptor (content) is
+ * allocated with malloc(), returned in (*note_data), with the note size,
+ * **minus any alignment**, returned in (*note_size).
+ *
+ * If a Solo5-owned NOTE of (note_type) was NOT found, but the executable is
+ * otherwise valid: Returns -1.
+ *
+ * In all other cases, reports any errors to stderr and terminates the program.
  */
-void elf_load_mft(const char *file, struct mft **mft, size_t *mft_size);
+int elf_load_note(const char *file, uint32_t note_type, size_t note_align,
+        size_t max_note_size, void **note_data, size_t *note_size);
 
 #endif /* COMMON_ELF_H */

--- a/tenders/common/mft.c
+++ b/tenders/common/mft.c
@@ -43,11 +43,13 @@ int mft_validate(struct mft *mft, size_t mft_size)
     if (mft->entries > MFT_MAX_ENTRIES)
         return -1;
     /*
-     * mft_size MAY be larger than the exact structure size due to alignment,
-     * so only fail here if it is strictly less than the space required for the
-     * declared number of manifest entries.
+     * mft_size must be the exact expected structure size, including the space
+     * required for manifest entires.
+     *
+     * If you are debugging this and it does not match up, the most likely
+     * cause is an internal structure alignment issue (see mft_abi.h).
      */
-    if (mft_size < (sizeof(struct mft) +
+    if (mft_size != (sizeof(struct mft) +
                 (mft->entries * sizeof(struct mft_entry))))
         return -1;
     /*

--- a/tenders/common/mft.h
+++ b/tenders/common/mft.h
@@ -32,6 +32,9 @@
  * Validate that the manfiest at (mft), of size (mft_size) is safe to use, and
  * sanitize all fields with prejudice, as these are considered untrusted data.
  *
+ * Note that (mft_size) must be the **exact** expected size of the expected
+ * manifest structure, including the array of entires.
+ *
  * On success returns 0, on error returns -1.
  */
 int mft_validate(struct mft *mft, size_t mft_size);

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -169,7 +169,9 @@ int main(int argc, char **argv)
      */
     struct mft *mft;
     size_t mft_size;
-    elf_load_mft(elffile, &mft, &mft_size);
+    if (elf_load_note(elffile, MFT1_NOTE_TYPE, MFT1_NOTE_ALIGN,
+                MFT1_NOTE_MAX_SIZE, (void **)&mft, &mft_size) == -1)
+        errx(1, "%s: No Solo5 manifest found in executable", elffile);
     if (mft_validate(mft, mft_size) == -1) {
         free(mft);
         errx(1, "%s: Solo5 manifest is invalid", elffile);

--- a/tenders/spt/spt_main.c
+++ b/tenders/spt/spt_main.c
@@ -163,7 +163,9 @@ int main(int argc, char **argv)
      */
     struct mft *mft;
     size_t mft_size;
-    elf_load_mft(elffile, &mft, &mft_size);
+    if (elf_load_note(elffile, MFT1_NOTE_TYPE, MFT1_NOTE_ALIGN,
+                MFT1_NOTE_MAX_SIZE, (void **)&mft, &mft_size) == -1)
+        errx(1, "%s: No Solo5 manifest found in executable", elffile);
     if (mft_validate(mft, mft_size) == -1) {
         free(mft);
         errx(1, "%s: Solo5 manifest is invalid", elffile);


### PR DESCRIPTION
The ultimate motivation for this is to allow us to use different ELF notes for different purposes (see https://github.com/Solo5/solo5/issues/372#issuecomment-525272670). This will be useful for ABI versioning. From the commit log:

Make the NOTE loading functionality generic, rather than coupled to loading just a "MFT1" note. elf_load_mft(...) is now renamed as elf_load_note(...). The code is also intentionally decoupled from any dependency on mft_abi.h.

In the process, various NOTE structure alignment issues which were "papered over" in the initial iteration of this code have been fixed now that I have a correct understanding of how (and why) the structures are laid out.

Additional fixes:

- place .note.solo5.manifest in .data (as opposed to .rodata) for virtio and muen, as these bindings are expected to need to modify the structure in-place (as opposed to getting a copy from a tender).
- improve virtio built-in manifest initialisation, and introduce a global variable for access to the validated struct mft.
- document the ELF functions some more.

@cfcs I would very much appreciate your thorough review :-)

/cc @ricarkol (virtio changes)
/cc @Kensan (see above re muen placement of note structure)
/cc @Ehmry what about Genode? I presume the bindings there also need to modify mft in place, so you may need to account for that in your linker script. OR it may be easier just to take a writable copy of the struct?