### PR TITLE
Introduce t_guest_mprotect() in ELF loader, fix hvt implementation

### DIFF
--- a/tenders/common/elf.c
+++ b/tenders/common/elf.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include "cc.h"
+#include "elf.h"
 
 /*
  * Define EM_TARGET, EM_PAGE_SIZE and EI_DATA_TARGET for the architecture we
@@ -194,7 +195,8 @@ static int align_up(Elf64_Addr addr, Elf64_Xword align, Elf64_Addr *out_result)
 }
 
 void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
-       uint64_t p_min_loadaddr, uint64_t *p_entry, uint64_t *p_end)
+        uint64_t p_min_loadaddr, guest_mprotect_fn_t t_guest_mprotect, void *t,
+        uint64_t *p_entry, uint64_t *p_end)
 {
     ssize_t nbytes;
     Elf64_Phdr *phdr = NULL;
@@ -329,11 +331,6 @@ void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
             goto out_invalid;
         if (p_vaddr_end & (EM_PAGE_SIZE - 1))
             goto out_invalid;
-        uint8_t *host_vaddr_start = mem + p_vaddr_start;
-        /*
-         * Double check result for host (caller) address space overflow.
-         */
-        assert(host_vaddr_start >= (mem + p_min_loadaddr));
         int prot = PROT_NONE;
         if (phdr[ph_i].p_flags & PF_R)
             prot |= PROT_READ;
@@ -346,7 +343,8 @@ void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
                   bin_name, ph_i);
             goto out_invalid;
         }
-        if (mprotect(host_vaddr_start, p_vaddr_end - p_vaddr_start, prot) == -1)
+        assert(t_guest_mprotect != NULL);
+        if (t_guest_mprotect(t, p_vaddr_start, p_vaddr_end, prot) == -1)
             goto out_error;
     }
 

--- a/tenders/common/elf.c
+++ b/tenders/common/elf.c
@@ -195,8 +195,8 @@ static int align_up(Elf64_Addr addr, Elf64_Xword align, Elf64_Addr *out_result)
 }
 
 void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
-        uint64_t p_min_loadaddr, guest_mprotect_fn_t t_guest_mprotect, void *t,
-        uint64_t *p_entry, uint64_t *p_end)
+        uint64_t p_min_loadaddr, guest_mprotect_fn_t t_guest_mprotect,
+        void *t_guest_mprotect_arg, uint64_t *p_entry, uint64_t *p_end)
 {
     ssize_t nbytes;
     Elf64_Phdr *phdr = NULL;
@@ -344,7 +344,8 @@ void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
             goto out_invalid;
         }
         assert(t_guest_mprotect != NULL);
-        if (t_guest_mprotect(t, p_vaddr_start, p_vaddr_end, prot) == -1)
+        if (t_guest_mprotect(t_guest_mprotect_arg, p_vaddr_start, p_vaddr_end,
+                    prot) == -1)
             goto out_error;
     }
 

--- a/tenders/common/elf.h
+++ b/tenders/common/elf.h
@@ -26,9 +26,21 @@
 #define COMMON_ELF_H
 
 /*
+ * guest_mprotect_fn() is called by the ELF loader to request that the page
+ * protection flags (prot) as used by the system mprotect(), i.e. PROT_X from
+ * sys/mman.h be applied to the guest memory range (addr_start .. addr_end).
+ * (t) is the backend-specific argument.
+ *
+ * Returns 0 on success, -1 and errno set on failure.
+ */
+typedef int (*guest_mprotect_fn_t)(void *t, uint64_t addr_start,
+        uint64_t addr_end, int prot);
+
+/*
  * Load an ELF binary from (bin_fd) into (mem_size) bytes of memory at (*mem).
  * (p_min_loadaddr) is the lowest allowed load address within (*mem). (bin_name)
  * is the file name of the binary and is used to report errors.
+ * (t_guest_mprotect) is a pointer to the function described above.
  *
  * If successful, returns the entry point (*p_entry) and last address used by
  * the binary (*p_end).
@@ -37,7 +49,8 @@
  * terminates the program.
  */
 void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
-        uint64_t p_min_loadaddr, uint64_t *p_entry, uint64_t *p_end);
+        uint64_t p_min_loadaddr, guest_mprotect_fn_t t_guest_mprotect, void *t,
+        uint64_t *p_entry, uint64_t *p_end);
 
 /*
  * Load the Solo5-owned NOTE of (note_type) from the ELF binary (file).

--- a/tenders/common/elf.h
+++ b/tenders/common/elf.h
@@ -29,11 +29,11 @@
  * guest_mprotect_fn() is called by the ELF loader to request that the page
  * protection flags (prot) as used by the system mprotect(), i.e. PROT_X from
  * sys/mman.h be applied to the guest memory range (addr_start .. addr_end).
- * (t) is the backend-specific argument.
+ * (t_arg) is a pointer to the backend-specific struct (hvt, spt, ...).
  *
  * Returns 0 on success, -1 and errno set on failure.
  */
