### PR TITLE
xen: remove the "skip the first token in the cmdline" from multiboot code path

### DIFF
--- a/bindings/xen/platform.c
+++ b/bindings/xen/platform.c
@@ -240,18 +240,6 @@ static void parse_multiboot(const void *arg)
         char *mi_cmdline = (char *)(uint64_t)mi->cmdline;
         size_t cmdline_len = strlen(mi_cmdline);
 
-        /*
-         * Skip the first token in the cmdline as it is an opaque "name" for
-         * the kernel coming from the bootloader.
-         */
-        for (; *mi_cmdline; mi_cmdline++, cmdline_len--) {
-            if (*mi_cmdline == ' ') {
-                mi_cmdline++;
-                cmdline_len--;
-                break;
-            }
-        }
-
         if (cmdline_len >= sizeof(cmdline)) {
             cmdline_len = sizeof(cmdline) - 1;
             log(WARN, "Solo5: warning: command line too long, truncated\n");


### PR DESCRIPTION
On recent QubesOS (4.1), this "opaque 'name'" is not present in the multiboot
cmdline.

//cc @xaki23 @palinp @marmarek