### PR TITLE
(WiP): Afl gcc

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -63,7 +63,7 @@ endef
 # The following variables and recpies apply to building tenders, i.e.
 # artifacts built to run on the (Solo5 tender's) *host*.
 #
-HOSTCC := $(MAKECONF_CC)
+HOSTCC := $(MAKECONF_HOSTCC)
 HOSTCFLAGS := -Wall -Werror -std=c11 -fstack-protector-strong -O2 -g
 HOSTCPPFLAGS := -I$(TOPDIR)/include/solo5
 HOSTLDFLAGS :=

--- a/configure.sh
+++ b/configure.sh
@@ -116,6 +116,7 @@ EOM
 # Allow external override of CC.
 CC=${CC:-cc}
 LD=${LD:-ld}
+HOSTCC=${HOSTCC:-$CC}
 
 CC_MACHINE=$(${CC} -dumpmachine)
 [ $? -ne 0 ] &&
@@ -292,6 +293,46 @@ case "${CONFIG_HOST}" in
         ;;
 esac
 
+while [ $# -ne 0 ]
+do
+  arg="$1"
+  case "$arg" in
+    --without-genode)
+      CONFIG_GENODE=
+      ;;
+    --without-hvt)
+      CONFIG_HVT=
+      ;;
+    --without-muen)
+      CONFIG_MUEN=
+      ;;
+    --without-spt)
+      CONFIG_SPT=
+      ;;
+    --without-virtio)
+      CONFIG_VIRTIO=
+      ;;
+    --with-afl-gcc)
+      # Build tenders with afl-gcc tooling.
+      HOSTCC=afl-gcc
+      # TODO before merge detect/check this
+      ;;
+    *)
+    printf '%s\n' 'Accepted flags for configure.sh:'
+    printf '%s\n' '--without-genode: Build without Genode support'
+    printf '%s\n' '--without-hvt: Build without HVT support'
+    printf '%s\n' '--without-muen: Build without Muen-SK support'
+    printf '%s\n' '--without-spt: Build without SPT (Linux Seccomp) support'
+    printf '%s\n' '--without-virtio: Build without Virtio support'
+    printf '%s\n' '--with-afl-gcc: Build tenders with afl-gcc instrumentation'
+    printf '%s\n' '               (equivalent to HOSTCC=afl-gcc ./configure.sh)'
+    exit 1
+    ;;
+  esac
+  # Check next argument:
+  shift
+done
+
 # WARNING:
 #
 # The generated Makeconf is dual-use! It is both sourced by GNU make, and by
@@ -323,10 +364,12 @@ CONFIG_HOST=${CONFIG_HOST}
 CONFIG_GUEST_PAGE_SIZE=${CONFIG_GUEST_PAGE_SIZE}
 MAKECONF_CC=${CC}
 MAKECONF_LD=${LD}
+MAKECONF_HOSTCC=${HOSTCC}
 CONFIG_SPT_NO_PIE=${CONFIG_SPT_NO_PIE}
 EOM
 
-echo "${prog_NAME}: Configured for ${CC_MACHINE}."
+echo "${prog_NAME}: Configured for ${CC_MACHINE} using ${HOSTCC}."
+[ "${CC}" = "${HOSTCC}" ] || printf '(tender) HOSTCC=%s   (unikernel) CC=%s\n' "${HOSTCC}" "${CC}"
 echo -n "${prog_NAME}: Enabled targets:"
 [ -n "${CONFIG_HVT}" ]    && echo -n " hvt"
 [ -n "${CONFIG_SPT}" ]    && echo -n " spt"

--- a/tenders/spt/spt_main.c
+++ b/tenders/spt/spt_main.c
@@ -222,6 +222,7 @@ int main(int argc, char **argv)
             matched = 1;
             argc--;
             argv++;
+	    continue;
         }
         if (handle_cmdarg(*argv, mft) == 0) {
             /* Handled by module, consume and go on to next arg */


### PR DESCRIPTION
This PR enables building the tenders with `afl-gcc` and the unikernels with your regular `$CC`.
1) It adds a `--dry-run` option to SPT which was helpful for fuzzing.
2) I don't really know what I'm doing re: the configure script. I am not attached to any of the changes, the main thing is making `HOSTCC` in `Makefile.common` be able to be different from `CC`.

I've been using this (for 15 min) to fuzz the `spt` tender and `elftool` with these commands:
```
mkdir fuzz-out fuzz-manifest fuzz-abi

afl-fuzz -i newfuzz-in -o fuzz-out/ -f /dev/shm/foo -t 200 -- ./tenders/spt/solo5-spt --dry-run --mem=2 -- /dev/shm/foo

afl-fuzz -i newfuzz-in -o fuzz-manifest -f /dev/shm/foo.manifest -t 200 -- ./elftool/solo5-elftool query-manifest /dev/shm/foo.manifest

afl-fuzz -i newfuzz-in -o fuzz-abi/ -f /dev/shm/foo.abi -t 500 -- ./elftool/solo5-elftool query-abi /dev/shm/foo.abi
```

So far it's managed to trigger a few assertions (that's fair), but has not produced any actual crashes (that's good :tada: )
```
solo5-spt: common/mft.c:145: mft_type_to_string: Assertion `false' failed.

solo5-spt: spt/spt_core.c:158: spt_guest_mprotect: Assertion `addr_start < addr_end' failed.


solo5-elftool: ../tenders/common/elf.c:476: elf_load_note: Assertion `note_size != 0 && note_size <= nhdr.h.n_descsz' failed.
```

Sometimes the `mft_type_to_string` assertions are triggered *after* `solo5-elftool query-manifest` has started printing JSON though, which may not be ideal.