### PR TITLE
Stop host kernels from executing Solo5 binaries

### DIFF
--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -34,6 +34,7 @@ ENTRY(_start)
  * into a separate PT_NOTE header, we need to lay these out explicitly.
  */
 PHDRS {
+    interp PT_INTERP;
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
@@ -51,6 +52,10 @@ SECTIONS {
      * :text: The following input sections are placed in the R/E :text segment.
      */
     _stext = .;
+
+    .interp : {
+        *(.interp)
+    } :interp :text
 
     .text :
     {

--- a/bindings/hvt/start.c
+++ b/bindings/hvt/start.c
@@ -50,10 +50,14 @@ void _start(const void *arg)
 }
 
 /*
+ * Place the .interp section in this module, as it comes first in the link
+ * order.
+ */
+DECLARE_ELF_INTERP
+
+/*
  * The "ABI1" Solo5 ELF note is declared in this module.
  *
- * TODO: We will want a separate start.c and muen_abi.h for Muen bindings, but
- * this will work for now.
  */
 ABI1_NOTE_DECLARE_BEGIN
 {

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -34,6 +34,7 @@ ENTRY(_start)
  * into a separate PT_NOTE header, we need to lay these out explicitly.
  */
 PHDRS {
+    interp PT_INTERP;
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     rodata PT_LOAD;
@@ -52,6 +53,10 @@ SECTIONS {
      * :text: The following input sections are placed in the R/E :text segment.
      */
     _stext = .;
+
+    .interp : {
+        *(.interp)
+    } :interp :text
 
     .text :
     {

--- a/bindings/muen/start.c
+++ b/bindings/muen/start.c
@@ -50,6 +50,12 @@ void _start(void *arg)
 }
 
 /*
+ * Place the .interp section in this module, as it comes first in the link
+ * order.
+ */
+DECLARE_ELF_INTERP
+
+/*
  * The "ABI1" Solo5 ELF note is declared in this module.
  *
  * Muen currently has no formal Solo5 ABI contract, so the version is always 1.

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -34,6 +34,7 @@ ENTRY(_start)
  * into a separate PT_NOTE header, we need lay these out explicitly.
  */
 PHDRS {
+    interp PT_INTERP;
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
@@ -51,6 +52,10 @@ SECTIONS {
      * :text: The following input sections are placed in the R/E :text segment.
      */
     _stext = .;
+
+    .interp : {
+        *(.interp)
+    } :interp :text
 
     .text :
     {

--- a/bindings/spt/start.c
+++ b/bindings/spt/start.c
@@ -47,6 +47,12 @@ void _start(void *arg)
 }
 
 /*
+ * Place the .interp section in this module, as it comes first in the link
+ * order.
+ */
+DECLARE_ELF_INTERP
+
+/*
  * The "ABI1" Solo5 ELF note is declared in this module.
  */
 ABI1_NOTE_DECLARE_BEGIN

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -34,6 +34,7 @@ ENTRY(_start)
  * into a separate PT_NOTE header, we need to lay these out explicitly.
  */
 PHDRS {
+    interp PT_INTERP;
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
@@ -51,6 +52,10 @@ SECTIONS {
      * :text: The following input sections are placed in the R/E :text segment.
      */
     _stext = .;
+
+    .interp : {
+        *(.interp)
+    } :interp :text
 
     .text :
     {

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -90,6 +90,12 @@ static void _start2(void *arg __attribute__((unused)))
 }
 
 /*
+ * Place the .interp section in this module, as it comes first in the link
+ * order.
+ */
+DECLARE_ELF_INTERP
+
+/*
  * The "ABI1" Solo5 ELF note is declared in this module.
  *
  * Virtio does not have an ABI contract (in the Solo5 sense) or use a tender,

--- a/include/solo5/elf_abi.h
+++ b/include/solo5/elf_abi.h
@@ -121,4 +121,20 @@ __attribute__ ((section (".note.solo5.abi"), aligned(4))) \
 
 #define ABI1_NOTE_DECLARE_END };
 
+/*
+ * Declare the contents of the .interp section / PT_INTERP.
+ *
+ * This mechanism is used by bindings to ensure that Solo5 ELF executables will
+ * not be loaded by a host system kernel.
+ *
+ * The string "/nonexistent/solo5/" with the trailing slash is used
+ * intentionally to ensure that loading will still fail even in the unlikely
+ * presence of a valid ELF executable at "/nonexistent/solo5".
+ *
+ */
+#define DECLARE_ELF_INTERP \
+const char __fake_interp[24] \
+__attribute__ ((section (".interp"), aligned(8))) \
+= "/nonexistent/solo5/";
+
 #endif /* ELF_ABI_H */


### PR DESCRIPTION
This is implemented for hvt, spt, muen and virtio bindings by:

- Adding a PT_INTERP and .interp in binding-specific linker scripts.
- Populating .interp via DECLARE_ELF_INTERP in binding-specific start.c.
- The content of PT_INTERP is "/nonexistent/solo5/".

The Genode bindings have not been changed, as they seem to do their own
thing regarding PT_INTERP.

With this change if a Solo5 unikernel binary is run directly (e.g.
./test_hello.hvt) on a Linux/FreeBSD/OpenBSD host, the host kernel will
not attempt to execute the binary and will fail with a more or less
sensible error message rather than produce a segmentation fault or
similar.

This provides both for a nicer "naive user" experience, and is a
security improvement against accidentally exposing the host kernel to
unikernel binaries from untrusted sources.

**TODO** before merging: Manually test targets that are not tested in CI:

1. [x] muen: Ensure that the Muen toolchain does not get confused by the presence of a `PT_INTERP`.
2. [x] virtio with byhve on FreeBSD.
3. [ ] virtio using Google Compute Engine.

Fixes #442.