### PR TITLE
CI: Update and re-enable E2E tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,9 +90,7 @@ case "${SURF_BUILD_TYPE}" in
         do_basic
         ;;
     e2e)
-        # TODO: Re-enable once MirageOS branches are settled.
-        # do_e2e
-        echo "WARNING: E2E tests currently disabled"
+        do_e2e
         ;;
     *)
         echo "WARNING: SURF_BUILD_TYPE not set, assuming 'basic'"

--- a/tests/e2e-mirage-solo5/README.md
+++ b/tests/e2e-mirage-solo5/README.md
@@ -4,7 +4,7 @@ This is an end to end "smoketest" for Mirage/Solo5.
 
 TL;DR on how to currently build/run in case I pointed you here:
 
-- `opam install dune shexp` if you don't have them already
+- `opam install dune shexp lwt` if you don't have them already
 - `dune exec bin/main.exe`
 
 This will build the test unikernel in `./unikernel` in a local switch created from scratch, with the package "universe" defined in `./universe` and then attempt to run the smoketest. 

--- a/tests/e2e-mirage-solo5/lib/lib.ml
+++ b/tests/e2e-mirage-solo5/lib/lib.ml
@@ -22,7 +22,7 @@ let prep_setup_switch =
       >> chdir switch_path (call [ "tar"; "-xzf"; "../switch.tar.gz" ])
     | false ->
       call [ "mkdir"; "-p"; switch_path ]
-      >> call [ "opam"; "switch"; "create"; switch_path; "4.07.1" ]
+      >> call [ "opam"; "switch"; "create"; switch_path; "4.09.0" ]
       >> chdir switch_path (call [ "tar"; "-czf"; "../switch.tar.gz"; "." ])
 
 (* Prepare: Install root packages ------------------------------------------- *)
@@ -99,35 +99,20 @@ let run_setup_block =
 
 (* Run: Initialise smoketest ------------------------------------------------ *)
 
-(* Determine if Solo5 is using the soon-to-be-old-style hvt tender build at
- * unikernel build time, or if we should run using the solo5-hvt binary
- * installed by OPAM.
- * TODO: This required adding with_switch to the following run_ steps which is
- * slow, re-work this to use "opam config --switch=... var bin" instead.
- *)
-let hvt_tender_path =
-  file_exists (src_path ^ "/solo5-hvt") >>= fun hvt_is_local ->
-  if hvt_is_local then
-    return (src_path ^ "/solo5-hvt")
-  else
-    return ("solo5-hvt")
-
 let run_init_smoketest =
-  hvt_tender_path >>= fun hvt_tender_path' ->
   call (with_switch @
-        [ hvt_tender_path';
-          "--net=tap100";
-          "--disk=" ^ block_path;
+        [ "solo5-hvt";
+          "--net:service=tap100";
+          "--block:storage=" ^ block_path;
           src_path ^ "/test.hvt"; "--init" ])
 
 (* Run: Run smoketest ------------------------------------------------------- *)
 
 let run_smoketest_server =
-  hvt_tender_path >>= fun hvt_tender_path' ->
   call (with_switch @
-        [ hvt_tender_path';
-          "--net=tap100";
-          "--disk=" ^ block_path;
+        [ "solo5-hvt";
+          "--net:service=tap100";
+          "--block:storage=" ^ block_path;
           src_path ^ "/test.hvt" ])
 
 let run_smoketest_client =

--- a/tests/e2e-mirage-solo5/unikernel/config.ml
+++ b/tests/e2e-mirage-solo5/unikernel/config.ml
@@ -21,6 +21,6 @@ let main =
 
 let stack = generic_stackv4 default_network
 
-let img = block_of_file "disk.img"
+let img = block_of_file "storage"
 
 let () = register "test" [main $ default_console $ stack $ img]


### PR DESCRIPTION
Now that MirageOS and Solo5 are back in sync, re-enable the E2E tests in CI.