### PR TITLE
Fix test_time test.

### DIFF
--- a/tests/test_time/test_time.c
+++ b/tests/test_time/test_time.c
@@ -110,7 +110,8 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
         /*
          * Verify that we did not sleep less than requested (see above).
          */
-        if (delta < NSEC_PER_SEC) {
+        const solo5_time_t slack = 100000000ULL;
+        if (delta < NSEC_PER_SEC - slack) {
             printf("[%d] ERROR: slept too little (expected at least %llu ns)\n",
                     iters, (unsigned long long)NSEC_PER_SEC);
             failed = true;
@@ -120,7 +121,6 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
          * Verify that we did not sleep more than requested, within reason
          * (scheduling delays, general inaccuracy of the current timing code).
          */
-        const solo5_time_t slack = 100000000ULL;
         if (delta > (NSEC_PER_SEC + slack)) {
             printf("[%d] ERROR: slept too much (expected at most %llu ns)\n",
                     iters, (unsigned long long)slack);


### PR DESCRIPTION
Sometimes sleep() may return a bit earlier than expected, again,
due to scheduling reasons. This should be accounted for as well.

For example, on my machine I had this:
```
# **** Solo5 standalone test_time ****
# 
# Overhead of solo5_yield(): 12518 ns
# [5] Sleeping for one second...
# [5] Slept for 999995014 ns
# [5] ERROR: slept too little (expected at least 1000000000 ns)
# [4] Sleeping for one second...
# [4] Slept for 1000012023 ns
# [3] Sleeping for one second...
# [3] Slept for 1000001308 ns
# [2] Sleeping for one second...
# [2] Slept for 1000001248 ns
# [1] Sleeping for one second...
# [1] Slept for 1000001078 ns
# Solo5: solo5_exit(1) called
```