### PR TITLE
Muen improvements

### DIFF
--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -128,12 +128,16 @@ bool muen_net_pending_data(solo5_handle_t handle)
 
 static void generate_mac_addr(uint8_t *addr)
 {
+    const uint64_t dsize = sizeof(uint64_t) * 8;
     const char *subject_name = muen_get_subject_name();
+    static uint64_t counter = 0;
     uint64_t data;
     int i;
 
     data  = (muen_get_sched_start() << 32) | muen_get_sched_end();
     data ^= tscclock_epochoffset();
+    data  = ((data << counter) | (data >> (dsize - counter))) + counter;
+    counter = (counter + 1) % dsize;
 
     for (i = 0; i < 6; i++)
     {

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -36,6 +36,7 @@ ENTRY(_start)
 PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
+    rodata PT_LOAD;
     data PT_LOAD;
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -63,21 +64,21 @@ SECTIONS {
 
     /* Read-only data */
 
-    /* For Muen, the ABI and MFT NOTEs are read-only and can be in :text. */
+    /* For Muen, the ABI and MFT NOTEs are read-only and can be in :rodata. */
     .note.solo5.manifest :
     {
         *(.note.solo5.manifest*)
-    } :text :note.manifest
+    } :rodata :note.manifest
     .note.solo5.abi :
     {
         *(.note.solo5.abi*)
-    } :text :note.abi
+    } :rodata :note.abi
 
     .rodata :
     {
         *(.rodata)
         *(.rodata.*)
-    } :text
+    } :rodata
     .eh_frame :
     {
         *(.eh_frame)


### PR DESCRIPTION
Some small changes to enforce stricter ELF section access rights as well as improvements to muen-net to avoid potential MAC address collisions for unikernels with multiple network interfaces.