### PR TITLE
Add "type" field to manifest JSON, better elftool

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,7 @@ customarily named `manifest.json`:
 
 ```
 {
+    "type" = "solo5.manifest",
     "version" = 1,
     "devices" = [
         { "name" = "<NAME>", "type" = "<TYPE>" },
@@ -109,9 +110,9 @@ customarily named `manifest.json`:
 }
 ```
 
-_NAME_ is a human-readable unique identifier for the device. The intention is
-that the name conveys some meaning of the intended use ("wiring") of the
-device, eg. `frontend` for a network or `storage` for a block device.
+_NAME_ is a unique logical identifier (a.k.a. "pet name") for the device. The
+intention is that the name conveys some meaning of the intended use ("wiring")
+of the device, eg. `frontend` for a network or `storage` for a block device.
 
 _NAME_ must be composed of alphanumeric characters only, and within 1..67
 characters in length.
@@ -125,6 +126,9 @@ At unikernel build time, `manifest.json` is pre-processed by `solo5-elftool`,
 generating a C source file with a binary representation. This source file is
 then compiled using `cc` from the Solo5 toolchain, and linked into the
 unikernel binary, where it is represented as an ELF "NOTE".
+
+Additionally, `solo5-elftool` provides the `query-manifest` subcommand to
+extract the binary manifest from a unikernel binary and display it as JSON.
 
 ## Public API, _Tenders_ and _Bindings_
 

--- a/tests/Makefile.tests
+++ b/tests/Makefile.tests
@@ -42,7 +42,7 @@ ELFTOOL := $(TOPDIR)/elftool/solo5-elftool
 
 manifest.c: manifest.json ../../include/solo5/mft_abi.h $(ELFTOOL)
 	@echo "ELFTOOL $<"
-	$(ELFTOOL) gen $< $@
+	$(ELFTOOL) gen-manifest $< $@
 
 %.o: %.c ../../include/solo5/solo5.h
 	@echo "CC $<"

--- a/tests/test_blk/manifest.json
+++ b/tests/test_blk/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ { "name": "storage", "type": "BLOCK_BASIC" } ]
 }

--- a/tests/test_dumpcore/manifest.json
+++ b/tests/test_dumpcore/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_exception/manifest.json
+++ b/tests/test_exception/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_fpu/manifest.json
+++ b/tests/test_fpu/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_globals/manifest.json
+++ b/tests/test_globals/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_hello/manifest.json
+++ b/tests/test_hello/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_mft_maxdevices/manifest.json
+++ b/tests/test_mft_maxdevices/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [
         { "name": "storage0", "type": "BLOCK_BASIC" },

--- a/tests/test_net/manifest.json
+++ b/tests/test_net/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ { "name": "service0", "type": "NET_BASIC" } ]
 }

--- a/tests/test_net_2if/manifest.json
+++ b/tests/test_net_2if/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [
         { "name": "service0", "type": "NET_BASIC" },

--- a/tests/test_notls/manifest.json
+++ b/tests/test_notls/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_quiet/manifest.json
+++ b/tests/test_quiet/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_seccomp/manifest.json
+++ b/tests/test_seccomp/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_ssp/manifest.json
+++ b/tests/test_ssp/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_time/manifest.json
+++ b/tests/test_time/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_tls/manifest.json
+++ b/tests/test_tls/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_wnox/manifest.json
+++ b/tests/test_wnox/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_xnow/manifest.json
+++ b/tests/test_xnow/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }

--- a/tests/test_zeropage/manifest.json
+++ b/tests/test_zeropage/manifest.json
@@ -1,4 +1,5 @@
 {
+    "type": "solo5.manifest",
     "version": 1,
     "devices": [ ]
 }


### PR DESCRIPTION
As discussed in #399.

Add a "type" field to the manifest JSON format. Improve elftool UX,
renaming "gen" to "gen-manifest", "dump" to "query-manifest" and "abi"
to "query-abi", the last of which now also outputs the ABI information
as structured JSON.