### PR TITLE
Fix broken API doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ hypervisors.
 
 Some of the unique features of Solo5:
 
-- a public ("guest-facing") [API](include/solo5/solo5.h) designed for ease of
+- a public ("guest-facing") [API](include/solo5.h) designed for ease of
   porting existing and future unikernel-native applications,
 - this aforementioned API facilitates the implementation of ("host-facing")
   _bindings_ and _tenders_ designed with isolation, a _minimal attack surface_


### PR DESCRIPTION
It fixes the broken API documentation link in `README.md`. (I guess it has been broken since [This commit](https://github.com/Solo5/solo5/pull/506/files#diff-9203b578f4415778e29f41c81e1e796621a1c1115bface8840e9c114e89029d6))