### PR TITLE
Suppress gcc array bounds warning in test_zeropage

### DIFF
--- a/tests/test_zeropage/test_zeropage.c
+++ b/tests/test_zeropage/test_zeropage.c
@@ -21,7 +21,10 @@
 #include "solo5.h"
 #include "../../bindings/lib.c"
 
-/* Silence GCC's array bounds warning when accessing memory at address "8" */
+/* 
+ * Silence GCC's array bounds warning when accessing memory at address "8".
+ * See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578
+ */
 #pragma GCC diagnostic ignored "-Warray-bounds"
 
 static void puts(const char *s)

--- a/tests/test_zeropage/test_zeropage.c
+++ b/tests/test_zeropage/test_zeropage.c
@@ -21,6 +21,9 @@
 #include "solo5.h"
 #include "../../bindings/lib.c"
 
+/* Silence GCC's array bounds warning when accessing memory at address "8" */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
 static void puts(const char *s)
 {
     solo5_console_write(s, strlen(s));


### PR DESCRIPTION
gcc 12 fails to compile test_zeropage. I have tested this with version 12.1.0 and 12.1.1.
This also breaks the installation via opam on Fedora 36 for me.

```
...
CC test_zeropage.o
test_zeropage.c: In function 'solo5_app_main':
test_zeropage.c:39:5: error: array subscript 0 is outside array bounds of 'uint64_t[0]' {aka 'long unsigned int[]'} [-Werror=array-bounds]
   39 |     *addr_invalid = 1;
      |     ^~~~~~~~~~~~~
```

There has been some discussion about similar issues on the gcc bug tracker.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578

The best workaround currently seems to be to disable the array bounds diagnostic for cases like this. 