### PR TITLE
tenders, FreeBSD, tap: Ignore "up" variable to avoid compiler warning

### DIFF
--- a/tenders/common/tap_attach.c
+++ b/tenders/common/tap_attach.c
@@ -162,6 +162,13 @@ int tap_attach(const char *ifname)
 
 #elif defined(__FreeBSD__)
 
+    /*
+     * Avoid unused-but-set-variable warning on FreeBSD, where the tap device
+     * is only up once open() was called by the process.
+     */
+    if (!up)
+      ;
+
     char devname[strlen(ifname) + 6];
 
     snprintf(devname, sizeof devname, "/dev/%s", ifname);


### PR DESCRIPTION
The unused-but-set-variable warning was emitted for the variable "up", which is
not used on FreeBSD. To keep the code simple (not introducing further ifdefs),
just ignore it via an empty conditional. Fixes #519.