### PR TITLE
spt: Load seccomp filter manually

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -561,19 +561,18 @@ xen_expect_abort() {
   expect_success
 }
 
-# Disabled until we have a fix for #477.
-# @test "mft_maxdevices spt" {
-#   for num in $(${SEQ} 0 62); do
-#       dd if=/dev/zero of=${BATS_TMPDIR}/storage${num}.img \
-#           bs=4k count=1 status=none
-#   done
-#
-#   DEVS=$(
-#   for num in $(${SEQ} 0 62); do
-#       echo -n "--block:storage${num}=${BATS_TMPDIR}/storage${num}.img "
-#   done
-#   )
-#
-#   spt_run ${DEVS} -- test_mft_maxdevices/test_mft_maxdevices.spt
-#   expect_success
-# }
+@test "mft_maxdevices spt" {
+  for num in $(${SEQ} 0 62); do
+      dd if=/dev/zero of=${BATS_TMPDIR}/storage${num}.img \
+          bs=4k count=1 status=none
+  done
+
+  DEVS=$(
+  for num in $(${SEQ} 0 62); do
+      echo -n "--block:storage${num}=${BATS_TMPDIR}/storage${num}.img "
+  done
+  )
+
+  spt_run ${DEVS} -- test_mft_maxdevices/test_mft_maxdevices.spt
+  expect_success
+}


### PR DESCRIPTION
libseccomp's seccomp_load() calls free(), which, depending on the libc
malloc() behaviour and generated BPF filter size may call brk(), which
we do not have in our seccomp filter. This leads to a crash during
solo5-spt start-up on some systems.

Work around this by exporting the generated BPF and loading it into the
kernel manually with seccomp().

Fixes #477.