### PR TITLE
Fix our opam-release.sh script

### DIFF
--- a/scripts/opam-release.sh
+++ b/scripts/opam-release.sh
@@ -43,7 +43,7 @@ url {
   checksum: "sha512=${CHECKSUM}"
 }
 EOM
-for VARIANT in '' 'cross-aarch64'; do
+for VARIANT in '' '-cross-aarch64'; do
     PKG_DIR=${OUTPUT_DIR}/packages/solo5${VARIANT}/solo5${VARIANT}.${OPAM_VERSION}
     mkdir -p ${PKG_DIR} || exit 1
     cat opam/solo5${VARIANT}.opam ${OUTPUT_DIR}/tmp/url \


### PR DESCRIPTION
reported by @hannesm as a missing commit from the Solo5.0.7.0 release.