### PR TITLE
Implement Multidevice support for Muen

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -31,24 +31,28 @@ $(V).SILENT:
 common_SRCS := abort.c cpu_$(CONFIG_ARCH).c cpu_vectors_$(CONFIG_ARCH).S \
     crt.c printf.c intr.c lib.c mem.c exit.c log.c cmdline.c tls.c mft.c
 
-common_hvt_SRCS := hvt/start.c hvt/platform.c hvt/platform_intr.c hvt/time.c
+common_hvt_SRCS := hvt/platform.c hvt/platform_intr.c hvt/time.c
 
-hvt_SRCS := $(common_SRCS) $(common_hvt_SRCS) \
+#
+# Note that the module defining _start should be listed first in <target>_SRCS,
+# in order to ensure that _start has a stable address (required for Muen).
+#
+hvt_SRCS := hvt/start.c $(common_SRCS) $(common_hvt_SRCS) \
     hvt/platform_lifecycle.c hvt/yield.c hvt/tscclock.c hvt/console.c \
     hvt/net.c hvt/block.c
 
-spt_SRCS := abort.c crt.c printf.c lib.c mem.c exit.c log.c cmdline.c tls.c \
-    mft.c \
-    spt/bindings.c spt/block.c spt/net.c spt/platform.c spt/start.c \
+spt_SRCS := spt/start.c \
+    abort.c crt.c printf.c lib.c mem.c exit.c log.c cmdline.c tls.c mft.c \
+    spt/bindings.c spt/block.c spt/net.c spt/platform.c \
     spt/sys_linux_$(CONFIG_ARCH).c
 
-virtio_SRCS := $(common_SRCS) \
-    virtio/boot.S virtio/start.c virtio/platform.c virtio/platform_intr.c \
+virtio_SRCS := virtio/boot.S virtio/start.c $(common_SRCS) \
+    virtio/platform.c virtio/platform_intr.c \
     virtio/pci.c virtio/serial.c virtio/time.c virtio/virtio_ring.c \
     virtio/virtio_net.c virtio/virtio_blk.c virtio/tscclock.c \
     virtio/clock_subr.c virtio/pvclock.c 
 
-muen_SRCS := $(common_SRCS) $(common_hvt_SRCS) \
+muen_SRCS := muen/start.c $(common_SRCS) $(common_hvt_SRCS) \
     muen/channel.c muen/reader.c muen/writer.c muen/muen-block.c \
     muen/muen-clock.c muen/muen-console.c muen/muen-net.c \
     muen/muen-platform_lifecycle.c muen/muen-yield.c muen/muen-sinfo.c

