### PR TITLE
Put Solo5 headers and tools in a standalone package

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -162,6 +162,9 @@ ifdef CONFIG_VIRTIO
 	cp scripts/virtio-run/solo5-virtio-run.sh \
 	    $(PREFIX)/bin/solo5-virtio-run
 endif
+ifdef CONFIG_XEN
+	cp -R include/xen/ $(PREFIX)/include/solo5-bindings-xen
+endif
 
 # uninstall-opam-% may not have a Makeconf available, so should always uninstall
 # all build products from all solo5-bindings variants regardless.

--- a/opam/solo5-bindings-genode.opam
+++ b/opam/solo5-bindings-genode.opam
@@ -17,12 +17,7 @@ depends: [
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [
-  "ocaml-freestanding" {< "0.6.0"}
-  "solo5-bindings-hvt"
-  "solo5-bindings-spt"
-  "solo5-bindings-virtio"
-  "solo5-bindings-muen"
-  "solo5-bindings-xen"
+  "ocaml-freestanding" {< "0.7.0"}
 ]
 available: [
   arch = "x86_64" &

--- a/opam/solo5-bindings-genode.pc.in
+++ b/opam/solo5-bindings-genode.pc.in
@@ -6,6 +6,7 @@ ld=!PC_LD!
 ldflags=!PC_GENODE_LDFLAGS! -T ${libdir}/genode_dyn.ld ${libdir}/solo5.lib.so
 
 Name: solo5-bindings-genode
-Version: 0.6.0
+Version: 0.7.0
 Description: Solo5 sandboxed execution environment (Genode target)
-Cflags: !PC_GENODE_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5
+Requires: solo5-headers
+Libs: ${ldflags}

--- a/opam/solo5-bindings-hvt.opam
+++ b/opam/solo5-bindings-hvt.opam
@@ -17,7 +17,7 @@ install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "solo5-headers"
+  "solo5-headers" {= version}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/opam/solo5-bindings-hvt.opam
+++ b/opam/solo5-bindings-hvt.opam
@@ -17,6 +17,7 @@ install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
+  "solo5-headers"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
@@ -25,12 +26,7 @@ depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
 ]
 conflicts: [
-  "ocaml-freestanding" {< "0.6.0"}
-  "solo5-bindings-spt"
-  "solo5-bindings-virtio"
-  "solo5-bindings-muen"
-  "solo5-bindings-genode"
-  "solo5-bindings-xen"
+  "ocaml-freestanding" {< "0.7.0"}
 ]
 available: [
   (arch = "x86_64" | arch = "arm64") &

--- a/opam/solo5-bindings-hvt.pc.in
+++ b/opam/solo5-bindings-hvt.pc.in
@@ -6,6 +6,7 @@ ld=!PC_LD!
 ldflags=!PC_LDFLAGS! -T ${libdir}/solo5_hvt.lds ${libdir}/solo5_hvt.o
 
 Name: solo5-bindings-hvt
-Version: 0.6.0
+Version: 0.7.0
 Description: Solo5 sandboxed execution environment (hvt target)
-Cflags: !PC_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5
+Requires: solo5-headers
+Libs: ${ldflags}

--- a/opam/solo5-bindings-muen.opam
+++ b/opam/solo5-bindings-muen.opam
@@ -17,7 +17,7 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "solo5-headers"
+  "solo5-headers" {= version}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.7.0"}

--- a/opam/solo5-bindings-muen.opam
+++ b/opam/solo5-bindings-muen.opam
@@ -17,14 +17,10 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
+  "solo5-headers"
 ]
 conflicts: [
-  "ocaml-freestanding" {< "0.6.0"}
-  "solo5-bindings-genode"
-  "solo5-bindings-hvt"
-  "solo5-bindings-spt"
-  "solo5-bindings-virtio"
-  "solo5-bindings-xen"
+  "ocaml-freestanding" {< "0.7.0"}
 ]
 available: [
   arch = "x86_64" &

--- a/opam/solo5-bindings-muen.pc.in
+++ b/opam/solo5-bindings-muen.pc.in
@@ -6,6 +6,7 @@ ld=!PC_LD!
 ldflags=!PC_LDFLAGS! -T ${libdir}/solo5_muen.lds ${libdir}/solo5_muen.o
 
 Name: solo5-bindings-muen
-Version: 0.6.0
+Version: 0.7.0
 Description: Solo5 sandboxed execution environment (Muen target)
-Cflags: !PC_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5
+Requires: solo5-headers
+Libs: ${ldflags}

--- a/opam/solo5-bindings-spt.opam
+++ b/opam/solo5-bindings-spt.opam
@@ -17,6 +17,7 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
+  "solo5-headers"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
@@ -25,12 +26,7 @@ depexts: [
   ["linux-libc-dev"] {os-family = "debian"}
 ]
 conflicts: [
-  "ocaml-freestanding" {< "0.6.0"}
-  "solo5-bindings-hvt"
-  "solo5-bindings-virtio"
-  "solo5-bindings-muen"
-  "solo5-bindings-genode"
-  "solo5-bindings-xen"
+  "ocaml-freestanding" {< "0.7.0"}
 ]
 available: [
   (arch = "x86_64" | arch = "arm64") & os = "linux"

--- a/opam/solo5-bindings-spt.opam
+++ b/opam/solo5-bindings-spt.opam
@@ -17,7 +17,7 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "solo5-headers"
+  "solo5-headers" {= version}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/opam/solo5-bindings-spt.pc.in
+++ b/opam/solo5-bindings-spt.pc.in
@@ -6,6 +6,7 @@ ld=!PC_LD!
 ldflags=!PC_LDFLAGS! -T ${libdir}/solo5_spt.lds ${libdir}/solo5_spt.o
 
 Name: solo5-bindings-spt
-Version: 0.6.0
+Version: 0.7.0
 Description: Solo5 sandboxed execution environment (spt target)
-Cflags: !PC_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5
+Requires: solo5-headers
+Libs: ${ldflags}

--- a/opam/solo5-bindings-virtio.opam
+++ b/opam/solo5-bindings-virtio.opam
@@ -17,7 +17,7 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "solo5-headers"
+  "solo5-headers" {= version}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.7.0"}

--- a/opam/solo5-bindings-virtio.opam
+++ b/opam/solo5-bindings-virtio.opam
@@ -17,14 +17,10 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
+  "solo5-headers"
 ]
 conflicts: [
-  "ocaml-freestanding" {< "0.6.0"}
-  "solo5-bindings-hvt"
-  "solo5-bindings-spt"
-  "solo5-bindings-muen"
-  "solo5-bindings-genode"
-  "solo5-bindings-xen"
+  "ocaml-freestanding" {< "0.7.0"}
 ]
 available: [
   arch = "x86_64" &

--- a/opam/solo5-bindings-virtio.pc.in
+++ b/opam/solo5-bindings-virtio.pc.in
@@ -5,6 +5,7 @@ libdir=${exec_prefix}/lib/solo5-bindings-virtio
 ldflags=!PC_LDFLAGS! -T ${libdir}/solo5_virtio.lds ${libdir}/solo5_virtio.o
 
 Name: solo5-bindings-virtio
-Version: 0.6.0
+Version: 0.7.0
 Description: Solo5 sandboxed execution environment (virtio target)
-Cflags: !PC_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5
+Requires: solo5-headers
+Libs: ${ldflags}

--- a/opam/solo5-bindings-xen.opam
+++ b/opam/solo5-bindings-xen.opam
@@ -17,7 +17,7 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "solo5-headers"
+  "solo5-headers" {= version}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.7.0"}

--- a/opam/solo5-bindings-xen.pc.in
+++ b/opam/solo5-bindings-xen.pc.in
@@ -10,3 +10,4 @@ Version: 0.7.0
 Description: Solo5 sandboxed execution environment (xen target)
 Requires: solo5-headers
 Libs: ${ldflags}
+Cflags: -I${includedir}

--- a/opam/solo5-bindings-xen.pc.in
+++ b/opam/solo5-bindings-xen.pc.in
@@ -6,6 +6,7 @@ ld=!PC_LD!
 ldflags=!PC_LDFLAGS! -T ${libdir}/solo5_xen.lds ${libdir}/solo5_xen.o
 
 Name: solo5-bindings-xen
-Version: 0.6.0
+Version: 0.7.0
 Description: Solo5 sandboxed execution environment (xen target)
-Cflags: !PC_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5
+Requires: solo5-headers
+Libs: ${ldflags}

--- a/opam/solo5-headers.opam
+++ b/opam/solo5-headers.opam
@@ -16,6 +16,7 @@ build: [
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-headers" "PREFIX=%{prefix}%"]
 depends: [
   "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.7.0"}

--- a/opam/solo5-headers.opam
+++ b/opam/solo5-headers.opam
@@ -11,29 +11,24 @@ license: "ISC"
 dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [
   ["./configure.sh"]
-  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN="]
 ]
-install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-xen" "PREFIX=%{prefix}%"]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-headers" "PREFIX=%{prefix}%"]
 depends: [
   "conf-pkg-config"
-  "conf-libseccomp" {build & os = "linux"}
-  "solo5-headers"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.7.0"}
 ]
 available: [
-  (arch = "x86_64") &
+  (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
-synopsis: "Solo5 sandboxed execution environment (xen target)"
+synopsis: "Solo5 sandboxed execution environment (headers)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended
 for, but not limited to, running applications built using various
 unikernels (a.k.a.  library operating systems).
 
-This package provides the Solo5 components needed to build and
-run MirageOS unikernels on the "xen" target.
-
-The "xen" target is supported on 64-bit Linux, FreeBSD and
-OpenBSD systems with hardware virtualization."""
+This package provides the Solo5 API and tools.
+"""

--- a/opam/solo5-headers.pc.in
+++ b/opam/solo5-headers.pc.in
@@ -1,0 +1,9 @@
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+includedir=${prefix}/include/solo5-headers
+libdir=${exec_prefix}/lib/solo5-headers
+
+Name: solo5-headers
+Version: 0.7.0
+Description: Solo5 sandboxed execution environment (headers)
+Cflags: !PC_CFLAGS! -isystem ${includedir}/crt -I${includedir}/solo5


### PR DESCRIPTION
This PR separates headers/tools from bindings, allowing to set-up ocaml-freestanding as a cross-compiler without having any binding installed, see https://github.com/mirage/ocaml-freestanding/pull/90. 

This also implies that bindings are now co-installable, as they are chosen link-time by the mirage tool.  

I've messed up a bit with opam files, I'm not sure what version bump you want to make (-> `0.7.0` or `1.0.0`) so I assumed `0.7.0`. 
