### PR TITLE
configure.sh: Don't install osreldate.h on FreeBSD

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -188,7 +188,7 @@ config_host_freebsd()
     # clang-provided headers for compiler instrinsics. We copy the rest
     # (std*.h, float.h and their dependencies) from the host.
     INCDIR=/usr/include
-    SRCS="float.h osreldate.h stddef.h stdint.h stdbool.h stdarg.h"
+    SRCS="float.h stddef.h stdint.h stdbool.h stdarg.h"
     DEPS="$(mktemp)"
     get_header_deps ${INCDIR} ${SRCS} >${DEPS} || \
         die "Failure getting dependencies of host headers"

--- a/opam/solo5-bindings-genode.opam
+++ b/opam/solo5-bindings-genode.opam
@@ -21,6 +21,7 @@ depends: [
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
   "solo5-bindings-hvt"
   "solo5-bindings-spt"
   "solo5-bindings-virtio"

--- a/opam/solo5-bindings-hvt.opam
+++ b/opam/solo5-bindings-hvt.opam
@@ -30,6 +30,7 @@ depexts: [
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
   "solo5-bindings-spt"
   "solo5-bindings-virtio"
   "solo5-bindings-muen"

--- a/opam/solo5-bindings-muen.opam
+++ b/opam/solo5-bindings-muen.opam
@@ -23,6 +23,7 @@ depends: [
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
   "solo5-bindings-genode"
   "solo5-bindings-hvt"
   "solo5-bindings-spt"

--- a/opam/solo5-bindings-spt.opam
+++ b/opam/solo5-bindings-spt.opam
@@ -30,6 +30,7 @@ depexts: [
   ["linux-libc-dev"] {os-distribution = "ubuntu"}
 ]
 conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
   "solo5-bindings-hvt"
   "solo5-bindings-virtio"
   "solo5-bindings-muen"

--- a/opam/solo5-bindings-virtio.opam
+++ b/opam/solo5-bindings-virtio.opam
@@ -23,6 +23,7 @@ depends: [
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
   "solo5-bindings-hvt"
   "solo5-bindings-spt"
   "solo5-bindings-muen"


### PR DESCRIPTION
With the release of ocaml-freestanding 0.6.0, we can drop osreldate.h
from the list of system/CRT headers installed on FreeBSD.

Fixes #456.