--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -52,16 +52,6 @@ SECTIONS {
      */
     _stext = .;
 
-    /* For Hvt, the ABI and MFT NOTEs are read-only and can be in :text. */
-    .note.solo5.manifest :
-    {
-        *(.note.solo5.manifest*)
-    } :text :note.manifest
-    .note.solo5.abi :
-    {
-        *(.note.solo5.abi*)
-    } :text :note.abi
-
     .text :
     {
         *(.text)
@@ -72,11 +62,22 @@ SECTIONS {
     _etext = .;
 
     /* Read-only data */
+
+    /* For Hvt, the ABI and MFT NOTEs are read-only and can be in :text. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :text :note.manifest
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :text :note.abi
+
     .rodata :
     {
         *(.rodata)
         *(.rodata.*)
-    }
+    } :text
     .eh_frame :
     {
         *(.eh_frame)
@@ -122,4 +123,10 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
+
+    /* We are not building a GNU executable, so discard any default NOTEs the
+       toolchain might generate to prevent any surprises in the final layout. */
+    /DISCARD/ : {
+        *(.note.gnu.*)
+    }
 }

--- a/bindings/muen/bindings.h
+++ b/bindings/muen/bindings.h
@@ -19,24 +19,31 @@
  */
 
 /*
- * virtio_abi.h: virtio ABI definitions.
+ * bindings.h: Solo5 bindings, muen implementation additions.
  *
- * This header file must be kept self-contained with no external dependencies
- * other than C99 headers.
+ * This header file includes (supersedes) the common bindings.h for the muen
+ * implementation.
  *
- * Virtio does not have an ABI contract (in the Solo5 sense) or use a tender, so
- * all we need to define here is an ABI version to go in the Solo5 ABI1 NOTE.
+ * TODO: Remove the dependency on hvt_abi.h entirely?
  */
 
-#ifndef VIRTIO_ABI_H
-#define VIRTIO_ABI_H
+#ifndef __MUEN_BINDINGS_H__
+#define __MUEN_BINDINGS_H__
 
+#include "../bindings.h"
+#include "hvt_abi.h"
 #include "elf_abi.h"
 
-/*
- * ABI version. For virtio, this is always 1.
- */
+void time_init(struct hvt_boot_info *bi);
+void console_init(void);
+void net_init(struct hvt_boot_info *bi);
+void block_init(struct hvt_boot_info *bi);
 
-#define VIRTIO_ABI_VERSION 1
+/* muen-clock.c: TSC-based clock */
+uint64_t tscclock_monotonic(void);
+int tscclock_init(uint64_t tsc_freq);
+uint64_t tscclock_epochoffset(void);
 
-#endif /* VIRTIO_ABI_H */
+void process_bootinfo(void *arg);
+
+#endif /* __MUEN_BINDINGS_H__ */

--- a/bindings/muen/muen-block.c
+++ b/bindings/muen/muen-block.c
@@ -18,23 +18,31 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../bindings.h"
+#include "../hvt/bindings.h"
 
-solo5_result_t solo5_block_write(solo5_off_t offset __attribute__((unused)),
-                         const uint8_t *buf __attribute__((unused)),
-                         size_t size __attribute__((unused)))
+solo5_result_t solo5_block_acquire(const char *name __attribute__((unused)),
+        solo5_handle_t *handle __attribute__((unused)),
+        struct solo5_block_info *info __attribute__((unused)))
 {
     return SOLO5_R_EUNSPEC;
 }
 
-solo5_result_t solo5_block_read(solo5_off_t offset __attribute__((unused)),
-                        uint8_t *buf __attribute__((unused)),
-                        size_t size __attribute__((unused)))
+solo5_result_t solo5_block_write(solo5_handle_t handle __attribute__((unused)),
+        solo5_off_t offset __attribute__((unused)),
+        const uint8_t *buf __attribute__((unused)),
+        size_t size __attribute__((unused)))
 {
     return SOLO5_R_EUNSPEC;
 }
 
-void solo5_block_info(struct solo5_block_info *info __attribute__((unused)))
+solo5_result_t solo5_block_read(solo5_handle_t handle __attribute__((unused)),
+        solo5_off_t offset __attribute__((unused)),
+        uint8_t *buf __attribute__((unused)),
+        size_t size __attribute__((unused)))
 {
-    assert(0);
+    return SOLO5_R_EUNSPEC;
+}
+
+void block_init(struct hvt_boot_info *bi __attribute__((unused)))
+{
 }

--- a/bindings/muen/muen-block.c
+++ b/bindings/muen/muen-block.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../hvt/bindings.h"
+#include "bindings.h"
 
 solo5_result_t solo5_block_acquire(const char *name __attribute__((unused)),
         solo5_handle_t *handle __attribute__((unused)),

--- a/bindings/muen/muen-clock.c
+++ b/bindings/muen/muen-clock.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../bindings.h"
+#include "bindings.h"
 #include "sinfo.h"
 #include "mutimeinfo.h"
 

--- a/bindings/muen/muen-console.c
+++ b/bindings/muen/muen-console.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../bindings.h"
+#include "bindings.h"
 #include "sinfo.h"
 #include "writer.h"
 

--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -126,7 +126,7 @@ bool muen_net_pending_data(solo5_handle_t handle)
                                          &net_devices[handle].net_rdr);
 }
 
-void generate_mac_addr(uint8_t *addr)
+static void generate_mac_addr(uint8_t *addr)
 {
     const char *subject_name = muen_get_subject_name();
     uint64_t data;

--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -18,6 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "mft_abi.h"
 #include "../hvt/bindings.h"
 #include "sinfo.h"
 #include "reader.h"
@@ -31,15 +32,31 @@ struct net_msg {
     uint16_t length;
 } __attribute__((packed));
 
-static struct muchannel *net_in;
-static struct muchannel *net_out;
-static struct muchannel_reader net_rdr;
+struct muen_net_device {
+    bool acquired;
+    uint8_t mac_addr[SOLO5_NET_ALEN];
+    struct muchannel *net_in;
+    struct muchannel *net_out;
+    struct muchannel_reader net_rdr;
+};
 
-static uint8_t mac_addr[6];
+extern struct mft *muen_manifest;
 
-solo5_result_t solo5_net_write(const uint8_t *buf, size_t size)
+static struct muen_net_device net_devices[MFT_MAX_ENTRIES];
+
+/**
+ * Initialize Muen network device with given name.
+ */
+static bool muen_net_dev_init(const char *name, struct muen_net_device *device,
+        struct solo5_net_info *info);
+
+solo5_result_t solo5_net_write(solo5_handle_t handle,
+        const uint8_t *buf, size_t size)
 {
     struct net_msg pkt;
+
+    if (handle >= MFT_MAX_ENTRIES || !net_devices[handle].acquired)
+        return SOLO5_R_EINVAL;
 
     if (size > PACKET_SIZE)
         return SOLO5_R_EINVAL;
@@ -48,20 +65,25 @@ solo5_result_t solo5_net_write(const uint8_t *buf, size_t size)
     cc_barrier();
     pkt.length = size;
     memcpy(&pkt.data, buf, size);
-    muen_channel_write(net_out, &pkt);
+    muen_channel_write(net_devices[handle].net_out, &pkt);
 
     return SOLO5_R_OK;
 }
 
-solo5_result_t solo5_net_read(uint8_t *buf, size_t size, size_t *read_size)
+solo5_result_t solo5_net_read(solo5_handle_t handle,
+        uint8_t *buf, size_t size, size_t *read_size)
 {
     enum muchannel_reader_result result;
     struct net_msg pkt;
 
+    if (handle >= MFT_MAX_ENTRIES || !net_devices[handle].acquired)
+        return SOLO5_R_EINVAL;
+
     if (size < PACKET_SIZE)
         return SOLO5_R_EINVAL;
 
-    result = muen_channel_read(net_in, &net_rdr, &pkt);
+    result = muen_channel_read(net_devices[handle].net_in,
+                               &net_devices[handle].net_rdr, &pkt);
     if (result == MUCHANNEL_SUCCESS) {
         memcpy(buf, &pkt.data, pkt.length);
         *read_size = pkt.length;
@@ -71,16 +93,38 @@ solo5_result_t solo5_net_read(uint8_t *buf, size_t size, size_t *read_size)
     }
 }
 
-bool muen_net_pending_data()
+solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *h,
+        struct solo5_net_info *info)
 {
-    return muen_channel_has_pending_data(net_in, &net_rdr);
+    solo5_handle_t handle = 0;
+    unsigned mft_index;
+    struct mft_entry *mft_e = mft_get_by_name(muen_manifest, name,
+            MFT_DEV_NET_BASIC, &mft_index);
+    if (mft_e == NULL)
+        return SOLO5_R_EINVAL;
+
+    handle = mft_index;
+
+    if (net_devices[handle].acquired) {
+        log(WARN, "Solo5: Net: Device '%s' already acquired\n", name);
+        return SOLO5_R_EINVAL;
+    }
+
+    if (!muen_net_dev_init(name, &net_devices[handle], info))
+        return SOLO5_R_EINVAL;
+
+    *h = handle;
+    net_devices[handle].acquired = true;
+    log(INFO, "Solo5: Application acquired '%s' as network device\n", name);
+    return SOLO5_R_OK;
 }
 
-/* TODO: Support configured MAC address */
-void solo5_net_info(struct solo5_net_info *info)
+bool muen_net_pending_data(solo5_handle_t handle)
 {
-    memcpy(info->mac_address, mac_addr, sizeof info->mac_address);
-    info->mtu = 1500;
+    return handle < MFT_MAX_ENTRIES
+        && net_devices[handle].acquired
+        && muen_channel_has_pending_data(net_devices[handle].net_in,
+                                         &net_devices[handle].net_rdr);
 }
 
 void generate_mac_addr(uint8_t *addr)
@@ -103,62 +147,82 @@ void generate_mac_addr(uint8_t *addr)
     addr[0] |= 0x02;
 }
 
