### PR TITLE
OPAM: Fix "make opam-install-%"

### DIFF
--- a/opam/solo5-bindings-genode.opam
+++ b/opam/solo5-bindings-genode.opam
@@ -11,7 +11,7 @@ build: [
   ["./configure.sh"]
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="]
 ]
-install: [make "V=1" "install-opam-genode" "PREFIX=%{prefix}%"]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "install-opam-genode" "PREFIX=%{prefix}%"]
 remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]

--- a/opam/solo5-bindings-hvt.opam
+++ b/opam/solo5-bindings-hvt.opam
@@ -13,7 +13,7 @@ build: [
   ["./configure.sh"]
   [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
-install: [make "V=1" "install-opam-hvt" "PREFIX=%{prefix}%"]
+install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-hvt" "PREFIX=%{prefix}%"]
 remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]

--- a/opam/solo5-bindings-muen.opam
+++ b/opam/solo5-bindings-muen.opam
@@ -13,7 +13,7 @@ build: [
   ["./configure.sh"]
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE="]
 ]
-install: [make "V=1" "install-opam-muen" "PREFIX=%{prefix}%"]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "install-opam-muen" "PREFIX=%{prefix}%"]
 remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]

--- a/opam/solo5-bindings-spt.opam
+++ b/opam/solo5-bindings-spt.opam
@@ -13,7 +13,7 @@ build: [
   ["./configure.sh"]
   [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
-install: [make "V=1" "install-opam-spt" "PREFIX=%{prefix}%"]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-spt" "PREFIX=%{prefix}%"]
 remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-spt" "PREFIX=%{prefix}%"]

--- a/opam/solo5-bindings-virtio.opam
+++ b/opam/solo5-bindings-virtio.opam
@@ -13,7 +13,7 @@ build: [
   ["./configure.sh"]
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
-install: [make "V=1" "install-opam-virtio" "PREFIX=%{prefix}%"]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-virtio" "PREFIX=%{prefix}%"]
 remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]


### PR DESCRIPTION
The CONFIG_ settings passed to "make" must be the same as those passed
to "make opam-install-%", otherwise things will fail.