### PR TITLE
bindings: Prevent OpenBSD from executing Solo5 binaries

### DIFF
--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -40,6 +40,7 @@ PHDRS {
     data PT_LOAD;
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
+    note.not-openbsd PT_NOTE;
 }
 
 /*
@@ -77,6 +78,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :text :note.abi
+    .note.solo5.not-openbsd :
+    {
+        *(.note.solo5.not-openbsd*)
+    } :text :note.not-openbsd
 
     .rodata :
     {

--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -38,9 +38,9 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    note.not-openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
-    note.not-openbsd PT_NOTE;
 }
 
 /*

--- a/bindings/hvt/start.c
+++ b/bindings/hvt/start.c
@@ -65,3 +65,8 @@ ABI1_NOTE_DECLARE_BEGIN
     .abi_version = HVT_ABI_VERSION
 }
 ABI1_NOTE_DECLARE_END
+
+/*
+ * Pretend that we are an OpenBSD executable. See elf_abi.h for details.
+ */
+DECLARE_OPENBSD_NOTE

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -41,6 +41,7 @@ PHDRS {
     data PT_LOAD;
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
+    note.not-openbsd PT_NOTE;
 }
 
 /*
@@ -78,6 +79,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :rodata :note.abi
+    .note.solo5.not-openbsd :
+    {
+        *(.note.solo5.not-openbsd*)
+    } :rodata :note.not-openbsd
 
     .rodata :
     {

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -39,9 +39,9 @@ PHDRS {
                               FLAGS values come from PF_x in elf.h */
     rodata PT_LOAD;
     data PT_LOAD;
+    note.not-openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
-    note.not-openbsd PT_NOTE;
 }
 
 /*

--- a/bindings/muen/start.c
+++ b/bindings/muen/start.c
@@ -66,3 +66,8 @@ ABI1_NOTE_DECLARE_BEGIN
     .abi_version = 2
 }
 ABI1_NOTE_DECLARE_END
+
+/*
+ * Pretend that we are an OpenBSD executable. See elf_abi.h for details.
+ */
+DECLARE_OPENBSD_NOTE

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -40,6 +40,7 @@ PHDRS {
     data PT_LOAD;
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
+    note.not-openbsd PT_NOTE;
 }
 
 /*
@@ -73,11 +74,14 @@ SECTIONS {
     {
         *(.note.solo5.manifest*)
     } :text :note.manifest
-
     .note.solo5.abi :
     {
         *(.note.solo5.abi*)
     } :text :note.abi
+    .note.solo5.not-openbsd :
+    {
+        *(.note.solo5.not-openbsd*)
+    } :text :note.not-openbsd
 
     .rodata :
     {

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -38,9 +38,9 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    note.not-openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
-    note.not-openbsd PT_NOTE;
 }
 
 /*

--- a/bindings/spt/start.c
+++ b/bindings/spt/start.c
@@ -61,3 +61,8 @@ ABI1_NOTE_DECLARE_BEGIN
     .abi_version = SPT_ABI_VERSION
 }
 ABI1_NOTE_DECLARE_END
+
+/*
+ * Pretend that we are an OpenBSD executable. See elf_abi.h for details.
+ */
+DECLARE_OPENBSD_NOTE

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -40,6 +40,7 @@ PHDRS {
     data PT_LOAD;
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
+    note.not-openbsd PT_NOTE;
 }
 
 /*
@@ -95,6 +96,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :data :note.abi
+    .note.solo5.not-openbsd :
+    {
+        *(.note.solo5.not-openbsd*)
+    } :data :note.not-openbsd
 
     /* Read-write data (initialized) */
     .got :

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -38,9 +38,9 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    note.not-openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
-    note.not-openbsd PT_NOTE;
 }
 
 /*

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -107,3 +107,8 @@ ABI1_NOTE_DECLARE_BEGIN
     .abi_version = 1
 }
 ABI1_NOTE_DECLARE_END
+
+/*
+ * Pretend that we are an OpenBSD executable. See elf_abi.h for details.
+ */
+DECLARE_OPENBSD_NOTE

--- a/include/solo5/elf_abi.h
+++ b/include/solo5/elf_abi.h
@@ -156,10 +156,14 @@ struct openbsd_note {
  * PT_INTERP trick to work on OpenBSD hosts, otherwise the host ELF loader
  * fails and the binary gets run via "/bin/sh" (!).
  *
- * Note that the section name does not matter, the OpenBSD kernel only checks
+ * Note 1: the section name does not matter, the OpenBSD kernel only checks
  * n_name and n_type from the PT_NOTE. We deliberately don't use
  * .note.openbsd.ident to make the purpose more obvious to someone inspecting
  * the ELF file "in anger".
+ *
+ * Note 2: for this to work on OpenBSD < 6.7 which has a buggy ELF NOTE parser,
+ * the "pretend to be an OpenBSD executable" NOTE must go in the *first*
+ * PT_NOTE.  See the linker scripts for that.
  */
 #define DECLARE_OPENBSD_NOTE \
 const struct openbsd_note __solo5_openbsd_note \

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -171,8 +171,6 @@ virtio_expect_abort() {
 # ------------------------------------------------------------------------------
 
 @test "noexec host" {
-  skip_unless_host_is Linux FreeBSD
-
   # Here be dragons.
   run test_hello/test_hello.hvt
   case "${CONFIG_HOST}" in
@@ -182,6 +180,10 @@ virtio_expect_abort() {
   FreeBSD)
     # XXX: imgact_elf.c:load_interp() outputs the "ELF interpreter ... not
     # found" using uprintf() here, so we can't test for it. Boo.
+    [ "$status" -eq 134 ]
+    ;;
+  OpenBSD)
+    # XXX: Unclear why the "Abort trap" is not showing up in the output.
     [ "$status" -eq 134 ]
     ;;
   *)


### PR DESCRIPTION
91a2cce408e75d34a34480e9608b36c28fefa69a introduced the feature of preventing host kernels from executing Solo5 binaries directly, by adding a fake non-existent PT_INTERP.

This change makes it work on OpenBSD by pretending to the host kernel that Solo5 binaries are actually OpenBSD native. See the comments in include/solo5/elf_abi.h for details.

Fixes #442.