### PR TITLE
Fix LD scripts syntax

### DIFF
--- a/bindings/hvt/solo5_hvt.lds
+++ b/bindings/hvt/solo5_hvt.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
 }
@@ -78,10 +78,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :text :note.abi
-    .note.solo5.not-openbsd :
+    .note.solo5.not_openbsd :
     {
-        *(.note.solo5.not-openbsd*)
-    } :text :note.not-openbsd
+        *(.note.solo5.not_openbsd*)
+    } :text :note.not_openbsd
 
     .rodata :
     {

--- a/bindings/muen/solo5_muen.lds
+++ b/bindings/muen/solo5_muen.lds
@@ -39,7 +39,7 @@ PHDRS {
                               FLAGS values come from PF_x in elf.h */
     rodata PT_LOAD;
     data PT_LOAD;
-    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
 }
@@ -79,10 +79,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :rodata :note.abi
-    .note.solo5.not-openbsd :
+    .note.solo5.not_openbsd :
     {
-        *(.note.solo5.not-openbsd*)
-    } :rodata :note.not-openbsd
+        *(.note.solo5.not_openbsd*)
+    } :rodata :note.not_openbsd
 
     .rodata :
     {

--- a/bindings/spt/solo5_spt.lds
+++ b/bindings/spt/solo5_spt.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
 }
@@ -78,10 +78,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :text :note.abi
-    .note.solo5.not-openbsd :
+    .note.solo5.not_openbsd :
     {
-        *(.note.solo5.not-openbsd*)
-    } :text :note.not-openbsd
+        *(.note.solo5.not_openbsd*)
+    } :text :note.not_openbsd
 
     .rodata :
     {

--- a/bindings/virtio/solo5_virtio.lds
+++ b/bindings/virtio/solo5_virtio.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
 }
@@ -96,10 +96,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :data :note.abi
-    .note.solo5.not-openbsd :
+    .note.solo5.not_openbsd :
     {
-        *(.note.solo5.not-openbsd*)
-    } :data :note.not-openbsd
+        *(.note.solo5.not_openbsd*)
+    } :data :note.not_openbsd
 
     /* Read-write data (initialized) */
     .got :

--- a/bindings/xen/solo5_xen.lds
+++ b/bindings/xen/solo5_xen.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.not_openbsd PT_NOTE; /* Must come first. */
     note.xen PT_NOTE;
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -97,10 +97,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :data :note.abi
-    .note.solo5.not-openbsd :
+    .note.solo5.not_openbsd :
     {
-        *(.note.solo5.not-openbsd*)
-    } :data :note.not-openbsd
+        *(.note.solo5.not_openbsd*)
+    } :data :note.not_openbsd
     .note.solo5.xen :
     {
         *(.note.solo5.xen*)

--- a/include/solo5/elf_abi.h
+++ b/include/solo5/elf_abi.h
@@ -168,7 +168,7 @@ struct openbsd_note {
  */
 #define DECLARE_OPENBSD_NOTE \
 const struct openbsd_note __solo5_openbsd_note \
-__attribute__ ((section (".note.solo5.not-openbsd"), aligned(4))) \
+__attribute__ ((section (".note.solo5.not_openbsd"), aligned(4))) \
 = { \
     .n_namesz = 8, \
     .n_descsz = 4, \


### PR DESCRIPTION
Although this syntax is supported by newer versions of GNU ld, it looks it's not supported some older releases. This seems to fix the problem and works for both older and newer versions.

Here's my version of ld, which is still the newer version for Fedora 35 https://src.fedoraproject.org/rpms/binutils
```
GNU ld version 2.37-10.fc35
Copyright (C) 2021 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```

I have tested on the current trunk for GNU binutils and it seems to work tough, which is the same minor version.
```
GNU ld (GNU Binutils) 2.37.50.20211207
Copyright (C) 2021 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```