### PR TITLE
bindings: Add some more const-ness for mft, spt/hvt ABI

### DIFF
--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -113,7 +113,7 @@ int isspace(int c);
 #include "printf.h"
 
 /* platform.c: specifics for hvt or virito platform */
-void platform_init(void *arg);
+void platform_init(const void *arg);
 const char *platform_cmdline(void);
 uint64_t platform_mem_size(void);
 void platform_exit(int status, void *cookie) __attribute__((noreturn));

--- a/bindings/hvt/bindings.h
+++ b/bindings/hvt/bindings.h
@@ -31,16 +31,16 @@
 #include "../bindings.h"
 #include "hvt_abi.h"
 
-void time_init(struct hvt_boot_info *bi);
+void time_init(const struct hvt_boot_info *bi);
 void console_init(void);
-void net_init(struct hvt_boot_info *bi);
-void block_init(struct hvt_boot_info *bi);
+void net_init(const struct hvt_boot_info *bi);
+void block_init(const struct hvt_boot_info *bi);
 
 /* tscclock.c: TSC-based clock */
 uint64_t tscclock_monotonic(void);
 int tscclock_init(uint64_t tsc_freq);
 uint64_t tscclock_epochoffset(void);
 
-void process_bootinfo(void *arg);
+void process_bootinfo(const void *arg);
 
 #endif /* __HVT_BINDINGS_H__ */

--- a/bindings/hvt/block.c
+++ b/bindings/hvt/block.c
@@ -20,12 +20,13 @@
 
 #include "bindings.h"
 
-static struct mft *mft;
+static const struct mft *mft;
 
 solo5_result_t solo5_block_write(solo5_handle_t handle, solo5_off_t offset,
         const uint8_t *buf, size_t size)
 {
-    struct mft_entry *e = mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
+    const struct mft_entry *e =
+        mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
     if (e == NULL)
         return SOLO5_R_EINVAL;
     if (offset & (e->u.block_basic.block_size - 1))
@@ -57,7 +58,8 @@ solo5_result_t solo5_block_write(solo5_handle_t handle, solo5_off_t offset,
 solo5_result_t solo5_block_read(solo5_handle_t handle, solo5_off_t offset,
         uint8_t *buf, size_t size)
 {
-    struct mft_entry *e = mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
+    const struct mft_entry *e =
+        mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
     if (e == NULL)
         return SOLO5_R_EINVAL;
     if (offset & (e->u.block_basic.block_size - 1))
@@ -90,8 +92,8 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *handle,
         struct solo5_block_info *info)
 {
     unsigned index;
-    struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC,
-            &index);
+    const struct mft_entry *e =
+        mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC, &index);
     if (e == NULL)
         return SOLO5_R_EINVAL;
     assert(e->attached);
@@ -102,7 +104,7 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *handle,
     return SOLO5_R_OK;
 }
 
-void block_init(struct hvt_boot_info *bi)
+void block_init(const struct hvt_boot_info *bi)
 {
     mft = bi->mft;
 }

--- a/bindings/hvt/net.c
+++ b/bindings/hvt/net.c
@@ -20,7 +20,7 @@
 
 #include "bindings.h"
 
-static struct mft *mft;
+static const struct mft *mft;
 
 solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf,
         size_t size)
@@ -57,7 +57,8 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *handle,
         struct solo5_net_info *info)
 {
     unsigned index;
-    struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_NET_BASIC, &index);
+    const struct mft_entry *e =
+        mft_get_by_name(mft, name, MFT_DEV_NET_BASIC, &index);
     if (e == NULL)
         return SOLO5_R_EINVAL;
     assert(e->attached);
@@ -69,7 +70,7 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *handle,
     return SOLO5_R_OK;
 }
 
-void net_init(struct hvt_boot_info *bi)
+void net_init(const struct hvt_boot_info *bi)
 {
     mft = bi->mft;
 }

--- a/bindings/hvt/platform.c
+++ b/bindings/hvt/platform.c
@@ -23,9 +23,9 @@
 static const char *cmdline;
 static uint64_t mem_size;
 
