### PR TITLE
Custom block size

### DIFF
--- a/tenders/common/block_attach.c
+++ b/tenders/common/block_attach.c
@@ -30,13 +30,15 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <assert.h>
 
 /*
  * Attach to the block device specified by (path), returning its capacity in
- * bytes in (*capacity).
+ * bytes in (*capacity). The block size (block_size) must be a power of two.
  */
 int block_attach(const char *path, uint16_t block_size, off_t *capacity_)
 {
+    assert((block_size & (block_size - 1)) == 0);
     int fd = open(path, O_RDWR);
     if (fd == -1)
         err(1, "Could not open block device: %s", path);
@@ -46,6 +48,7 @@ int block_attach(const char *path, uint16_t block_size, off_t *capacity_)
     if (capacity < block_size)
         errx(1, "%s: Backing storage must be at least 1 block (%hu bytes) "
                 "in size", path, block_size);
+    /* this assumes block_size is a power of 2 */
     if ((capacity & (block_size - 1)) != 0)
         errx(1, "%s: Backing storage size must be block aligned (%hu bytes)",
                 path, block_size);

--- a/tenders/common/block_attach.c
+++ b/tenders/common/block_attach.c
@@ -45,6 +45,8 @@ int block_attach(const char *path, off_t *capacity_)
     if (capacity < 512)
         errx(1, "%s: Backing storage must be at least 1 block (512 bytes) "
                 "in size", path);
+    if (capacity & (512 - 1))
+        err(1, "%s: Backing storage size must be block aligned (512 bytes)", path);
 
     *capacity_ = capacity;
     return fd;

--- a/tenders/common/block_attach.c
+++ b/tenders/common/block_attach.c
@@ -34,24 +34,16 @@
 
 /*
  * Attach to the block device specified by (path), returning its capacity in
- * bytes in (*capacity). The block size (block_size) must be a power of two.
+ * bytes in (*capacity).
  */
-int block_attach(const char *path, uint16_t block_size, off_t *capacity_)
+int block_attach(const char *path, off_t *capacity_)
 {
-    assert((block_size & (block_size - 1)) == 0);
     int fd = open(path, O_RDWR);
     if (fd == -1)
         err(1, "Could not open block device: %s", path);
     off_t capacity = lseek(fd, 0, SEEK_END);
     if (capacity == -1)
         err(1, "%s: Could not determine capacity", path);
-    if (capacity < block_size)
-        errx(1, "%s: Backing storage must be at least 1 block (%hu bytes) "
-                "in size", path, block_size);
-    /* this assumes block_size is a power of 2 */
-    if ((capacity & (block_size - 1)) != 0)
-        errx(1, "%s: Backing storage size must be block aligned (%hu bytes)",
-                path, block_size);
 
     *capacity_ = capacity;
     return fd;

--- a/tenders/common/block_attach.c
+++ b/tenders/common/block_attach.c
@@ -46,7 +46,7 @@ int block_attach(const char *path, off_t *capacity_)
         errx(1, "%s: Backing storage must be at least 1 block (512 bytes) "
                 "in size", path);
     if (capacity & (512 - 1))
-        err(1, "%s: Backing storage size must be block aligned (512 bytes)", path);
+        errx(1, "%s: Backing storage size must be block aligned (512 bytes)", path);
 
     *capacity_ = capacity;
     return fd;

--- a/tenders/common/block_attach.h
+++ b/tenders/common/block_attach.h
@@ -34,6 +34,6 @@
  * Attach to the block device specified by (path). Returns the file descriptor
  * and device capacity in * bytes in (*capacity).
  */
-int block_attach(const char *path, uint16_t block_size, off_t *capacity_);
+int block_attach(const char *path, off_t *capacity_);
 
 #endif /* COMMON_BLOCK_ATTACH_H */

--- a/tenders/common/block_attach.h
+++ b/tenders/common/block_attach.h
@@ -28,11 +28,12 @@
 #define _GNU_SOURCE
 #define _FILE_OFFSET_BITS 64
 #include <sys/types.h>
+#include <stdint.h>
 
 /*
  * Attach to the block device specified by (path). Returns the file descriptor
  * and device capacity in * bytes in (*capacity).
  */
-int block_attach(const char *path, off_t *capacity_);
+int block_attach(const char *path, uint16_t block_size, off_t *capacity_);
 
 #endif /* COMMON_BLOCK_ATTACH_H */

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -106,15 +106,19 @@ static void hypercall_block_read(struct hvt *hvt, hvt_gpa_t gpa)
     rd->ret = SOLO5_R_OK;
 }
 
+#define BLOCK_PREFIX "--block:"
+#define BLOCK_SECTOR_SIZE_PREFIX "--block-sector-size:"
+
 static int handle_cmdarg(char *cmdarg, struct mft *mft)
 {
     enum {
         opt_block,
         opt_block_size,
     } which;
-    if (strncmp("--block:", cmdarg, 8) == 0)
+    if (strncmp(BLOCK_PREFIX, cmdarg, sizeof(BLOCK_PREFIX) - 1) == 0)
         which = opt_block;
-    else if (strncmp("--block-size:", cmdarg, 13) == 0)
+    else if (strncmp(BLOCK_SECTOR_SIZE_PREFIX, cmdarg,
+                sizeof(BLOCK_SECTOR_SIZE_PREFIX) - 1) == 0)
         which = opt_block_size;
     else
         return -1;
@@ -146,7 +150,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         module_in_use = true;
     } else if (which == opt_block_size) {
         int rc = sscanf(cmdarg,
-                "--block-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
+                "--block-sector-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%hu",
                 name, &block_size);
         if (rc != 2)
@@ -198,7 +202,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
 static char *usage(void)
 {
     return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)\n"
-	"  [ --block-size:NAME=BLOCKSIZE ] (set block size for block device NAME; must be a power of two greater than or equal 512)";
+	"  [ --block-sector-size:NAME=SECTORSIZE ] (set sector size for block device NAME; must be a power of two greater than or equal 512)";
 }
 
 DECLARE_MODULE(block,

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -197,7 +197,8 @@ static int setup(struct hvt *hvt, struct mft *mft)
 
 static char *usage(void)
 {
-    return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)";
+    return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)\n"
+	"  [ --block-size:NAME=BLOCKSIZE ] (set block size for block device NAME; must be a power of two greater than or equal 512)";
 }
 
 DECLARE_MODULE(block,

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -200,10 +200,10 @@ static int setup(struct hvt *hvt, struct mft *mft)
         assert((block_size & (block_size - 1)) == 0);
         /* this assumes block_size is a power of 2 */
         if ((capacity & (block_size - 1)) != 0)
-            errx(1, "%" XSTR(MFT_NAME_MAX) "s: Backing storage size must be block aligned (%hu bytes)",
+            errx(1, "%." XSTR(MFT_NAME_MAX) "s: Backing storage size must be block aligned (%hu bytes)",
                     name, block_size);
         if (capacity < block_size)
-            errx(1, "%" XSTR(MFT_NAME_MAX) "s: Backing storage must be at least 1 block (%hu bytes) "
+            errx(1, "%." XSTR(MFT_NAME_MAX) "s: Backing storage must be at least 1 block (%hu bytes) "
                     "in size", name, block_size);
     }
 

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -129,7 +129,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
     if (which == opt_block) {
         block_size = 512;
         int rc = sscanf(cmdarg,
-                "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
+                BLOCK_PREFIX "%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%" XSTR(PATH_MAX) "s", name, path);
         if (rc != 2)
             return -1;
@@ -150,7 +150,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         module_in_use = true;
     } else if (which == opt_block_size) {
         int rc = sscanf(cmdarg,
-                "--block-sector-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
+                BLOCK_SECTOR_SIZE_PREFIX "%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%hu",
                 name, &block_size);
         if (rc != 2)

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -37,15 +37,19 @@
 
 static bool module_in_use;
 
+#define BLOCK_PREFIX "--block:"
+#define BLOCK_SECTOR_SIZE_PREFIX "--block-sector-size:"
+
 static int handle_cmdarg(char *cmdarg, struct mft *mft)
 {
     enum {
         opt_block,
         opt_block_size,
     } which;
-    if (strncmp("--block:", cmdarg, 8) == 0)
+    if (strncmp(BLOCK_PREFIX, cmdarg, sizeof(BLOCK_PREFIX) - 1) == 0)
         which = opt_block;
-    else if (strncmp("--block-size:", cmdarg, 13) == 0)
+    else if (strncmp(BLOCK_SECTOR_SIZE_PREFIX, cmdarg,
+                sizeof(BLOCK_SECTOR_SIZE_PREFIX) - 1) == 0)
         which = opt_block_size;
     else
         return -1;
@@ -77,7 +81,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         module_in_use = true;
     } else if (which == opt_block_size) {
         int rc = sscanf(cmdarg,
-                "--block-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
+                "--block-sector-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%hu",
                 name, &block_size);
         if (rc != 2)
@@ -147,7 +151,7 @@ static int setup(struct spt *spt, struct mft *mft)
 static char *usage(void)
 {
     return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)\n"
-	"  [ --block-size:NAME=BLOCKSIZE ] (set block size for block device NAME; must be a power of two greater than or equal 512)";
+	"  [ --block-sector-size:NAME=SECTORSIZE ] (set sector size for block device NAME; must be a power of two greater than or equal 512)";
 }
 
 DECLARE_MODULE(block,

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -39,49 +39,63 @@ static bool module_in_use;
 
 static int handle_cmdarg(char *cmdarg, struct mft *mft)
 {
-    if (strncmp("--block:", cmdarg, 8) != 0)
+    enum {
+        opt_block,
+        opt_block_size,
+    } which;
+    if (strncmp("--block:", cmdarg, 8) == 0)
+        which = opt_block;
+    else if (strncmp("--block-size:", cmdarg, 13) == 0)
+        which = opt_block_size;
+    else
         return -1;
 
     char name[MFT_NAME_SIZE];
     char path[PATH_MAX + 1];
     uint16_t block_size;
-    do {
-        int rc = sscanf(cmdarg,
-                "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]:"
-                "%hu="
-                "%" XSTR(PATH_MAX) "s", name, &block_size, path);
-        if (rc == 3)
-            break;
+    if (which == opt_block) {
         block_size = 512;
-        rc = sscanf(cmdarg,
+        int rc = sscanf(cmdarg,
                 "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%" XSTR(PATH_MAX) "s", name, path);
-	if (rc == 2)
-            break;
-        goto match_fail;
-    } while (0);
-    if (block_size < 512 || block_size & (block_size - 1)) {
-        warnx("Block size must be a multiple of 2 greater than or equal 512");
-        return -1;
-    }
-    struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC, NULL);
-    if (e == NULL) {
-        warnx("Resource not declared in manifest: '%s'", name);
-        return -1;
-    }
+        if (rc != 2)
+            return -1;
 
-    off_t capacity;
-    int fd = block_attach(path, block_size, &capacity);
-    e->u.block_basic.capacity = capacity;
-    e->u.block_basic.block_size = 512;
-    e->b.hostfd = fd;
-    e->attached = true;
-    module_in_use = true;
+        struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC, NULL);
+        if (e == NULL) {
+            warnx("Resource not declared in manifest: '%s'", name);
+            return -1;
+        }
+        off_t capacity;
+        int fd = block_attach(path, block_size, &capacity);
+        /* e->u.block_basic.block_size is set either by option or generated
+         * later by setup().
+         */
+        e->u.block_basic.capacity = capacity;
+        e->b.hostfd = fd;
+        e->attached = true;
+        module_in_use = true;
+    } else if (which == opt_block_size) {
+        int rc = sscanf(cmdarg,
+                "--block-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
+                "%hu",
+                name, &block_size);
+        if (rc != 2)
+            return -1;
+        if (block_size < 512 || block_size & (block_size - 1)) {
+            warnx("Block size must be a multiple of 2 greater than or equal 512");
+            return -1;
+        }
+
+        struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC, NULL);
+        if (e == NULL) {
+            warnx("Resource not declared in manifest: '%s'", name);
+            return -1;
+        }
+        e->u.block_basic.block_size = block_size;
+    }
 
     return 0;
-
-match_fail:
-    return -1;
 }
 
 static int setup(struct spt *spt, struct mft *mft)
@@ -92,6 +106,8 @@ static int setup(struct spt *spt, struct mft *mft)
     for (unsigned i = 0; i != mft->entries; i++) {
         if (mft->e[i].type != MFT_DEV_BLOCK_BASIC || !mft->e[i].attached)
             continue;
+        if (mft->e[i].u.block_basic.block_size == 0)
+            mft->e[i].u.block_basic.block_size = 512;
 
         int rc = -1;
 

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -146,7 +146,8 @@ static int setup(struct spt *spt, struct mft *mft)
 
 static char *usage(void)
 {
-    return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)";
+    return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)\n"
+	"  [ --block-size:NAME=BLOCKSIZE ] (set block size for block device NAME; must be a power of two greater than or equal 512)";
 }
 
 DECLARE_MODULE(block,

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -123,10 +123,10 @@ static int setup(struct spt *spt, struct mft *mft)
         assert((block_size & (block_size - 1)) == 0);
         /* this assumes block_size is a power of 2 */
         if ((capacity & (block_size - 1)) != 0)
-            errx(1, "%" XSTR(MFT_NAME_MAX) "s: Backing storage size must be block aligned (%hu bytes)",
+            errx(1, "%." XSTR(MFT_NAME_MAX) "s: Backing storage size must be block aligned (%hu bytes)",
                     name, block_size);
         if (capacity < block_size)
-            errx(1, "%" XSTR(MFT_NAME_MAX) "s: Backing storage must be at least 1 block (%hu bytes) "
+            errx(1, "%." XSTR(MFT_NAME_MAX) "s: Backing storage must be at least 1 block (%hu bytes) "
                     "in size", name, block_size);
 
         int rc = -1;

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -44,11 +44,26 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
 
     char name[MFT_NAME_SIZE];
     char path[PATH_MAX + 1];
-    int rc = sscanf(cmdarg,
-            "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
-            "%" XSTR(PATH_MAX) "s", name, path);
-    if (rc != 2)
+    uint16_t block_size;
+    do {
+        int rc = sscanf(cmdarg,
+                "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]:"
+                "%hu="
+                "%" XSTR(PATH_MAX) "s", name, &block_size, path);
+        if (rc == 3)
+            break;
+        block_size = 512;
+        rc = sscanf(cmdarg,
+                "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
+                "%" XSTR(PATH_MAX) "s", name, path);
+	if (rc == 2)
+            break;
+        goto match_fail;
+    } while (0);
+    if (block_size < 512 || block_size & (block_size - 1)) {
+        warnx("Block size must be a multiple of 2 greater than or equal 512");
         return -1;
+    }
     struct mft_entry *e = mft_get_by_name(mft, name, MFT_DEV_BLOCK_BASIC, NULL);
     if (e == NULL) {
         warnx("Resource not declared in manifest: '%s'", name);
@@ -56,7 +71,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
     }
 
     off_t capacity;
-    int fd = block_attach(path, &capacity);
+    int fd = block_attach(path, block_size, &capacity);
     e->u.block_basic.capacity = capacity;
     e->u.block_basic.block_size = 512;
     e->b.hostfd = fd;
@@ -64,6 +79,9 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
     module_in_use = true;
 
     return 0;
+
+match_fail:
+    return -1;
 }
 
 static int setup(struct spt *spt, struct mft *mft)

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -55,10 +55,8 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         return -1;
 
     char name[MFT_NAME_SIZE];
-    char path[PATH_MAX + 1];
-    uint16_t block_size;
     if (which == opt_block) {
-        block_size = 512;
+        char path[PATH_MAX + 1];
         int rc = sscanf(cmdarg,
                 "--block:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%" XSTR(PATH_MAX) "s", name, path);
@@ -71,7 +69,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
             return -1;
         }
         off_t capacity;
-        int fd = block_attach(path, block_size, &capacity);
+        int fd = block_attach(path, &capacity);
         /* e->u.block_basic.block_size is set either by option or generated
          * later by setup().
          */
@@ -80,6 +78,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         e->attached = true;
         module_in_use = true;
     } else if (which == opt_block_size) {
+        uint16_t block_size;
         int rc = sscanf(cmdarg,
                 "--block-sector-size:%" XSTR(MFT_NAME_MAX) "[A-Za-z0-9]="
                 "%hu",
@@ -110,8 +109,25 @@ static int setup(struct spt *spt, struct mft *mft)
     for (unsigned i = 0; i != mft->entries; i++) {
         if (mft->e[i].type != MFT_DEV_BLOCK_BASIC || !mft->e[i].attached)
             continue;
+
+        /*
+         * We now set default block_size if needed, and check that the capacity
+         * is block aligned, and the capacity is not zero.
+         */
         if (mft->e[i].u.block_basic.block_size == 0)
             mft->e[i].u.block_basic.block_size = 512;
+        const char *name = mft->e[i].name;
+        uint16_t block_size = mft->e[i].u.block_basic.block_size;
+        off_t capacity = mft->e[i].u.block_basic.capacity;
+
+        assert((block_size & (block_size - 1)) == 0);
+        /* this assumes block_size is a power of 2 */
+        if ((capacity & (block_size - 1)) != 0)
+            errx(1, "%" XSTR(MFT_NAME_MAX) "s: Backing storage size must be block aligned (%hu bytes)",
+                    name, block_size);
+        if (capacity < block_size)
+            errx(1, "%" XSTR(MFT_NAME_MAX) "s: Backing storage must be at least 1 block (%hu bytes) "
+                    "in size", name, block_size);
 
         int rc = -1;
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -487,6 +487,30 @@ xen_expect_abort() {
   expect_success
 }
 
+@test "blk misaligned hvt" {
+  dd if=/dev/zero of=${BATS_TMPDIR}/storage.img \
+      bs=2k count=3 status=none
+  hvt_run --block:storage=${BATS_TMPDIR}/storage.img \
+      --block-sector-size:storage=4096 -- test_blk/test_blk.hvt
+  [ "$status" = 1 ] && [[ "$output" == *"Backing storage size must be block aligned"* ]]
+}
+
+@test "blk odd hvt" {
+  dd if=/dev/zero of=${BATS_TMPDIR}/storage.img \
+      bs=521 count=3 status=none
+  hvt_run --block:storage=${BATS_TMPDIR}/storage.img \
+      --block-sector-size:storage=521 -- test_blk/test_blk.hvt
+  [ "$status" = 1 ] && [[ "$output" == *"Block size must be a multiple of 2"* ]]
+}
+
+@test "blk too small hvt" {
+  dd if=/dev/zero of=${BATS_TMPDIR}/storage.img \
+      bs=256 count=1 status=none
+  hvt_run --block:storage=${BATS_TMPDIR}/storage.img \
+      --block-sector-size:storage=256 -- test_blk/test_blk.hvt
+  [ "$status" = 1 ] && [[ "$output" == *"Block size must be a multiple of 2 greater than or equal 512"* ]]
+}
+
 @test "blk virtio" {
   setup_block
   virtio_run -d ${BLOCK} -- test_blk/test_blk.virtio
@@ -503,6 +527,30 @@ xen_expect_abort() {
   setup_block
   spt_run --block:storage=${BLOCK} --block-sector-size:storage=4096 -- test_blk/test_blk.spt
   expect_success
+}
+
+@test "blk misaligned spt" {
+  dd if=/dev/zero of=${BATS_TMPDIR}/storage.img \
+      bs=2k count=3 status=none
+  spt_run --block:storage=${BATS_TMPDIR}/storage.img \
+      --block-sector-size:storage=4096 -- test_blk/test_blk.spt
+  [ "$status" = 1 ] && [[ "$output" == *"Backing storage size must be block aligned"* ]]
+}
+
+@test "blk odd spt" {
+  dd if=/dev/zero of=${BATS_TMPDIR}/storage.img \
+      bs=521 count=3 status=none
+  spt_run --block:storage=${BATS_TMPDIR}/storage.img \
+      --block-sector-size:storage=521 -- test_blk/test_blk.spt
+  [ "$status" = 1 ] && [[ "$output" == *"Block size must be a multiple of 2"* ]]
+}
+
+@test "blk too small spt" {
+  dd if=/dev/zero of=${BATS_TMPDIR}/storage.img \
+      bs=256 count=1 status=none
+  spt_run --block:storage=${BATS_TMPDIR}/storage.img \
+      --block-sector-size:storage=256 -- test_blk/test_blk.spt
+  [ "$status" = 1 ] && [[ "$output" == *"Block size must be a multiple of 2 greater than or equal 512"* ]]
 }
 
 @test "net hvt" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -97,11 +97,11 @@ setup_block() {
 }
 
 hvt_run() {
-  run ${TIMEOUT} --foreground 60s ${HVT_TENDER} --mem=2 "$@"
+  run ${TIMEOUT} --foreground 60s "${HVT_TENDER}" --mem=2 "$@"
 }
 
 spt_run() {
-  run ${TIMEOUT} --foreground 60s ${SPT_TENDER} --mem=2 "$@"
+  run ${TIMEOUT} --foreground 60s "${SPT_TENDER}" --mem=2 "$@"
 }
 
 virtio_run() {
@@ -481,6 +481,12 @@ xen_expect_abort() {
   expect_success
 }
 
+@test "blk block-size=4096 hvt" {
+  setup_block
+  hvt_run --block:storage=${BLOCK} --block-size:storage=4096 -- test_blk/test_blk.hvt
+  expect_success
+}
+
 @test "blk virtio" {
   setup_block
   virtio_run -d ${BLOCK} -- test_blk/test_blk.virtio
@@ -490,6 +496,12 @@ xen_expect_abort() {
 @test "blk spt" {
   setup_block
   spt_run --block:storage=${BLOCK} -- test_blk/test_blk.spt
+  expect_success
+}
+
+@test "blk block-size=4096 spt" {
+  setup_block
+  spt_run --block:storage=${BLOCK} --block-size:storage=4096 -- test_blk/test_blk.spt
   expect_success
 }
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -481,9 +481,9 @@ xen_expect_abort() {
   expect_success
 }
 
-@test "blk block-size=4096 hvt" {
+@test "blk block-sector-size=4096 hvt" {
   setup_block
-  hvt_run --block:storage=${BLOCK} --block-size:storage=4096 -- test_blk/test_blk.hvt
+  hvt_run --block:storage=${BLOCK} --block-sector-size:storage=4096 -- test_blk/test_blk.hvt
   expect_success
 }
 
@@ -499,9 +499,9 @@ xen_expect_abort() {
   expect_success
 }
 
-@test "blk block-size=4096 spt" {
+@test "blk block-sector-size=4096 spt" {
   setup_block
-  spt_run --block:storage=${BLOCK} --block-size:storage=4096 -- test_blk/test_blk.spt
+  spt_run --block:storage=${BLOCK} --block-sector-size:storage=4096 -- test_blk/test_blk.spt
   expect_success
 }
 


### PR DESCRIPTION
This adds an option to specify a block size different from 512. The block size must be a power of 2 greater than or equal 512.

Marked as a draft as
- it's not well tested,
- I'm not sure about a few details and decisions.

Some things to investigate (CC @Julow):
- [ ] Does the restriction on block size make sense?
- [ ] What other components require block sizes to be >= 512 ?
- [ ] Is here anything that might misbehave if it no longer exactly 512 ?
- [ ] The mirage library has "preferred block size" to give a chance to the lower levels to enforce the block size. Should there be something similar here (get feedback from the lower levels instead of writing the rule in the parser) ?