### PR TITLE
xen: Fix assembler warnings in hypercall_page.S

### DIFF
--- a/bindings/xen/hypercall_page.S
+++ b/bindings/xen/hypercall_page.S
@@ -79,6 +79,7 @@ HYPERCALL_PAGE:
 #define DECLARE_HYPERCALL(name)                                             \
     .globl HYPERCALL_ ## name;                                              \
     .set   HYPERCALL_ ## name, HYPERCALL_PAGE + __HYPERVISOR_ ## name * 32; \
+    .type  HYPERCALL_ ## name, STT_NOTYPE;                                  \
     .type  HYPERCALL_ ## name, STT_FUNC;                                    \
     .size  HYPERCALL_ ## name, 32
 


### PR DESCRIPTION
Recent versions of gas emit a warning when the type of a symbol is
changed between incompatible types. DECLARE_HYPERCALL() does this
intentionally, so silence the warning using the method suggested in the
manual [1].

[1] https://sourceware.org/binutils/docs/as/Type.html#Type