### PR TITLE
multiboot: add -aout as an argument to mboot.c32

### DIFF
--- a/scripts/virtio-mkimage/solo5-virtio-mkimage.sh
+++ b/scripts/virtio-mkimage/solo5-virtio-mkimage.sh
@@ -195,7 +195,7 @@ SERIAL 0 115200
 DEFAULT unikernel
 LABEL unikernel
   KERNEL mboot.c32
-  APPEND unikernel.bin $@
+  APPEND -aout unikernel.bin $@
 EOM
 # Ugh, mtools complains about filesystem size not being a multiple of
 # what it thinks the sectors-per-track are, ignore.


### PR DESCRIPTION
Fix for #429. The issue is that the latest syslinux broke us; more specifically, the latest mboot.c32 does not default to use the aout kludge option anymore. This commit just adds it with the `-aout` option in the config file.

Tested with `kollerr/solo5-virtio-mkimage`. Just update the script to point to it:
```
--- a/scripts/virtio-mkimage/solo5-virtio-mkimage.sh
+++ b/scripts/virtio-mkimage/solo5-virtio-mkimage.sh
@@ -133,7 +133,7 @@ if [ -n "${RUN_IN_DOCKER}" ]; then
     exec docker run --rm \
         ${TMPFS} \
         -v ${SRCDIR}:/host/src -v ${DESTDIR}:/host/dest \
-        mato/solo5-virtio-mkimage -f ${FORMAT} \
+        kollerr/solo5-virtio-mkimage -f ${FORMAT} \
             -- \
             /host/dest/${DESTFILE} /host/src/${SRCFILE} "$@"
 fi
```
and run this:
```
bash ./scripts/virtio-mkimage/solo5-virtio-mkimage.sh -d test.img tests/test_hello/test_hello.virtio 
sudo qemu-system-x86_64 -cpu host -enable-kvm -m 2048 -nodefaults -no-acpi -display none -serial stdio -device isa-debug-exit test.img
```