### PR TITLE
Fix syntax error in stubs ld file

### DIFF
--- a/bindings/solo5_stub.lds
+++ b/bindings/solo5_stub.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
 }
@@ -78,10 +78,10 @@ SECTIONS {
     {
         *(.note.solo5.abi*)
     } :text :note.abi
-    .note.solo5.not-openbsd :
+    .note.solo5.not_openbsd :
     {
-        *(.note.solo5.not-openbsd*)
-    } :text :note.not-openbsd
+        *(.note.solo5.not_openbsd*)
+    } :text :note.not_openbsd
 
     .rodata :
     {


### PR DESCRIPTION
When switching to Fedora 35 and updating to solo5 0.7.0, I've encountered again the error that was fixed by https://github.com/Solo5/solo5/pull/502.
What happened is that in the new stubs ld file introduced in https://github.com/Solo5/solo5/pull/506, the breaking syntax was still used.
