### PR TITLE
Implement tender/bindings ABI versioning

### DIFF
--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -1,16 +1,72 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is the custom linker script for the Solo5 'hvt' target.
+ *
+ * The script is tested to work with a minimal set of input sections. If there
+ * are unexpected input sections not named here, the result will probably not be
+ * correct.
+ */
+TEXT_START = 0x100000;
+
 ENTRY(_start)
 
-SECTIONS {
-    . = 0x100000;
+/*
+ * Program headers: In order to force the linker to place each of our NOTEs
+ * into a separate PT_NOTE header, we need to lay these out explicitly.
+ */
+PHDRS {
+    text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
+                              FLAGS values come from PF_x in elf.h */
+    data PT_LOAD;
+    note.abi PT_NOTE;
+    note.manifest PT_NOTE;
+}
 
-    /* Code */
+/*
+ * Output sections.
+ */
+SECTIONS {
+    . = TEXT_START; /* No + SIZEOF_HEADERS */
+
+    /*
+     * :text: The following input sections are placed in the R/E :text segment.
+     */
     _stext = .;
+
+    /* For Hvt, the ABI and MFT NOTEs are read-only and can be in :text. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :text :note.manifest
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :text :note.abi
 
     .text :
     {
         *(.text)
         *(.text.*)
-    }
+    } :text
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
@@ -21,11 +77,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    /* For Hvt, the manifest NOTE(s) are read-only. */
-    .note.solo5.manifest :
-    {
-        *(.note.solo5.manifest*)
-    }
     .eh_frame :
     {
         *(.eh_frame)
@@ -34,12 +85,16 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
+    /*
+     * :data: The following input sections are placed in the R/W :data segment.
+     */
+
     /* Read-write data (initialized) */
     .got :
     {
         *(.got.plt)
         *(.got)
-    }
+    } :data
     .data :
     {
         *(.data)

--- a/bindings/hvt/start.c
+++ b/bindings/hvt/start.c
@@ -48,3 +48,16 @@ void _start(void *arg)
     mem_lock_heap(&si.heap_start, &si.heap_size);
     solo5_exit(solo5_app_main(&si));
 }
+
+/*
+ * The "ABI1" Solo5 ELF note is declared in this module.
+ *
+ * TODO: We will want a separate start.c and muen_abi.h for Muen bindings, but
+ * this will work for now.
+ */
+ABI1_NOTE_DECLARE_BEGIN
+{
+    .abi_target = HVT_ABI_TARGET,
+    .abi_version = HVT_ABI_VERSION
+}
+ABI1_NOTE_DECLARE_END

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -1,16 +1,62 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is the custom linker script for the Solo5 'muen' target.
+ *
+ * The script is tested to work with a minimal set of input sections. If there
+ * are unexpected input sections not named here, the result will probably not be
+ * correct.
+ */
+TEXT_START = 0x100000;
+
 ENTRY(_start)
 
-SECTIONS {
-    . = 0x100000;
+/*
+ * Program headers: In order to force the linker to place each of our NOTEs
+ * into a separate PT_NOTE header, we need to lay these out explicitly.
+ */
+PHDRS {
+    text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
+                              FLAGS values come from PF_x in elf.h */
+    data PT_LOAD;
+    note.abi PT_NOTE;
+    note.manifest PT_NOTE;
+}
 
-    /* Code */
+/*
+ * Output sections.
+ */
+SECTIONS {
+    . = TEXT_START; /* No + SIZEOF_HEADERS */
+
+    /*
+     * :text: The following input sections are placed in the R/E :text segment.
+     */
     _stext = .;
 
     .text :
     {
         *(.text)
         *(.text.*)
-    }
+    } :text
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
@@ -29,22 +75,31 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
+    /*
+     * :data: The following input sections are placed in the R/W :data segment.
+     */
+
+    /* For Muen, the ABI and MFT NOTEs must be in an R/W segment, as they may
+     * be modified in-place by the bindings. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :data :note.manifest
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :data :note.abi
+
     /* Read-write data (initialized) */
     .got :
     {
         *(.got.plt)
         *(.got)
-    }
+    } :data
     .data :
     {
         *(.data)
         *(.data.*)
-    }
-    /* For Muen, the manifest NOTE(s) must be in a read-write section, as they
-     * may be modified in-place by the bindings. */
-    .note.solo5.manifest :
-    {
-        *(.note.solo5.manifest*)
     }
     .tdata :
     {

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -1,16 +1,73 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is the custom linker script for the Solo5 'spt' target.
+ *
+ * The script is tested to work with a minimal set of input sections. If there
+ * are unexpected input sections not named here, the result will probably not be
+ * correct.
+ */
+TEXT_START = 0x100000;
+
 ENTRY(_start)
 
-SECTIONS {
-    . = 0x100000;
+/*
+ * Program headers: In order to force the linker to place each of our NOTEs
+ * into a separate PT_NOTE header, we need lay these out explicitly.
+ */
+PHDRS {
+    text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
+                              FLAGS values come from PF_x in elf.h */
+    data PT_LOAD;
+    note.abi PT_NOTE;
+    note.manifest PT_NOTE;
+}
 
-    /* Code */
+/*
+ * Output sections.
+ */
+SECTIONS {
+    . = TEXT_START; /* No + SIZEOF_HEADERS */
+
+    /*
+     * :text: The following input sections are placed in the R/E :text segment.
+     */
     _stext = .;
+
+    /* For Spt, the ABI and MFT NOTEs are read-only and can be in :text. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :text :note.manifest
+
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :text :note.abi
 
     .text :
     {
         *(.text)
         *(.text.*)
-    }
+    } :text
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
@@ -21,11 +78,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    /* For Spt, the manifest NOTE(s) are read-only. */
-    .note.solo5.manifest :
-    {
-        *(.note.solo5.manifest*)
-    }
     .eh_frame :
     {
         *(.eh_frame)
@@ -34,12 +86,16 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
+    /*
+     * :data: The following input sections are placed in the R/W :data segment.
+     */
+
     /* Read-write data (initialized) */
     .got :
     {
         *(.got.plt)
         *(.got)
-    }
+    } :data
     .data :
     {
         *(.data)

--- a/bindings/spt/start.c
+++ b/bindings/spt/start.c
@@ -45,3 +45,13 @@ void _start(void *arg)
     mem_lock_heap(&si.heap_start, &si.heap_size);
     solo5_exit(solo5_app_main(&si));
 }
+
+/*
+ * The "ABI1" Solo5 ELF note is declared in this module.
+ */
+ABI1_NOTE_DECLARE_BEGIN
+{
+    .abi_target = SPT_ABI_TARGET,
+    .abi_version = SPT_ABI_VERSION
+}
+ABI1_NOTE_DECLARE_END

--- a/bindings/virtio/bindings.h
+++ b/bindings/virtio/bindings.h
@@ -30,6 +30,7 @@
 
 #include "../bindings.h"
 #include "multiboot.h"
+#include "virtio_abi.h"
 
 /* serial.c: console output for debugging */
 void serial_init(void);

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -1,9 +1,55 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is the custom linker script for the Solo5 'virtio' target.
+ *
+ * The script is tested to work with a minimal set of input sections. If there
+ * are unexpected input sections not named here, the result will probably not be
+ * correct.
+ */
+TEXT_START = 0x100000;
+
 ENTRY(_start)
 
-SECTIONS {
-    . = 0x100000;
+/*
+ * Program headers: In order to force the linker to place each of our NOTEs
+ * into a separate PT_NOTE header, we need to lay these out explicitly.
+ */
+PHDRS {
+    text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
+                              FLAGS values come from PF_x in elf.h */
+    data PT_LOAD;
+    note.abi PT_NOTE;
+    note.manifest PT_NOTE;
+}
 
-    /* Code */
+/*
+ * Output sections.
+ */
+SECTIONS {
+    . = TEXT_START; /* No + SIZEOF_HEADERS */
+
+    /*
+     * :text: The following input sections are placed in the R/E :text segment.
+     */
     _stext = .;
 
     .text :
@@ -11,7 +57,7 @@ SECTIONS {
         *(.data.multiboot)
         *(.text)
         *(.text.*)
-    }
+    } :text
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _etext = .;
@@ -30,22 +76,31 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
 
+    /*
+     * :data: The following input sections are placed in the R/W :data segment.
+     */
+
+    /* For Virtio, the ABI and MFT NOTEs must be in an R/W segment, as they may
+     * be modified in-place by the bindings. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :data :note.manifest
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :data :note.abi
+
     /* Read-write data (initialized) */
     .got :
     {
         *(.got.plt)
         *(.got)
-    }
+    } :data
     .data :
     {
         *(.data)
         *(.data.*)
-    }
-    /* For Virtio, the manifest NOTE(s) must be in a read-write section, as they
-     * may be modified in-place by the bindings. */
-    .note.solo5.manifest :
-    {
-        *(.note.solo5.manifest*)
     }
     .tdata :
     {

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -90,3 +90,13 @@ static void _start2(void *arg __attribute__((unused)))
     mem_lock_heap(&si.heap_start, &si.heap_size);
     solo5_exit(solo5_app_main(&si));
 }
+
+/*
+ * The "ABI1" Solo5 ELF note is declared in this module.
+ */
+ABI1_NOTE_DECLARE_BEGIN
+{
+    .abi_target = VIRTIO_ABI_TARGET,
+    .abi_version = VIRTIO_ABI_VERSION
+}
+ABI1_NOTE_DECLARE_END

--- a/include/solo5/hvt_abi.h
+++ b/include/solo5/hvt_abi.h
@@ -28,11 +28,29 @@
  * including it.
  */
 
-#ifndef HVT_GUEST_H
-#define HVT_GUEST_H
+#ifndef HVT_ABI_H
+#define HVT_ABI_H
 
 #include <stddef.h>
 #include <stdint.h>
+
+/*
+ * ABI version. This must be incremented before cutting a release of Solo5 if
+ * any material changes are made to the interfaces or data structures defined
+ * in this file.
+ */
+
+#define HVT_ABI_VERSION 1
+
+/*
+ * ABI target.
+ */
+
+#define HVT_ABI_TARGET 1
+/* #define SPT_ABI_TARGET 2 */
+/* #define VIRTIO_ABI_TARGET 3 */
+/* #define MUEN_ABI_TARGET 4 */
+/* #define GENODE_ABI_TARGET 5 */
 
 /*
  * Lowest virtual address at which guests can be loaded.
@@ -268,4 +286,80 @@ struct hvt_hc_halt {
     int exit_status;
 };
 
-#endif /* HVT_GUEST_H */
+/*
+ * HERE BE DRAGONS.
+ *
+ * The following structures and macros are used to declare a Solo5 "ABI1"
+ * format note at link time. This is somewhat tricky, as we need to ensure all
+ * structures are aligned correctly.
+ */
+#define ABI1_NOTE_NAME "Solo5"
+#define ABI1_NOTE_TYPE 0x31494241 /* "ABI1" */
+
+/*
+ * Defines an Elf64_Nhdr with n_name filled in and padded to a 4-byte boundary,
+ * i.e. the common part of a Solo5-owned Nhdr.
+ */
+struct abi1_nhdr {
+    uint32_t n_namesz;
+    uint32_t n_descsz;
+    uint32_t n_type;
+    char n_name[(sizeof(ABI1_NOTE_NAME) + 3) & -4];
+};
+
+_Static_assert((sizeof(struct abi1_nhdr)) ==
+        (sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t) + 8),
+        "struct abi1_nhdr alignment issue");
+
+/*
+ * Defines the entire note (header, descriptor content).
+ */
+struct abi1_info {
+    uint32_t abi_target;
+    uint32_t abi_version;
+};
+
+struct abi1_note {
+    struct abi1_nhdr h;
+    struct abi1_info i;
+};
+
+/*
+ * Internal alignment of (i) within struct abi1_note. Must be passed to
+ * elf_load_note() as note_align when loading.
+ */
+#define ABI1_NOTE_ALIGN offsetof(struct { char c; struct abi1_info i; }, i)
+
+_Static_assert((offsetof(struct abi1_note, i) & (ABI1_NOTE_ALIGN - 1)) == 0,
+        "struct abi1_note.i is not aligned to a ABI1_NOTE_ALIGN boundary");
+
+/*
+ * Maximum descsz of ABI1 ELF note descriptor (content), including
+ * internal alignment.
+ */
+#define ABI1_NOTE_MAX_SIZE ((sizeof (struct abi1_note) - \
+         sizeof (struct abi1_nhdr) + sizeof (struct abi1_info)))
+
+/*
+ * Declare a Solo5 "ABI1" format NOTE.
+ *
+ * Structure must be aligned to a 4-byte boundary (or possibly an 8-byte
+ * boundary, but ELF64 toolchains seem happy with the current arrangement...
+ * the specifications are mess).
+ */
+#define ABI1_NOTE_DECLARE_BEGIN \
+const struct abi1_note __solo5_abi1_note \
+__attribute__ ((section (".note.solo5.abi"), aligned(4))) \
+= { \
+    .h = { \
+        .n_namesz = sizeof(ABI1_NOTE_NAME), \
+        .n_descsz = (sizeof(struct abi1_note) - \
+                    sizeof(struct abi1_nhdr)), \
+        .n_type = ABI1_NOTE_TYPE, \
+        .n_name = ABI1_NOTE_NAME \
+    }, \
+    .i =
+
+#define ABI1_NOTE_DECLARE_END };
+
+#endif /* HVT_ABI_H */

--- a/include/solo5/mft_abi.h
+++ b/include/solo5/mft_abi.h
@@ -172,7 +172,7 @@ __attribute__ ((section (".note.solo5.manifest"), aligned(4))) \
         .n_type = MFT1_NOTE_TYPE, \
         .n_name = MFT1_NOTE_NAME \
     }, \
-    .m = \
+    .m =
 
 #define MFT1_NOTE_DECLARE_END };
 

--- a/include/solo5/virtio_abi.h
+++ b/include/solo5/virtio_abi.h
@@ -19,74 +19,37 @@
  */
 
 /*
- * spt_abi.h: spt guest/tender interface definitions.
+ * virtio_abi.h: virtio ABI definitions.
  *
  * This header file must be kept self-contained with no external dependencies
  * other than C99 headers.
+ *
+ * Virtio does not have an ABI contract (in the Solo5 sense) or use a tender.
+ * This file defines only the structures required to embed a Solo5 ABI NOTE in
+ * the ELF binary in order to be compatible with Solo5-specific tooling.
  */
 
-#ifndef SPT_ABI_H
-#define SPT_ABI_H
+#ifndef VIRTIO_ABI_H
+#define VIRTIO_ABI_H
 
 #include <stddef.h>
 #include <stdint.h>
 
 /*
- * ABI version. This must be incremented before cutting a release of Solo5 if
- * any material changes are made to the interfaces or data structures defined
- * in this file.
+ * ABI version. For virtio, this is always 1.
  */
 
-#define SPT_ABI_VERSION 1
+#define VIRTIO_ABI_VERSION 1
 
 /*
  * ABI target.
  */
 
 /* #define HVT_ABI_TARGET 1 */
-#define SPT_ABI_TARGET 2
-/* #define VIRTIO_ABI_TARGET 3 */
+/* #define SPT_ABI_TARGET 2 */
+#define VIRTIO_ABI_TARGET 3
 /* #define MUEN_ABI_TARGET 4 */
 /* #define GENODE_ABI_TARGET 5 */
-
-/*
- * Lowest virtual address at which guests can be loaded.
- */
-#define SPT_GUEST_MIN_BASE 0x100000
-
-/*
- * A pointer to this structure is passed by the tender as the sole argument to
- * the guest entrypoint.
- */
-struct spt_boot_info {
-    uint64_t mem_size;                  /* Memory size in bytes */
-    uint64_t kernel_end;                /* Address of end of kernel */
-    const char * cmdline;               /* Address of command line (C string) */
-    void *mft;                          /* Address of application manifest */
-    int epollfd;                        /* epoll() set for yield() */
-    int timerfd;                        /* internal timerfd for yield() */
-};
-
-/*
- * Identifier (data.u64) for internal timerfd in epoll() set.
- */
-#define SPT_INTERNAL_TIMERFD (~1U)
-
-/*
- * The lowest memory address at which we can mmap() memory on the host. See
- * spt_main.c for an explanation.
- */
-#define SPT_HOST_MEM_BASE 0x10000
-
-/*
- * Guest low memory layout.
- */
-#define SPT_BOOT_INFO_BASE (SPT_HOST_MEM_BASE + 0x1000)
-
-/*
- * Maximum size of guest command line, including the string terminator.
- */
-#define SPT_CMDLINE_SIZE 8192
 
 /*
  * HERE BE DRAGONS.
@@ -164,4 +127,4 @@ __attribute__ ((section (".note.solo5.abi"), aligned(4))) \
 
 #define ABI1_NOTE_DECLARE_END };
 
-#endif /* SPT_ABI_H */
+#endif /* VIRTIO_ABI_H */

--- a/tenders/common/elf.h
+++ b/tenders/common/elf.h
@@ -60,6 +60,11 @@ void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
  * will cause the executable to be rejected. (bin_name) is the file name of the
  * binary and is used to report errors.
  *
+ * XXX: In order to not have to deal with internal alignment issues and
+ * simplify parsing, this function only supports PT_NOTE headers containing a
+ * *single* NOTE descriptor. Refer to the Solo5 linker scripts for how to
+ * produce ELF binaries using this scheme.
+ *
  * Returns / error handling:
  *
  * On success: Returns 0 and memory for the note descriptor (content) is

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -130,7 +130,8 @@ static void usage(const char *prog)
 
 static void version(const char *prog)
 {
-    fprintf(stderr, "%s %s\n", prog, SOLO5_VERSION);
+    fprintf(stderr, "%s tender, version %s\n", prog, SOLO5_VERSION);
+    fprintf(stderr, "ABI version %u\n", HVT_ABI_VERSION);
     exit(0);
 }
 
@@ -165,8 +166,8 @@ int main(int argc, char **argv)
 
         if (strcmp("--help", *argv1) == 0)
             usage(prog);
-	else if(strcmp("--version", *argv1) == 0)
-	    version(prog);
+        else if(strcmp("--version", *argv1) == 0)
+            version(prog);
 
         argc1--;
         argv1++;
@@ -178,12 +179,27 @@ int main(int argc, char **argv)
     elf_filename = *argv1;
 
     /*
-     * Now that we have the ELF file name, try and load the manifest from it,
-     * as subsequent parsing of the command line in the 2nd pass depends on it.
+     * Now that we have the ELF file name, verify that is binary is
+     * ABI-compatible and load the MFT1 NOTE from it, as subsequent parsing of
+     * the command line in the 2nd pass depends on the application-supplied
+     * manifest.
      */
     elf_fd = open(elf_filename, O_RDONLY);
     if (elf_fd == -1)
         err(1, "%s: Could not open", elf_filename);
+
+    struct abi1_info *abi1;
+    size_t abi1_size;
+    if (elf_load_note(elf_fd, elf_filename, ABI1_NOTE_TYPE, ABI1_NOTE_ALIGN,
+                ABI1_NOTE_MAX_SIZE, (void **)&abi1, &abi1_size) == -1)
+        errx(1, "%s: No Solo5 ABI information found in executable",
+                elf_filename);
+    if (abi1->abi_target != HVT_ABI_TARGET)
+        errx(1, "%s: Executable is not for the solo5-hvt target", elf_filename);
+    if (abi1->abi_version != HVT_ABI_VERSION)
+        errx(1, "%s: Executable requests unsupported ABI version %u",
+                elf_filename, abi1->abi_version);
+    free(abi1);
 
     struct mft *mft;
     size_t mft_size;
@@ -243,7 +259,7 @@ int main(int argc, char **argv)
 
     elf_load(elf_fd, elf_filename, hvt->mem, hvt->mem_size, HVT_GUEST_MIN_BASE,
             hvt_guest_mprotect, hvt, &gpa_ep, &gpa_kend);
-    close(elf_fd);
+    close(elf_fd);                      /* Done with ELF binary */
 
     hvt_vcpu_init(hvt, gpa_ep);
 


### PR DESCRIPTION
    You are wandering around the dark corners of the ELF toolchain. 
    You are likely to be eaten by a grue.

As outlined in https://github.com/Solo5/solo5/issues/372#issuecomment-525272670.

----

This change introduces an additional Solo5-owned ELF note, "ABI1", which is used to embed information about the backend target (hvt, spt, ...) and internal tender/bindings ABI version of a unikernel binary linked with the Solo5 bindings.

The internal ABI version is defined as a single uint32_t value, starting at 1. The spt and hvt tenders now refuse to load a binary whose ABI version does not match that of the tender.

----

This is a first draft, and the scheme we are using may yet change. I need to consult with some GCC / LLVM toolchain experts over the next days to be sure that our approach to ELF NOTEs is correct and won't break unexpectedly in the future.

@ricarkol Note that _in it's current state_, this will need linker script changes for libOSes not using the Solo5 linker scripts. No way around that unfortunately, as the default linker behaviour is to pack all input `.note` sections into a single output `PT_NOTE` segment.

@Kensan The Muen linker script is speculative, but I expect that you will need the built-in MFT1 in a R/W segment (`:data`).

@ehmry Probably doesn't concern Genode, but you may or may not want a similar scheme.

@cfcs Please take a look.