### PR TITLE
Compile with -std=c11 throughout

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -30,7 +30,7 @@ include $(TOPDIR)/Makeconf
 # tests (applications).
 #
 CC := $(MAKECONF_CC)
-CFLAGS := -std=gnu99 -Wall -Wextra -Werror -O2 -g
+CFLAGS := -std=c11 -Wall -Wextra -Werror -O2 -g
 CFLAGS += -ffreestanding -fstack-protector-strong $(MAKECONF_CFLAGS)
 CPPFLAGS := -isystem $(TOPDIR)/include/crt -I$(TOPDIR)/include/solo5
 LD := $(MAKECONF_LD)
@@ -64,7 +64,7 @@ endef
 # artifacts built to run on the (Solo5 tender's) *host*.
 #
 HOSTCC := $(MAKECONF_CC)
-HOSTCFLAGS := -Wall -Werror -std=c99 -O2 -g
+HOSTCFLAGS := -Wall -Werror -std=c11 -O2 -g
 HOSTCPPFLAGS := -I$(TOPDIR)/include/solo5
 HOSTLDFLAGS :=
 HOSTLDLIBS :=

--- a/bindings/spt/sys_linux_x86_64.c
+++ b/bindings/spt/sys_linux_x86_64.c
@@ -71,7 +71,7 @@ long sys_write(long fd, const void *buf, long size)
 long sys_pread64(long fd, void *buf, long size, long pos)
 {
     long ret;
-    register long r10 asm("r10") = pos;
+    register long r10 __asm__("r10") = pos;
 
     __asm__ __volatile__ (
             "syscall"
@@ -86,7 +86,7 @@ long sys_pread64(long fd, void *buf, long size, long pos)
 long sys_pwrite64(long fd, const void *buf, long size, long pos)
 {
     long ret;
-    register long r10 asm("r10") = pos;
+    register long r10 __asm__("r10") = pos;
 
     __asm__ __volatile__ (
             "syscall"
@@ -128,9 +128,9 @@ long sys_epoll_pwait(long epfd, void *events, long maxevents, long timeout,
         void *sigmask, long sigsetsize)
 {
     long ret;
-    register long r10 asm("r10") = timeout;
-    register long r8 asm("r8") = (long)sigmask;
-    register long r9 asm("r9") = sigsetsize;
+    register long r10 __asm__("r10") = timeout;
+    register long r8 __asm__("r8") = (long)sigmask;
+    register long r9 __asm__("r9") = sigsetsize;
 
     __asm__ __volatile__ (
             "syscall"
@@ -146,7 +146,7 @@ long sys_epoll_pwait(long epfd, void *events, long maxevents, long timeout,
 long sys_timerfd_settime(long fd, long flags, const void *utmr, void *otmr)
 {
     long ret;
-    register long r10 asm("r10") = (long)otmr;
+    register long r10 __asm__("r10") = (long)otmr;
 
     __asm__ __volatile__ (
             "syscall"

--- a/tests/test_wnox/test_wnox.c
+++ b/tests/test_wnox/test_wnox.c
@@ -28,7 +28,7 @@ static void puts(const char *s)
 
 __attribute__((section (".data"), noinline)) void nothing(void)
 {
-    asm("");
+    __asm__("");
 }
 
 int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))

--- a/tests/test_xnow/test_xnow.c
+++ b/tests/test_xnow/test_xnow.c
@@ -28,7 +28,7 @@ static void puts(const char *s)
 
 __attribute__((noinline)) void nothing(void)
 {
-    asm ("");
+    __asm__("");
 }
 
 int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))


### PR DESCRIPTION
Allows us to use C11 features such as _Static_assert.