### PR TITLE
virtio: add missing reset for net and blk devices

### DIFF
--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -152,6 +152,7 @@ void virtio_config_block(struct pci_config_info *pci)
     uint32_t host_features, guest_features;
     size_t pgs;
 
+    outb(pci->base + VIRTIO_PCI_STATUS, 0);
     outb(pci->base + VIRTIO_PCI_STATUS, ready_for_init);
 
     host_features = inl(pci->base + VIRTIO_PCI_HOST_FEATURES);

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -141,6 +141,13 @@ void virtio_config_network(struct pci_config_info *pci)
     size_t pgs;
 
     /*
+     * 3.1.1 Driver Requirements: Device Initialization
+     *
+     * 1. Reset the device.
+     */
+    outb(pci->base + VIRTIO_PCI_STATUS, 0);
+
+    /*
      * 2. Set the ACKNOWLEDGE status bit: the guest OS has notice the device.
      * 3. Set the DRIVER status bit: the guest OS knows how to drive the device.
      */


### PR DESCRIPTION
The configuration functions for virtio blk and net were missing the first step
of the device initialization sequence (virtio spec 1.0).
```
	3.1.1 Driver Requirements: Device Initialization
	The driver MUST follow this sequence to initialize a device:
	1. reset the device.
	2. ... <=== we seem to follow everything nicely after this
```
The consequence of this is that a vmm (like QEMU) couldn't boot using a disk
image exposed as a virtio-blk device. This was reported in issue 483.  The
issue is that the boot loader (before solo5 discover the virtio devices)
initializes the device, negotiates features, and reads the kernel from it. The
solo5 kernel then tries to negotiate features again, which is fine, except that
it does it without a reset. This is wrong according to the spec:
```
	2.2 Feature Bits
	... The only way to renegotiate is to reset the device.
```
Tested:
```
	cd tests
	../scripts/virtio-mkimage/solo5-virtio-mkimage.sh -f raw \
		disk-net.img test_net/test_net.virtio
	sudo qemu-system-x86_64 -drive file=disk-net.img,if=virtio,format=raw \
		-cpu Westmere -m 128 -nodefaults -no-acpi -display none \
		-serial stdio -device virtio-net,netdev=n0 \
		-netdev tap,id=n0,ifname=tap100,script=no,downscript=no \
		-device isa-debug-exit
	ping 10.0.0.2 # works
```