### PR TITLE
configure.sh: Improve CRT header copying on BSDs

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -100,8 +100,7 @@ get_header_deps()
         temp="$(mktemp)"
         cd ${path} || exit 1
         ${CC} -M "$@" >${temp} || exit 1
-        cat ${temp} \
-            | sed -e 's!.*\.o:!!g' -e "s!${path}/!!g" \
+        sed -e 's!.*\.o:!!g' -e "s!${path}/!!g" ${temp} \
             | tr ' \\' '\n' \
             | sort \
             | uniq
@@ -196,7 +195,7 @@ config_host_freebsd()
     # cpio will fail if HOST_INCDIR is below a symlink, so squash that
     mkdir -p ${HOST_INCDIR}
     HOST_INCDIR="$(readlink -f ${HOST_INCDIR})"
-    (cd ${INCDIR} && cpio -Lpdm ${HOST_INCDIR} <${DEPS}) || \
+    (cd ${INCDIR} && cpio --quiet -Lpdm ${HOST_INCDIR} <${DEPS}) || \
         die "Failure copying host headers"
     rm ${DEPS}
 


### PR DESCRIPTION
The *BSD C runtime header copying code is somewhat fragile and requires
manually keeping track of dependencies of each header that gets copied.

This change uses cc -M to gather a list of dependencies of all the
requested header files, and then cpio to copy the result including
intermediate directories to the target directory.

While I'm at it, remove osreldate.h from SRCS= on FreeBSD, since
as far as I can tell there's nothing that depends on that.

/cc @hannesm @adamsteen