### PR TITLE
xen: Wait for console backend to process data

### DIFF
--- a/bindings/xen/console.c
+++ b/bindings/xen/console.c
@@ -125,11 +125,9 @@ void console_write(const char *buf, size_t len)
 
     } while (written < len);
 
-#if 0 /* For debugging only, no need to wait synchronously here. */
     /* Wait for xenconsoled to consume all the data we gave. */
     while (ACCESS_ONCE(console_ring->out_cons) != console_ring->out_prod)
         hypercall_yield();
-#endif
 }
 
 void console_init(void)


### PR DESCRIPTION
Left-over from development. Fixes #489.

@talex5 Any objections? This doesn't seem any less performant than what Mini-OS was doing, and just does exactly what the XTF [code](https://xenbits.xen.org/gitweb/?p=xtf.git;a=blob;f=common/console.c;h=b3e89473a7b43266b41b72dff45d7865aa199db9;hb=HEAD#l79) does. It fixes the test unikernel for me, though I can see in real-time that it's pausing for console writes.