-typedef int (*guest_mprotect_fn_t)(void *t, uint64_t addr_start,
+typedef int (*guest_mprotect_fn_t)(void *t_arg, uint64_t addr_start,
         uint64_t addr_end, int prot);
 
 /*
@@ -41,6 +41,7 @@ typedef int (*guest_mprotect_fn_t)(void *t, uint64_t addr_start,
  * (p_min_loadaddr) is the lowest allowed load address within (*mem). (bin_name)
  * is the file name of the binary and is used to report errors.
  * (t_guest_mprotect) is a pointer to the function described above.
+ * (t_guest_mprotect_arg) is passed through to t_guest_mprotect().
  *
  * If successful, returns the entry point (*p_entry) and last address used by
  * the binary (*p_end).
@@ -49,8 +50,8 @@ typedef int (*guest_mprotect_fn_t)(void *t, uint64_t addr_start,
  * terminates the program.
  */
 void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
-        uint64_t p_min_loadaddr, guest_mprotect_fn_t t_guest_mprotect, void *t,
-        uint64_t *p_entry, uint64_t *p_end);
+        uint64_t p_min_loadaddr, guest_mprotect_fn_t t_guest_mprotect,
+        void *t_guest_mprotect_arg, uint64_t *p_entry, uint64_t *p_end);
 
 /*
  * Load the Solo5-owned NOTE of (note_type) from the ELF binary (file).

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -111,7 +111,7 @@ void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
  * Apply page protections to guest memory. See guest_mprotect_fn_t in elf.h for
  * a full description.
  */
-int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot);
 
 #if HVT_DROP_PRIVILEGES

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -107,6 +107,13 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep);
 void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
         char **cmdline_argv, struct mft *mft, size_t mft_size);
 
+/*
+ * Apply page protections to guest memory. See guest_mprotect_fn_t in elf.h for
+ * a full description.
+ */
+int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+        int prot);
+
 #if HVT_DROP_PRIVILEGES
 /*
  * Drop privileges. This function is called by the tender before entering the

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -140,3 +140,20 @@ void hvt_drop_privileges()
      */
 }
 #endif
+
+int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+        int prot)
+{
+    struct hvt *hvt = t;
+
+    assert(addr_start <= hvt->mem_size);
+    assert(addr_end <= hvt->mem_size);
+    assert(addr_start < addr_end);
+
+    uint8_t *vaddr_start = hvt->mem + addr_start;
+    assert(vaddr_start >= hvt->mem);
+    size_t size = addr_end - addr_start;
+    assert(size > 0 && size <= hvt->mem_size);
+
+    return mprotect(vaddr_start, size, prot);
+}

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -141,10 +141,10 @@ void hvt_drop_privileges()
 }
 #endif
 
-int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot)
 {
-    struct hvt *hvt = t;
+    struct hvt *hvt = t_arg;
 
     assert(addr_start <= hvt->mem_size);
     assert(addr_end <= hvt->mem_size);

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -155,5 +155,16 @@ int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
     size_t size = addr_end - addr_start;
     assert(size > 0 && size <= hvt->mem_size);
 
+    /*
+     * Host-side page protections:
+     *
+     * Ensure that guest-executable pages are not also executable in the host.
+     *
+     * Guest-side page protections:
+     *
+     * Manipulating guest-side (EPT) mappings is currently not supported by
+     * FreeBSD vmm, so there is nothing more we can do.
+     */
+    prot &= ~(PROT_EXEC);
     return mprotect(vaddr_start, size, prot);
 }

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -118,10 +118,10 @@ void hvt_drop_privileges()
 }
 #endif
 
-int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot)
 {
-    struct hvt *hvt = t;
+    struct hvt *hvt = t_arg;
 
     assert(addr_start <= hvt->mem_size);
     assert(addr_end <= hvt->mem_size);

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -117,3 +117,20 @@ void hvt_drop_privileges()
                 "Linux distribution and GCC version");
 }
 #endif
+
+int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+        int prot)
+{
+    struct hvt *hvt = t;
+
+    assert(addr_start <= hvt->mem_size);
+    assert(addr_end <= hvt->mem_size);
+    assert(addr_start < addr_end);
+
+    uint8_t *vaddr_start = hvt->mem + addr_start;
+    assert(vaddr_start >= hvt->mem);
+    size_t size = addr_end - addr_start;
+    assert(size > 0 && size <= hvt->mem_size);
+
+    return mprotect(vaddr_start, size, prot);
+}

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -132,5 +132,16 @@ int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
     size_t size = addr_end - addr_start;
     assert(size > 0 && size <= hvt->mem_size);
 
+    /*
+     * Host-side page protections:
+     *
+     * Ensure that guest-executable pages are not also executable in the host.
+     *
+     * Guest-side page protections:
+     *
+     * KVM will propagate guest-side R/W protections to its EPT mappings,
+     * guest-side X/NX protection is currently not supported by the hypervisor.
+     */
+    prot &= ~(PROT_EXEC);
     return mprotect(vaddr_start, size, prot);
 }

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
     struct hvt *hvt = hvt_init(mem_size);
 
     elf_load(elf_fd, elf_filename, hvt->mem, hvt->mem_size, HVT_GUEST_MIN_BASE,
-            &gpa_ep, &gpa_kend);
+            hvt_guest_mprotect, hvt, &gpa_ep, &gpa_kend);
     close(elf_fd);
 
     hvt_vcpu_init(hvt, gpa_ep);

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -180,5 +180,16 @@ int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
     size_t size = addr_end - addr_start;
     assert(size > 0 && size <= hvt->mem_size);
 
