### PR TITLE
Be more informative when tap_attach fails

### DIFF
--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -116,7 +116,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         }
         int fd = tap_attach(iface);
         if (fd < 0) {
-            warnx("Could not attach interface: %s", iface);
+            warnx("Could not attach interface: %s: %s", iface, strerror(errno));
             return -1;
         }
 

--- a/tenders/spt/spt_module_net.c
+++ b/tenders/spt/spt_module_net.c
@@ -24,6 +24,7 @@
 
 #include <assert.h>
 #include <err.h>
+#include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -67,7 +68,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         }
         int fd = tap_attach(iface);
         if (fd < 0) {
-            warnx("Could not attach interface: %s", iface);
+            warnx("Could not attach interface: %s: %s", iface, strerror(errno));
             return -1;
         }
 


### PR DESCRIPTION
As it is now the error message when attaching to a tap interface fails does not give any explanation as to why it failed.
```
solo5-spt: Could not attach interface: temp0
```
I reviewed the code for `tap_attach`, and in all paths where `-1` is returned either `errno` is set directly or a previous call will have set it. With this patch `strerror(errno)` is added at the end of the warning:
```
solo5-spt: Could not attach interface: temp0: Network is down
```
Now I know to run `ip link set temp0 up` :-)