### PR TITLE
mft: Add mft_get_builtin_mft1()

### DIFF
--- a/bindings/muen/muen-platform_lifecycle.c
+++ b/bindings/muen/muen-platform_lifecycle.c
@@ -36,14 +36,12 @@ void platform_init(void *arg)
     fpu_init();
 
     /*
-     * Get the built-in manifest "out of" the ELF NOTE and validate it. Note
-     * that the size must be adjusted from n_descsz to remove any internal
-     * alignment. Once validated, it is available for access globally by the
-     * bindings.
+     * Get the built-in manifest out of the ELF NOTE and validate it.
+     * Once validated, it is available for access globally by the bindings.
      */
-    struct mft *mft = &__solo5_mft1_note.m;
-    size_t mft_size = __solo5_mft1_note.h.n_descsz -
-        (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
+    struct mft *mft;
+    size_t mft_size;
+    mft_get_builtin_mft1(&__solo5_mft1_note, &mft, &mft_size);
     if (mft_validate(mft, mft_size) != 0) {
         log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
         solo5_abort();

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -67,25 +67,23 @@ static void _start2(void *arg __attribute__((unused)))
     log(INFO, "____/\\___/ _|\\___/____/\n");
     log(INFO, "Solo5: Bindings version %s\n", SOLO5_VERSION);
 
-    mem_init();
-    time_init();
-    pci_enumerate();
-    cpu_intr_enable();
-
     /*
-     * Get the built-in manifest "out of" the ELF NOTE and validate it. Note
-     * that the size must be adjusted from n_descsz to remove any internal
-     * alignment. Once validated, it is available for access globally by the
-     * bindings.
+     * Get the built-in manifest out of the ELF NOTE and validate it.
+     * Once validated, it is available for access globally by the bindings.
      */
-    struct mft *mft = &__solo5_mft1_note.m;
-    size_t mft_size = __solo5_mft1_note.h.n_descsz -
-        (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
+    struct mft *mft;
+    size_t mft_size;
+    mft_get_builtin_mft1(&__solo5_mft1_note, &mft, &mft_size);
     if (mft_validate(mft, mft_size) != 0) {
 	log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
 	solo5_abort();
     }
     virtio_manifest = mft;
+
+    mem_init();
+    time_init();
+    pci_enumerate();
+    cpu_intr_enable();
 
     mem_lock_heap(&si.heap_start, &si.heap_size);
     solo5_exit(solo5_app_main(&si));

--- a/tenders/common/mft.c
+++ b/tenders/common/mft.c
@@ -85,6 +85,18 @@ int mft_validate(struct mft *mft, size_t mft_size)
     return 0;
 }
 
+void mft_get_builtin_mft1(struct mft1_note *note, struct mft **out_mft,
+        size_t *out_mft_size)
+{
+    /*
+     * Get the built-in manifest out of the ELF NOTE. Note that the size must
+     * be adjusted from n_descsz to remove any internal alignment.
+     */
+    *out_mft = &note->m;
+    *out_mft_size = note->h.n_descsz -
+        (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
+}
+
 struct mft_entry *mft_get_by_name(struct mft *mft, const char *name,
         mft_type_t type, unsigned *index)
 {

--- a/tenders/common/mft.h
+++ b/tenders/common/mft.h
@@ -40,6 +40,17 @@
 int mft_validate(struct mft *mft, size_t mft_size);
 
 /*
+ * Given the address of a MFT1 ELF note at (note), returns the address of the
+ * embedded struct mft in (*out_mft) and its expected size in (*out_size).
+ *
+ * This is intended for use by bindings implementations that wish to access the
+ * built-in copy of the application manifest in-place. You should call
+ * mft_validate() on the returned values before using them.
+ */
+void mft_get_builtin_mft1(struct mft1_note *note, struct mft **out_mft,
+        size_t *out_mft_size);
+
+/*
  * Return the manifest entry matching (name), of type (type), or NULL if none
  * found.
  */


### PR DESCRIPTION
As suggested by @cfcs in https://github.com/Solo5/solo5/pull/402#discussion_r325190810. Can't really do much better than this, but at least the internal details of adjusting the size for alignment are encapsulated in a function.

----

Add a mft_get_builtin_mft1() function to extract a struct mft from the MFT1 ELF note. Modify virtio and muen bindings to use it.