### PR TITLE
OPAM: Update metadata

### DIFF
--- a/opam/solo5-bindings-genode.opam
+++ b/opam/solo5-bindings-genode.opam
@@ -12,10 +12,6 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "install-opam-genode" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}

--- a/opam/solo5-bindings-hvt.opam
+++ b/opam/solo5-bindings-hvt.opam
@@ -14,20 +14,15 @@ build: [
   [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-hvt" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/opam/solo5-bindings-muen.opam
+++ b/opam/solo5-bindings-muen.opam
@@ -14,10 +14,6 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "install-opam-muen" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}

--- a/opam/solo5-bindings-spt.opam
+++ b/opam/solo5-bindings-spt.opam
@@ -14,20 +14,15 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-spt" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-spt" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-distribution = "debian"}
   ["kernel-headers"] {os-distribution = "fedora"}
   ["kernel-headers"] {os-distribution = "rhel"}
-  ["linux-libc-dev"] {os-distribution = "ubuntu"}
+  ["linux-libc-dev"] {os-family = "debian"}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/opam/solo5-bindings-virtio.opam
+++ b/opam/solo5-bindings-virtio.opam
@@ -14,10 +14,6 @@ build: [
   [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="]
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-virtio" "PREFIX=%{prefix}%"]
-remove: [
-  ["touch" "./Makeconf"]
-  [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]
-]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}


### PR DESCRIPTION
OPAM 2.x no longer needs a "remove:", and fold Debian and Ubuntu depexts
into "os-family".

Fixes #465.