### PR TITLE
build: Use pkg-config to find libseccomp on Linux

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -23,7 +23,8 @@ Solo5 itself has the following build dependencies:
 * a C11 compiler; recent versions of GCC and clang are supported,
 * GNU make,
 * full host system headers (on Linux, kernel headers are not always installed
-  by default).
+  by default),
+* on Linux only, pkg-config and libseccomp >= 2.3.3 are required.
 
 Note that Solo5 does not support cross-compilation. With the exception of the
 _muen_ and _genode_ targets (which are not self-hosting), you should build

--- a/tenders/GNUmakefile
+++ b/tenders/GNUmakefile
@@ -96,7 +96,8 @@ HOSTLDFLAGS += -Wl,-Ttext-segment=0x40000000
 
 endif
 
-HOSTLDLIBS += -lseccomp
+HOSTCFLAGS += $(MAKECONF_SPT_CFLAGS)
+HOSTLDLIBS += $(MAKECONF_SPT_LDLIBS)
 
 spt_SRCS := spt/spt_main.c spt/spt_core.c spt/spt_launch_$(CONFIG_ARCH).S \
     spt/spt_module_net.c spt/spt_module_block.c


### PR DESCRIPTION
Some Linux distributions install libseccomp in non-standard directories.
Use pkg-config to look for it instead of guessing. Note that this
makes pkg-config a hard build-time dependency.

While we're at it, we can use pkg-config to do version tests, so make
libseccomp >= 2.3.3 a hard requirement and warn but proceed on
libseccomp < 2.4.1.

Fixes #419, fixes #418 (by eliminating the no-targets case).