-void net_init(void)
+static bool muen_net_dev_init(const char *name, struct muen_net_device *device,
+        struct solo5_net_info *info)
 {
-    char mac_str[18];
+    assert(!device->acquired);
     const uint64_t epoch = muen_get_sched_start();
+    char mac_str[18];
+    char buffer[64];
+    const int retval = snprintf(buffer, sizeof buffer, "%s|out", name);
+    assert(retval > 0 && (unsigned)retval < sizeof buffer);
     const struct muen_resource_type *const
-        chan_out = muen_get_resource("net_out", MUEN_RES_MEMORY);
+        chan_out = muen_get_resource(buffer, MUEN_RES_MEMORY);
+	snprintf(buffer, sizeof buffer, "%s|in", name);
     const struct muen_resource_type *const
-        chan_in = muen_get_resource("net_in", MUEN_RES_MEMORY);
+        chan_in = muen_get_resource(buffer, MUEN_RES_MEMORY);
 
     if (!chan_out) {
-        log(WARN, "Solo5: Net: No output channel\n");
-        return;
+        log(WARN, "Solo5: Net: '%s': No output channel\n", name);
+        return false;
     }
     if (!(chan_out->data.mem.flags & MEM_CHANNEL_FLAG)) {
-        log(WARN, "Solo5: Net: Memory '%s' is not a channel\n",
-            chan_out->name.data);
-        return;
+        log(WARN, "Solo5: Net: '%s': Memory '%s' is not a channel\n",
+            name, chan_out->name.data);
+        return false;
     }
     if (!(chan_out->data.mem.flags & MEM_WRITABLE_FLAG)) {
-        log(WARN, "Solo5: Net: Output channel '%s' not writable\n",
-            chan_out->name.data);
-        return;
+        log(WARN, "Solo5: Net: '%s': Output channel '%s' not writable\n",
+            name, chan_out->name.data);
+        return false;
     }
 
-    net_out = (struct muchannel *)(chan_out->data.mem.address);
-    muen_channel_init_writer(net_out, MUENNET_PROTO, sizeof(struct net_msg),
+    if (!chan_in) {
+        log(WARN, "Solo5: Net: '%s': No input channel\n", name);
+        return false;
+    }
+    if (!(chan_in->data.mem.flags & MEM_CHANNEL_FLAG)) {
+        log(WARN, "Solo5: Net: '%s': Memory '%s' is not a channel\n",
+            name, chan_in->name.data);
+        return false;
+    }
+    if (chan_in->data.mem.flags & MEM_WRITABLE_FLAG) {
+        log(DEBUG, "Solo5: Net: '%s': Input channel '%s' is writable\n",
+            name, chan_in->name.data);
+    }
+
+    device->net_out = (struct muchannel *)(chan_out->data.mem.address);
+    muen_channel_init_writer(device->net_out, MUENNET_PROTO, sizeof(struct net_msg),
                              chan_out->data.mem.size, epoch);
-    log(INFO, "Solo5: Net: Muen shared memory stream, protocol 0x%llx\n",
-        MUENNET_PROTO);
-    log(INFO, "Solo5: Net: Output channel @ 0x%llx, size 0x%llx, epoch 0x%llx\n",
+    log(INFO, "Solo5: Net: '%s': Muen shared memory stream, protocol 0x%llx\n",
+        name, MUENNET_PROTO);
+    log(INFO, "Solo5: Net: '%s': Output channel @ 0x%llx, size 0x%llx, epoch 0x%llx\n",
+        name,
         (unsigned long long)chan_out->data.mem.address,
         (unsigned long long)chan_out->data.mem.size, (unsigned long long)epoch);
 
-    if (!chan_in) {
-        log(WARN, "Solo5: Net: No input channel\n");
-        return;
-    }
-    if (!(chan_in->data.mem.flags & MEM_CHANNEL_FLAG)) {
-        log(WARN, "Solo5: Net: Memory '%s' is not a channel\n",
-            chan_in->name.data);
-        return;
-    }
-    if (chan_in->data.mem.flags & MEM_WRITABLE_FLAG) {
-        log(DEBUG, "Solo5: Net: Input channel '%s' is writable\n",
-            chan_in->name.data);
-    }
-
-    net_in = (struct muchannel *)(chan_in->data.mem.address);
-    muen_channel_init_reader(&net_rdr, MUENNET_PROTO);
-    log(INFO, "Solo5: Net: Input  channel @ 0x%llx, size 0x%llx\n",
+    device->net_in = (struct muchannel *)(chan_in->data.mem.address);
+    muen_channel_init_reader(&device->net_rdr, MUENNET_PROTO);
+    log(INFO, "Solo5: Net: '%s': Input  channel @ 0x%llx, size 0x%llx\n",
+        name,
         (unsigned long long)chan_in->data.mem.address,
         (unsigned long long)chan_in->data.mem.size);
 
-    generate_mac_addr(mac_addr);
+    generate_mac_addr(device->mac_addr);
     snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
-             mac_addr[0], mac_addr[1], mac_addr[2],
-             mac_addr[3], mac_addr[4], mac_addr[5]);
-    log(INFO, "Solo5: Net: Using MAC address %s\n", mac_str);
+             device->mac_addr[0], device->mac_addr[1], device->mac_addr[2],
+             device->mac_addr[3], device->mac_addr[4], device->mac_addr[5]);
+    memcpy(info->mac_address, device->mac_addr, sizeof info->mac_address);
+    info->mtu = 1500;
+    log(INFO, "Solo5: Net: '%s': Using MAC address %s\n", name, mac_str);
+    return true;
+}
+
+void net_init(struct hvt_boot_info *bi __attribute__((unused)))
+{
+    for (solo5_handle_t i = 0U; i < MFT_MAX_ENTRIES; ++i) {
+        net_devices[i].acquired = false;
+        net_devices[i].net_in = NULL;
+        net_devices[i].net_out = NULL;
+    }
 }

--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -18,8 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "mft_abi.h"
-#include "../hvt/bindings.h"
+#include "bindings.h"
 #include "sinfo.h"
 #include "reader.h"
 #include "writer.h"

--- a/bindings/muen/muen-net.h
+++ b/bindings/muen/muen-net.h
@@ -22,8 +22,8 @@
 #define MUEN_NET_H
 
 /*
- * Returns True if there is pending network data.
+ * Returns True if the network device designated by handle has pending data.
  */
-bool muen_net_pending_data();
+bool muen_net_pending_data(solo5_handle_t handle);
 
 #endif

--- a/bindings/muen/muen-platform_lifecycle.c
+++ b/bindings/muen/muen-platform_lifecycle.c
@@ -20,16 +20,35 @@
 
 #include "../hvt/bindings.h"
 
+struct mft *muen_manifest = NULL;
+
 void fpu_init(void)
 {
     const unsigned default_mxcsr = 0x1f80;
     __asm__ __volatile__("ldmxcsr %0" : : "m"(default_mxcsr));
 }
 
+extern struct mft1_note __solo5_mft1_note;
+
 void platform_init(void *arg)
 {
     process_bootinfo(arg);
     fpu_init();
+
+    /*
+     * Get the built-in manifest "out of" the ELF NOTE and validate it. Note
+     * that the size must be adjusted from n_descsz to remove any internal
+     * alignment. Once validated, it is available for access globally by the
+     * bindings.
+     */
+    struct mft *mft = &__solo5_mft1_note.m;
+    size_t mft_size = __solo5_mft1_note.h.n_descsz -
+        (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
+    if (mft_validate(mft, mft_size) != 0) {
+        log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
+        solo5_abort();
+    }
+    muen_manifest = mft;
 }
 
 void platform_exit(int status __attribute__((unused)),

--- a/bindings/muen/muen-platform_lifecycle.c
+++ b/bindings/muen/muen-platform_lifecycle.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../hvt/bindings.h"
+#include "bindings.h"
 
 struct mft *muen_manifest = NULL;
 

--- a/bindings/muen/muen-sinfo.c
+++ b/bindings/muen/muen-sinfo.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../bindings.h"
+#include "bindings.h"
 
 #include "sinfo.h"
 #include "muschedinfo.h"

--- a/bindings/muen/muen-yield.c
+++ b/bindings/muen/muen-yield.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../bindings.h"
+#include "bindings.h"
 #include "muen-net.h"
 
 void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)

--- a/bindings/muen/muen-yield.c
+++ b/bindings/muen/muen-yield.c
@@ -21,20 +21,22 @@
 #include "../bindings.h"
 #include "muen-net.h"
 
-bool solo5_yield(uint64_t deadline)
+void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
 {
-    bool rc = false;
+    solo5_handle_set_t tmp_ready_set = 0;
+
     do {
-        if (muen_net_pending_data()) {
-            rc = true;
-            break;
+        for (solo5_handle_t i = 0U; i < MFT_MAX_ENTRIES; ++i) {
+            if (muen_net_pending_data(i))
+                tmp_ready_set |= 1UL << i;
         }
+
+        if (tmp_ready_set > 0)
+            break;
+
         __asm__ __volatile__("pause");
     } while (solo5_clock_monotonic() < deadline);
 
-    if (muen_net_pending_data()) {
-        rc = true;
-    }
-
-    return rc;
+    if (ready_set)
+        *ready_set = tmp_ready_set;
 }

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -62,11 +62,22 @@ SECTIONS {
     _etext = .;
 
     /* Read-only data */
+
+    /* For Muen, the ABI and MFT NOTEs are read-only and can be in :text. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :text :note.manifest
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :text :note.abi
+
     .rodata :
     {
         *(.rodata)
         *(.rodata.*)
-    }
+    } :text
     .eh_frame :
     {
         *(.eh_frame)
@@ -78,17 +89,6 @@ SECTIONS {
     /*
      * :data: The following input sections are placed in the R/W :data segment.
      */
-
-    /* For Muen, the ABI and MFT NOTEs must be in an R/W segment, as they may
-     * be modified in-place by the bindings. */
-    .note.solo5.manifest :
-    {
-        *(.note.solo5.manifest*)
-    } :data :note.manifest
-    .note.solo5.abi :
-    {
-        *(.note.solo5.abi*)
-    } :data :note.abi
 
     /* Read-write data (initialized) */
     .got :
@@ -123,4 +123,10 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
+
+    /* We are not building a GNU executable, so discard any default NOTEs the
+       toolchain might generate to prevent any surprises in the final layout. */
+    /DISCARD/ : {
+        *(.note.gnu.*)
+    }
 }

--- a/bindings/muen/util.h
+++ b/bindings/muen/util.h
@@ -21,7 +21,7 @@
 #ifndef MUEN_UTIL_H
 #define MUEN_UTIL_H
 
-#include "../bindings.h"
+#include "bindings.h"
 
 static inline void serialized_copy(const uint64_t * const src, uint64_t *dst)
 {

--- a/bindings/muen/writer.c
+++ b/bindings/muen/writer.c
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "../bindings.h"
+#include "bindings.h"
 #include "writer.h"
 #include "util.h"
 

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -52,6 +52,17 @@ SECTIONS {
      */
     _stext = .;
 
+    .text :
+    {
+        *(.text)
+        *(.text.*)
+    } :text
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    _etext = .;
+
+    /* Read-only data */
+
     /* For Spt, the ABI and MFT NOTEs are read-only and can be in :text. */
     .note.solo5.manifest :
     {
@@ -63,21 +74,11 @@ SECTIONS {
         *(.note.solo5.abi*)
     } :text :note.abi
 
-    .text :
-    {
-        *(.text)
-        *(.text.*)
-    } :text
-
-    . = ALIGN(CONSTANT(MAXPAGESIZE));
-    _etext = .;
-
-    /* Read-only data */
     .rodata :
     {
         *(.rodata)
         *(.rodata.*)
-    }
+    } :text
     .eh_frame :
     {
         *(.eh_frame)
@@ -123,4 +124,10 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
+
+    /* We are not building a GNU executable, so discard any default NOTEs the
+       toolchain might generate to prevent any surprises in the final layout. */
+    /DISCARD/ : {
+        *(.note.gnu.*)
+    }
 }

--- a/bindings/virtio/bindings.h
+++ b/bindings/virtio/bindings.h
@@ -30,7 +30,7 @@
 
 #include "../bindings.h"
 #include "multiboot.h"
-#include "virtio_abi.h"
+#include "elf_abi.h"
 
 /* serial.c: console output for debugging */
 void serial_init(void);

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -124,4 +124,10 @@ SECTIONS {
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
+
+    /* We are not building a GNU executable, so discard any default NOTEs the
+       toolchain might generate to prevent any surprises in the final layout. */
+    /DISCARD/ : {
+        *(.note.gnu.*)
+    }
 }

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -210,12 +210,12 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *h,
         MFT_DEV_BLOCK_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;
-    blk_handle = (solo5_handle_t)mft_index;
+    blk_handle = mft_index;
     blk_acquired = true;
 
     info->block_size = VIRTIO_BLK_SECTOR_SIZE;
     info->capacity = virtio_blk_sectors * VIRTIO_BLK_SECTOR_SIZE;
-    *h = (solo5_handle_t)mft_index;
+    *h = mft_index;
     log(INFO, "Solo5: Application acquired '%s' as block device\n", name);
     return SOLO5_R_OK;
 }

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -296,12 +296,12 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *h,
             MFT_DEV_NET_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;
-    net_handle = (solo5_handle_t)mft_index;
+    net_handle = mft_index;
     net_acquired = true;
 
     memcpy(info->mac_address, virtio_net_mac, sizeof info->mac_address);
     info->mtu = 1500;
-    *h = (solo5_handle_t)mft_index;
+    *h = mft_index;
     log(INFO, "Solo5: Application acquired '%s' as network device\n", name);
     return SOLO5_R_OK;
 }

--- a/configure.sh
+++ b/configure.sh
@@ -292,12 +292,6 @@ case "${CONFIG_HOST}" in
         ;;
 esac
 
-# TODO: Re-enable muen once multiple-device support is available.
-if [ "${CONFIG_MUEN}" = "1" ]; then
-    warn "Disabling support for 'muen', not updated to new APIs yet"
-    CONFIG_MUEN=
-fi
-
 # WARNING:
 #
 # The generated Makeconf is dual-use! It is both sourced by GNU make, and by


### PR DESCRIPTION
This updates the Muen bindings wrt. the recent API changes and implements multi-device support for network devices (see issue #372). Block devices are still not supported. Only the necessary API changes have been done to the dummy blockdev implementation.