### PR TITLE
get configure script to work for gcc > 9

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -32,7 +32,7 @@ warn()
 
 cc_maybe_gcc()
 {
-    ${CC} -dM -E - </dev/null | grep -Eq '^#define __GNUC__ [4-9]$'
+    ${CC} -dM -E - </dev/null | grep -Eq '^#define __GNUC__ ([4-9]$|[1-9][0-9]+$)'
 }
 
 cc_is_clang()


### PR DESCRIPTION
This fixes the build for me and i'm able to install solo5-bindings-hvt after this, and build my mirageOS application. Apologies if the upper limit for gcc was set to 9 on purpose, and 10 is not supposed to be supported just yet.

reference: #458