-void process_bootinfo(void *arg)
+void process_bootinfo(const void *arg)
 {
-    struct hvt_boot_info *bi = arg;
+    const struct hvt_boot_info *bi = arg;
 
     cmdline = bi->cmdline;
     mem_size = bi->mem_size;

--- a/bindings/hvt/platform_lifecycle.c
+++ b/bindings/hvt/platform_lifecycle.c
@@ -20,7 +20,7 @@
 
 #include "bindings.h"
 
-void platform_init(void *arg)
+void platform_init(const void *arg)
 {
     process_bootinfo(arg);
 }

--- a/bindings/hvt/start.c
+++ b/bindings/hvt/start.c
@@ -22,7 +22,7 @@
 #include "../crt_init.h"
 #include "solo5_version.h"
 
-void _start(void *arg)
+void _start(const void *arg)
 {
     crt_init_ssp();
     crt_init_tls();

--- a/bindings/hvt/time.c
+++ b/bindings/hvt/time.c
@@ -20,7 +20,7 @@
 
 #include "bindings.h"
 
-void time_init(struct hvt_boot_info *bi)
+void time_init(const struct hvt_boot_info *bi)
 {
     assert(tscclock_init(bi->cpu_cycle_freq) == 0);
 }

--- a/bindings/muen/bindings.h
+++ b/bindings/muen/bindings.h
@@ -34,16 +34,16 @@
 #include "hvt_abi.h"
 #include "elf_abi.h"
 
-void time_init(struct hvt_boot_info *bi);
+void time_init(const struct hvt_boot_info *bi);
 void console_init(void);
-void net_init(struct hvt_boot_info *bi);
-void block_init(struct hvt_boot_info *bi);
+void net_init(const struct hvt_boot_info *bi);
+void block_init(const struct hvt_boot_info *bi);
 
 /* muen-clock.c: TSC-based clock */
 uint64_t tscclock_monotonic(void);
 int tscclock_init(uint64_t tsc_freq);
 uint64_t tscclock_epochoffset(void);
 
-void process_bootinfo(void *arg);
+void process_bootinfo(const void *arg);
 
 #endif /* __MUEN_BINDINGS_H__ */

--- a/bindings/muen/muen-block.c
+++ b/bindings/muen/muen-block.c
@@ -43,6 +43,6 @@ solo5_result_t solo5_block_read(solo5_handle_t handle __attribute__((unused)),
     return SOLO5_R_EUNSPEC;
 }
 
-void block_init(struct hvt_boot_info *bi __attribute__((unused)))
+void block_init(const struct hvt_boot_info *bi __attribute__((unused)))
 {
 }

--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -97,7 +97,7 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *h,
 {
     solo5_handle_t handle = 0;
     unsigned mft_index;
-    struct mft_entry *mft_e = mft_get_by_name(muen_manifest, name,
+    const struct mft_entry *mft_e = mft_get_by_name(muen_manifest, name,
             MFT_DEV_NET_BASIC, &mft_index);
     if (mft_e == NULL)
         return SOLO5_R_EINVAL;
@@ -217,7 +217,7 @@ static bool muen_net_dev_init(const char *name, struct muen_net_device *device,
     return true;
 }
 
-void net_init(struct hvt_boot_info *bi __attribute__((unused)))
+void net_init(const struct hvt_boot_info *bi __attribute__((unused)))
 {
     for (solo5_handle_t i = 0U; i < MFT_MAX_ENTRIES; ++i) {
         net_devices[i].acquired = false;

--- a/bindings/muen/muen-platform_lifecycle.c
+++ b/bindings/muen/muen-platform_lifecycle.c
@@ -30,7 +30,7 @@ void fpu_init(void)
 
 extern const struct mft1_note __solo5_mft1_note;
 
-void platform_init(void *arg)
+void platform_init(const void *arg)
 {
     process_bootinfo(arg);
     fpu_init();

--- a/bindings/spt/block.c
+++ b/bindings/spt/block.c
@@ -20,7 +20,7 @@
 
 #include "bindings.h"
 
-static struct mft *mft;
+static const struct mft *mft;
 
 void block_init(struct spt_boot_info *bi)
 {
@@ -31,8 +31,8 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *handle,
         struct solo5_block_info *info)
 {
     unsigned index;
-    struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC,
-            &index);
+    const struct mft_entry *e =
+        mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC, &index);
     if (e == NULL)
         return SOLO5_R_EINVAL;
     assert(e->attached);
@@ -46,7 +46,8 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *handle,
 solo5_result_t solo5_block_read(solo5_handle_t handle, solo5_off_t offset,
         uint8_t *buf, size_t size)
 {
-    struct mft_entry *e = mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
+    const struct mft_entry *e =
+        mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
     if (e == NULL)
         return SOLO5_R_EINVAL;
 
@@ -69,7 +70,8 @@ solo5_result_t solo5_block_read(solo5_handle_t handle, solo5_off_t offset,
 solo5_result_t solo5_block_write(solo5_handle_t handle, solo5_off_t offset,
         const uint8_t *buf, size_t size)
 {
-    struct mft_entry *e = mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
+    const struct mft_entry *e =
+        mft_get_by_index(mft, handle, MFT_DEV_BLOCK_BASIC);
     if (e == NULL)
         return SOLO5_R_EINVAL;
 

--- a/bindings/spt/net.c
+++ b/bindings/spt/net.c
@@ -20,7 +20,7 @@
 
 #include "bindings.h"
 
-static struct mft *mft;
+static const struct mft *mft;
 static int epollfd;
 static int npollfds;
 static int timerfd;
@@ -42,7 +42,8 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *handle,
         struct solo5_net_info *info)
 {
     unsigned index;
-    struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_NET_BASIC, &index);
+    const struct mft_entry *e =
+        mft_get_by_name(mft, name, MFT_DEV_NET_BASIC, &index);
     if (e == NULL)
         return SOLO5_R_EINVAL;
     assert(e->attached);
@@ -57,7 +58,8 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *handle,
 solo5_result_t solo5_net_read(solo5_handle_t handle, uint8_t *buf, size_t size,
         size_t *read_size)
 {
-    struct mft_entry *e = mft_get_by_index(mft, handle, MFT_DEV_NET_BASIC);
+    const struct mft_entry *e =
+        mft_get_by_index(mft, handle, MFT_DEV_NET_BASIC);
     if (e == NULL)
         return SOLO5_R_EINVAL;
 
@@ -76,7 +78,8 @@ solo5_result_t solo5_net_read(solo5_handle_t handle, uint8_t *buf, size_t size,
 solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf,
         size_t size)
 {
-    struct mft_entry *e = mft_get_by_index(mft, handle, MFT_DEV_NET_BASIC);
+    const struct mft_entry *e =
+        mft_get_by_index(mft, handle, MFT_DEV_NET_BASIC);
     if (e == NULL)
         return SOLO5_R_EINVAL;
 

--- a/bindings/spt/platform.c
+++ b/bindings/spt/platform.c
@@ -23,9 +23,9 @@
 static const char *cmdline;
 static uint64_t mem_size;
 
-void platform_init(void *arg)
+void platform_init(const void *arg)
 {
-    struct spt_boot_info *bi = arg;
+    const struct spt_boot_info *bi = arg;
 
     cmdline = bi->cmdline;
     mem_size = bi->mem_size;

--- a/bindings/virtio/platform.c
+++ b/bindings/virtio/platform.c
@@ -27,13 +27,13 @@ static char cmdline[8192];
 
 static uint64_t mem_size;
 
-void platform_init(void *arg)
+void platform_init(const void *arg)
 {
     /*
      * The multiboot structures may be anywhere in memory, so take a copy of
      * the command line before we initialise memory allocation.
      */
-    struct multiboot_info *mi = (struct multiboot_info *)arg;
+    const struct multiboot_info *mi = (struct multiboot_info *)arg;
 
     if (mi->flags & MULTIBOOT_INFO_CMDLINE) {
         char *mi_cmdline = (char *)(uint64_t)mi->cmdline;

--- a/include/solo5/hvt_abi.h
+++ b/include/solo5/hvt_abi.h
@@ -154,8 +154,8 @@ struct hvt_boot_info {
     uint64_t mem_size;                  /* Memory size in bytes */
     uint64_t kernel_end;                /* Address of end of kernel */
     uint64_t cpu_cycle_freq;            /* CPU cycle counter frequency, Hz */
-    HVT_GUEST_PTR(char *) cmdline;      /* Address of command line (C string) */
-    HVT_GUEST_PTR(void *) mft;          /* Address of application manifest */
+    HVT_GUEST_PTR(const char *) cmdline;/* Address of command line (C string) */
+    HVT_GUEST_PTR(const void *) mft;    /* Address of application manifest */
 };
 
 /*

--- a/include/solo5/spt_abi.h
+++ b/include/solo5/spt_abi.h
@@ -52,8 +52,8 @@
 struct spt_boot_info {
     uint64_t mem_size;                  /* Memory size in bytes */
     uint64_t kernel_end;                /* Address of end of kernel */
-    const char * cmdline;               /* Address of command line (C string) */
-    void *mft;                          /* Address of application manifest */
+    const char *cmdline;                /* Address of command line (C string) */
+    const void *mft;                    /* Address of application manifest */
     int epollfd;                        /* epoll() set for yield() */
     int timerfd;                        /* internal timerfd for yield() */
 };


### PR DESCRIPTION
No functional changes.

Inspired by #404, add some more const-ness to (struct mft *) and (struct
mft_entry *) used by the bindings.

For hvt and spt, also make the argument passed to _start() and its
pointer members const, as it is in low memory and will result in a fault
if accidentally modified. The rest is just the ripple-down effect of
these changes.