### PR TITLE
[PoC] Change the default pagesize on aarch64 from 4k to 16k to support apple hardware

### DIFF
--- a/bindings/cpu_aarch64.h
+++ b/bindings/cpu_aarch64.h
@@ -21,8 +21,8 @@
 #define __CPU_AARCH64_H__
 
 /* memory defines */
-#define PAGE_SIZE   4096
-#define PAGE_SHIFT  12
+#define PAGE_SHIFT  14
+#define PAGE_SIZE   (1 << 14)
 #define PAGE_MASK   ~(0xfff)
 
 #ifndef _BITUL

--- a/bindings/cpu_aarch64.h
+++ b/bindings/cpu_aarch64.h
@@ -22,7 +22,7 @@
 
 /* memory defines */
 #define PAGE_SHIFT  14
-#define PAGE_SIZE   (1 << 14)
+#define PAGE_SIZE   (1 << PAGE_SHIFT)
 #define PAGE_MASK   ~(0xfff)
 
 #ifndef _BITUL

--- a/bindings/cpu_ppc64.h
+++ b/bindings/cpu_ppc64.h
@@ -21,8 +21,8 @@
 #define __CPU_PPC64_H__
 
 /* memory defines */
-#define PAGE_SIZE   (64 * 1024)
 #define PAGE_SHIFT  16
+#define PAGE_SIZE   (1 << PAGE_SHIFT)
 #define PAGE_MASK   ~(0xffff)
 
 #define CR0_SO      (0x80000000 >> 3) /* summary overflow;

--- a/bindings/cpu_x86_64.h
+++ b/bindings/cpu_x86_64.h
@@ -72,8 +72,8 @@
 #define X86_EFER_NXE_BIT        11 /* No-execute enable */
 #define X86_EFER_NXE            _BITUL(X86_EFER_NXE_BIT)
 
-#define PAGE_SIZE               4096
 #define PAGE_SHIFT              12
+#define PAGE_SIZE               (1 << PAGE_SHIFT)
 #define PAGE_MASK               ~(0xfff)
 
 /*

--- a/configure.sh
+++ b/configure.sh
@@ -383,7 +383,7 @@ case ${TARGET_CC_MACHINE} in
         ;;
     aarch64-*)
         TARGET_ARCH=aarch64
-        TARGET_LD_MAX_PAGE_SIZE=0x1000
+        TARGET_LD_MAX_PAGE_SIZE=0x4000
         CONFIG_HVT=1 CONFIG_SPT=1
         ;;
     powerpc64le-*|ppc64le-*)

--- a/tenders/common/elf.c
+++ b/tenders/common/elf.c
@@ -51,13 +51,13 @@
  */
 #if defined(__x86_64__)
 #define EM_TARGET EM_X86_64
-#define EM_PAGE_SIZE 0x1000
+#define EM_PAGE_SIZE (1 << 12)
 #elif defined(__aarch64__)
 #define EM_TARGET EM_AARCH64
-#define EM_PAGE_SIZE 0x1000
+#define EM_PAGE_SIZE (1 << 14)
 #elif defined(__powerpc64__)
 #define EM_TARGET EM_PPC64
-#define EM_PAGE_SIZE 0x10000
+#define EM_PAGE_SIZE (1 << 16)
 #else
 #error Unsupported target
 #endif

--- a/tenders/hvt/hvt_cpu_aarch64.h
+++ b/tenders/hvt/hvt_cpu_aarch64.h
@@ -88,7 +88,7 @@
     (((~0UL) << (l)) & (~0UL >> (63 - (h))))
 
 /* Definitions of Page tables */
-#define PAGE_SHIFT  12
+#define PAGE_SHIFT  14
 #define PAGE_SIZE   (1 << (PAGE_SHIFT))
 
 /*


### PR DESCRIPTION
This is an attempt at hotfixing https://github.com/Solo5/solo5/issues/529 for 16k aarch64 hardware as I need to have a working solo5 to test https://github.com/mirage/ocaml-solo5/pull/122 on my work laptop (apple M1 hardware).

I don't think this should be merged as-is as I think `sysconf(_SC_PAGESIZE)` should be used instead but the goal is to show which parts of the code needs to change for solo5 to work on 16k pagesize hardware.

As of afa7fdf2d09b55acdb955b5783e41f92585e2ee0: only `solo5-spt` works. `solo5-hvt` infinit loops for some reason, so something else might be needed.