+    /*
+     * Host-side page protections:
+     *
+     * Ensure that guest-executable pages are not also executable in the host.
+     *
+     * Guest-side page protections:
+     *
+     * Manipulating guest-side (EPT) mappings is currently not supported by
+     * OpenBSD vmm, so there is nothing more we can do.
+     */
+    prot &= ~(PROT_EXEC);
     return mprotect(vaddr_start, size, prot);
 }

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -166,10 +166,10 @@ void hvt_drop_privileges()
 }
 #endif
 
-int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot)
 {
-    struct hvt *hvt = t;
+    struct hvt *hvt = t_arg;
 
     assert(addr_start <= hvt->mem_size);
     assert(addr_end <= hvt->mem_size);

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -165,3 +165,20 @@ void hvt_drop_privileges()
         err(errno, "pledge");
 }
 #endif
+
+int hvt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+        int prot)
+{
+    struct hvt *hvt = t;
+
+    assert(addr_start <= hvt->mem_size);
+    assert(addr_end <= hvt->mem_size);
+    assert(addr_start < addr_end);
+
+    uint8_t *vaddr_start = hvt->mem + addr_start;
+    assert(vaddr_start >= hvt->mem);
+    size_t size = addr_end - addr_start;
+    assert(size > 0 && size <= hvt->mem_size);
+
+    return mprotect(vaddr_start, size, prot);
+}

--- a/tenders/spt/spt.h
+++ b/tenders/spt/spt.h
@@ -45,6 +45,9 @@ struct spt {
 
 struct spt *spt_init(size_t mem_size);
 
+int spt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+        int prot);
+
 void spt_boot_info_init(struct spt *spt, uint64_t p_end, int cmdline_argc,
 	char **cmdline_argv, struct mft *mft, size_t mft_size);
 

--- a/tenders/spt/spt.h
+++ b/tenders/spt/spt.h
@@ -45,7 +45,7 @@ struct spt {
 
 struct spt *spt_init(size_t mem_size);
 
-int spt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+int spt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot);
 
 void spt_boot_info_init(struct spt *spt, uint64_t p_end, int cmdline_argc,

--- a/tenders/spt/spt_core.c
+++ b/tenders/spt/spt_core.c
@@ -146,10 +146,10 @@ struct spt *spt_init(size_t mem_size)
     return spt;
 }
 
-int spt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+int spt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot)
 {
-    struct spt *spt = t;
+    struct spt *spt = t_arg;
 
     assert(addr_start <= spt->mem_size);
     assert(addr_end <= spt->mem_size);

--- a/tenders/spt/spt_core.c
+++ b/tenders/spt/spt_core.c
@@ -160,6 +160,11 @@ int spt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
     size_t size = addr_end - addr_start;
     assert(size > 0 && size <= spt->mem_size);
 
+    /*
+     * On spt, there is no distinction between host-side and guest-side memory
+     * protection, so just pass through to mprotect() directly, which will do
+     * the right thing.
+     */
     return mprotect(vaddr_start, size, prot);
 }
 

--- a/tenders/spt/spt_core.c
+++ b/tenders/spt/spt_core.c
@@ -146,6 +146,23 @@ struct spt *spt_init(size_t mem_size)
     return spt;
 }
 
+int spt_guest_mprotect(void *t, uint64_t addr_start, uint64_t addr_end,
+        int prot)
+{
+    struct spt *spt = t;
+
+    assert(addr_start <= spt->mem_size);
+    assert(addr_end <= spt->mem_size);
+    assert(addr_start < addr_end);
+
+    uint8_t *vaddr_start = spt->mem + addr_start;
+    assert(vaddr_start >= spt->mem);
+    size_t size = addr_end - addr_start;
+    assert(size > 0 && size <= spt->mem_size);
+
+    return mprotect(vaddr_start, size, prot);
+}
+
 static void setup_cmdline(uint8_t *cmdline, int argc, char **argv)
 {
     size_t cmdline_free = SPT_CMDLINE_SIZE;

--- a/tenders/spt/spt_main.c
+++ b/tenders/spt/spt_main.c
@@ -221,7 +221,7 @@ int main(int argc, char **argv)
     struct spt *spt = spt_init(mem_size);
 
     elf_load(elf_fd, elf_filename, spt->mem, spt->mem_size, SPT_GUEST_MIN_BASE,
-            &p_entry, &p_end);
+            spt_guest_mprotect, spt, &p_entry, &p_end);
     close(elf_fd);
 
     setup_modules(spt, mft);


### PR DESCRIPTION
This allows for tender (spt, hvt) control over how page protection is applied to guest memory. This infrastructure is then used to ensure that guest-executable pages are not also host-executable.

See individual commits for details.

Fixes #390.

/cc @cfcs #370 #303