### PR TITLE
muen: Drop explicit FPU initialization

### DIFF
--- a/bindings/muen/muen-platform_lifecycle.c
+++ b/bindings/muen/muen-platform_lifecycle.c
@@ -22,18 +22,11 @@
 
 const struct mft *muen_manifest = NULL;
 
-void fpu_init(void)
-{
-    const unsigned default_mxcsr = 0x1f80;
-    __asm__ __volatile__("ldmxcsr %0" : : "m"(default_mxcsr));
-}
-
 extern const struct mft1_note __solo5_mft1_note;
 
 void platform_init(const void *arg)
 {
     process_bootinfo(arg);
-    fpu_init();
 
     /*
      * Get the built-in manifest out of the ELF NOTE and validate it.


### PR DESCRIPTION
The MXCSR register is initialized to the default value [1] so there is
no need to explicitly set it.

NOTE: The ABI version is unchanged since there has not been a Solo5 (or
      Muen) release since it was raised to 2.

[1] - Muen commit f10bd6b