### PR TITLE
block_attach: check file is aligned

### DIFF
--- a/tenders/common/block_attach.c
+++ b/tenders/common/block_attach.c
@@ -45,6 +45,8 @@ int block_attach(const char *path, off_t *capacity_)
     if (capacity < 512)
         errx(1, "%s: Backing storage must be at least 1 block (512 bytes) "
                 "in size", path);
+    if (capacity & (512 - 1))
+        err(1, "%s: Backing storage size must be block aligned (512 bytes)", path);
 
     *capacity_ = capacity;
     return fd;

--- a/tenders/common/block_attach.c
+++ b/tenders/common/block_attach.c
@@ -46,7 +46,7 @@ int block_attach(const char *path, off_t *capacity_)
         errx(1, "%s: Backing storage must be at least 1 block (512 bytes) "
                 "in size", path);
     if (capacity & (512 - 1))
-        err(1, "%s: Backing storage size must be block aligned (512 bytes)", path);
+        errx(1, "%s: Backing storage size must be block aligned (512 bytes)", path);
 
     *capacity_ = capacity;
     return fd;


### PR DESCRIPTION
Otherwise if the file is not a multiple of block_size (512) we have to make up bytes for the missing part.