### PR TITLE
Disable Genode build for Linux hosts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,11 @@ do_basic()
 {
     message "Starting build."
     try ./configure.sh
+    # Genode bindings are disabled by default; enable them for Linux hosts to
+    # ensure they get tested by Solo5 CI.
+    if [ "$(uname -s)" = "Linux" ]; then
+        echo CONFIG_GENODE=1 >>Makeconf
+    fi
     try ${MAKE}
     # Some CIs can now run tests, so do that.
     if [ -n "${SURF_RUN_TESTS}" ]; then

--- a/configure.sh
+++ b/configure.sh
@@ -153,8 +153,8 @@ config_host_linux()
     fi
     [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_VIRTIO=1
     [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_MUEN=1
-    [ "${CONFIG_ARCH}" = "x86_64" ] && CONFIG_GENODE=1
     [ "${CONFIG_ARCH}" = "ppc64le" ] && CONFIG_HVT=
+    CONFIG_GENODE=
 }
 
 config_host_freebsd()

--- a/docs/building.md
+++ b/docs/building.md
@@ -45,7 +45,9 @@ to disable some _targets_, you can either use:
 make CONFIG_HVT= # disables hvt
 ```
 
-or edit the generated `Makeconf` before running `make`.
+or edit the generated `Makeconf` before running `make`. Conversely, using
+`CONFIG_TARGET=1` will enable a _target_ that was not explicitly enabled by
+configure.sh (for example, Genode).
 
 Note that the Solo5 Makefiles do not support building arbitrary `make` targets
 (e.g. `bindings` or `tests`).
@@ -85,7 +87,9 @@ Experimental:
   and executed as a native Genode component. The bindings library is provided
   here in the form of a stub library that can be built using a stock C
   toolchain along with the C++ implementation that must be built using the
-  Genode toolchain.
+  Genode toolchain. Note that the Genode _target_ must be enabled explicitly
+  using `CONFIG_GENODE=1`, and may not build with standard toolchains. If in
+  doubt, please consult with Genode developers.
 
 Limited:
 


### PR DESCRIPTION
Do not implicitly cross-compile Genode bindings for Linux hosts. Do not
assume that the host toolchain can link the tests to the bindings.

Fix #441 

 ---

I don't have a mainstream Linux installation to test against, so I would prefer to disable cross-compilation. I am still running my own tests of the bindings -  https://opensource.sotest.io/results/41/391