### PR TITLE
add openbsd mprotect ept support

### DIFF
--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -190,6 +190,14 @@ int hvt_vcpu_loop(struct hvt *hvt)
                     hvt_gpa_t gpa = vei->vei.vei_data;
                     fn(hvt, gpa);
                     break;
+#if defined(VMM_IOC_MPROTECT_EPT)
+                case VMX_EXIT_EPT_VIOLATION:
+                    if(vei->vee.vee_fault_type == VEE_FAULT_PROTECT) { 
+                        errx(1, "VMM: host/guest translation fault: rip=0x%llx",
+                            vei->vrs.vrs_gprs[VCPU_REGS_RIP]);
+                    }
+                    break;
+#endif
                 case VMX_EXIT_TRIPLE_FAULT:
                 case SVM_VMEXIT_SHUTDOWN:
                     /* reset VM */


### PR DESCRIPTION
This change add support for mprotect_ept ioctl in openbsd, but will only be enabled on an OpenBSD 6.7 system (just gone into beta)

the ifdefs check for VMM_IOC_MPROTECT_EPT, and call if available

Would like to get reviews, so we can add this when 6.7 is released.