### PR TITLE
Muen Sinfo & ABI update

### DIFF
--- a/bindings/muen/muen-net.c
+++ b/bindings/muen/muen-net.c
@@ -169,7 +169,7 @@ static bool muen_net_dev_init(const char *name, struct muen_net_device *device,
         log(WARN, "Solo5: Net: '%s': No output channel\n", name);
         return false;
     }
-    if (!(chan_out->data.mem.flags & MEM_CHANNEL_FLAG)) {
+    if (chan_out->data.mem.kind != MUEN_MEM_SUBJ_CHANNEL) {
         log(WARN, "Solo5: Net: '%s': Memory '%s' is not a channel\n",
             name, chan_out->name.data);
         return false;
@@ -184,7 +184,7 @@ static bool muen_net_dev_init(const char *name, struct muen_net_device *device,
         log(WARN, "Solo5: Net: '%s': No input channel\n", name);
         return false;
     }
-    if (!(chan_in->data.mem.flags & MEM_CHANNEL_FLAG)) {
+    if (chan_in->data.mem.kind != MUEN_MEM_SUBJ_CHANNEL) {
         log(WARN, "Solo5: Net: '%s': Memory '%s' is not a channel\n",
             name, chan_in->name.data);
         return false;

--- a/bindings/muen/muen-sinfo.c
+++ b/bindings/muen/muen-sinfo.c
@@ -35,8 +35,8 @@ static const struct subject_info_type *sinfo =
 static volatile struct scheduling_info_type *sched_info =
     (struct scheduling_info_type *)(SCHED_INFO_ADDR);
 
-static bool names_equal(const struct muen_name_type *const n1,
-                        const char *const n2)
+bool muen_names_equal(const struct muen_name_type *const n1,
+                      const char *const n2)
 {
     return n1->length == strlen(n2)
         && strncmp(n1->data, n2, n1->length) == 0;
@@ -93,7 +93,7 @@ muen_get_resource(const char *const name, enum muen_resource_kind kind)
     struct iterator i = { NULL, 0 };
 
     while (iterate_resources(&i))
-        if (i.res->kind == kind && names_equal(&i.res->name, name))
+        if (i.res->kind == kind && muen_names_equal(&i.res->name, name))
             return i.res;
 
     return NULL;

--- a/bindings/muen/sinfo.h
+++ b/bindings/muen/sinfo.h
@@ -21,7 +21,7 @@
 #ifndef __MUEN_SINFO_H__
 #define __MUEN_SINFO_H__
 
-#define MUEN_SUBJECT_INFO_MAGIC	0x02006f666e69756dULL
+#define MUEN_SUBJECT_INFO_MAGIC        0x03006f666e69756dULL
 
 #define MAX_RESOURCE_COUNT 255
 #define MAX_NAME_LENGTH    63
@@ -30,7 +30,6 @@
 
 #define MEM_WRITABLE_FLAG   (1 << 0)
 #define MEM_EXECUTABLE_FLAG (1 << 1)
-#define MEM_CHANNEL_FLAG    (1 << 2)
 
 #define DEV_MSI_FLAG        (1 << 0)
 
@@ -48,20 +47,46 @@ struct muen_name_type {
     uint8_t null_term;
 } __attribute__((__packed__));
 
+/* Type of memory */
+enum muen_memory_kind {
+    MUEN_MEM_SUBJ = 0,
+    MUEN_MEM_SUBJ_INFO,
+    MUEN_MEM_SUBJ_BIN,
+    MUEN_MEM_SUBJ_ZP,
+    MUEN_MEM_SUBJ_INITRD,
+    MUEN_MEM_SUBJ_CHANNEL,
+    MUEN_MEM_SUBJ_STATE,
+    MUEN_MEM_SUBJ_TIMED_EVT,
+    MUEN_MEM_SUBJ_INTRS,
+    MUEN_MEM_SUBJ_SCHEDINFO,
+    MUEN_MEM_SUBJ_BIOS,
+    MUEN_MEM_SUBJ_ACPI_RSDP,
+    MUEN_MEM_SUBJ_ACPI_XSDT,
+    MUEN_MEM_SUBJ_ACPI_FADT,
+    MUEN_MEM_SUBJ_ACPI_DSDT,
+    MUEN_MEM_SUBJ_DEVICE,
+    MUEN_MEM_SUBJ_SOLO5_BOOT_INFO,
+    MUEN_MEM_SUBJ_CRASH_AUDIT,
+    MUEN_MEM_KRNL_IFACE
+} __attribute__((__packed__));
+
 /* Known memory contents */
 enum muen_content_kind {
-    MUEN_CONTENT_UNINITIALIZED, MUEN_CONTENT_FILL, MUEN_CONTENT_FILE
-};
+    MUEN_CONTENT_UNINITIALIZED = 0,
+    MUEN_CONTENT_FILL,
+    MUEN_CONTENT_FILE
+} __attribute__((__packed__));
 
 /* Structure holding information about a memory region */
 struct muen_memregion_type {
+    enum muen_memory_kind kind;
     enum muen_content_kind content;
+    uint8_t flags;
+    uint16_t pattern;
+    char padding[3];
     uint64_t address;
     uint64_t size;
     uint8_t hash[HASH_LENGTH];
-    uint8_t flags;
-    uint16_t pattern;
-    char padding[1];
 } __attribute__((__packed__));
 
 /* Required for explicit padding */
@@ -78,16 +103,32 @@ struct muen_device_type {
     char padding[largest_variant_size - device_type_size];
 } __attribute__((__packed__));
 
+#define devmem_type_size (1 + 16)
+
+/* Structure holding information about a device MMIO region */
+struct muen_devmem_type {
+    uint8_t flags;
+    char padding1[7];
+    uint64_t address;
+    uint64_t size;
+    char padding2[largest_variant_size - (devmem_type_size + 7)];
+} __attribute__((__packed__));
+
 /* Currently known resource types */
 enum muen_resource_kind {
-    MUEN_RES_NONE, MUEN_RES_MEMORY, MUEN_RES_EVENT, MUEN_RES_VECTOR,
-    MUEN_RES_DEVICE
+    MUEN_RES_NONE = 0,
+    MUEN_RES_MEMORY,
+    MUEN_RES_EVENT,
+    MUEN_RES_VECTOR,
+    MUEN_RES_DEVICE,
+    MUEN_RES_DEVMEM
 };
 
 /* Resource data depending on the kind of resource */
 union muen_resource_data {
     struct muen_memregion_type mem;
     struct muen_device_type dev;
+    struct muen_devmem_type devmem;
     uint8_t number;
 };
 
@@ -108,6 +149,12 @@ struct subject_info_type {
     char padding[1];
     struct muen_resource_type resources[MAX_RESOURCE_COUNT];
 } __attribute__((__packed__));
+
+/*
+ * Return true if both names are equal.
+ */
+bool muen_names_equal(const struct muen_name_type *const n1,
+                      const char *const n2);
 
 /*
  * Check Muen sinfo Magic.

--- a/bindings/muen/start.c
+++ b/bindings/muen/start.c
@@ -58,11 +58,11 @@ DECLARE_ELF_INTERP
 /*
  * The "ABI1" Solo5 ELF note is declared in this module.
  *
- * Muen currently has no formal Solo5 ABI contract, so the version is always 1.
+ * Solo5/Muen uses ABI version 2 as of Muen commit 2a64844.
  */
 ABI1_NOTE_DECLARE_BEGIN
 {
     .abi_target = MUEN_ABI_TARGET,
-    .abi_version = 1
+    .abi_version = 2
 }
 ABI1_NOTE_DECLARE_END


### PR DESCRIPTION
This pull request updates the subject info implementation to Sinfo 03 and increments the ABI version 2. A check for this new ABI version has been added to Muen with commit [2a64844](https://git.codelabs.ch/?p=muen.git;a=commit;h=2a64844).

It has been manually tested to work with the referenced Muen version, by running `test_hello.muen` on Muen in KVM/QEMU.