### PR TITLE
test compilation failure on FreeBSD 12+

### DIFF
--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -49,7 +49,7 @@ static void puts(const char *s)
     solo5_console_write(s, strlen(s));
 }
 
-#if defined(__OpenBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
 /* __thread is not supported in OpenBSD (this test fails on it). */
 volatile uint64_t _data;
 #else


### PR DESCRIPTION
on FreeBSD-12 with clang 8.0.1 (and their ld), I get:
```
ld -nostdlib -z max-page-size=0x1000 -static  -T /usr/home/hannes/.opam/4.09.0/.opam-switch/build/solo5-bindings-hvt.0.6.2/bindings/hvt/solo5_hvt.lds /usr/home/hannes/.opam/4.09.0/.opam-switch/build/solo5-bindings-hvt.0.6.2/bindings/hvt/solo5_hvt.o test_tls.o manifest.o -o test_tls.hvt
ld: error: test_tls.o has an STT_TLS symbol but doesn't have an SHF_TLS section
```
when attempting to link test_tls

and it looks the "opam install" always triggers a testbuild...

this is a workaround which disables `test_tls` on FreeBSD