### PR TITLE
fix linker scripts with thread section

### DIFF
--- a/bindings/solo5_hvt.lds
+++ b/bindings/solo5_hvt.lds
@@ -40,6 +40,8 @@ PHDRS {
     rodata PT_LOAD FLAGS(4);
 
     data PT_LOAD;
+    tdata PT_TLS;
+    tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -116,21 +118,21 @@ SECTIONS {
     .tdata :
     {
         *(.tdata)
-    }
+    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .tbss :
-    {
-        *(.tbss)
-    }
     .bss :
     {
         *(.bss)
         *(COMMON)
     }
+    .tbss (NOLOAD) :
+    {
+        *(.tbss)
+    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;

--- a/bindings/solo5_muen.lds
+++ b/bindings/solo5_muen.lds
@@ -39,6 +39,8 @@ PHDRS {
                               FLAGS values come from PF_x in elf.h */
     rodata PT_LOAD;
     data PT_LOAD;
+    tdata PT_TLS;
+    tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -115,21 +117,21 @@ SECTIONS {
     .tdata :
     {
         *(.tdata)
-    }
+    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .tbss :
-    {
-        *(.tbss)
-    }
     .bss :
     {
         *(.bss)
         *(COMMON)
     }
+    .tbss (NOLOAD) :
+    {
+        *(.tbss)
+    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;

--- a/bindings/solo5_spt.lds
+++ b/bindings/solo5_spt.lds
@@ -38,6 +38,8 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    tdata PT_TLS;
+    tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -114,21 +116,21 @@ SECTIONS {
     .tdata :
     {
         *(.tdata)
-    }
+    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .tbss :
-    {
-        *(.tbss)
-    }
     .bss :
     {
         *(.bss)
         *(COMMON)
     }
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;

--- a/bindings/solo5_stub.lds
+++ b/bindings/solo5_stub.lds
@@ -38,6 +38,8 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    tdata PT_TLS;
+    tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -114,21 +116,21 @@ SECTIONS {
     .tdata :
     {
         *(.tdata)
-    }
+    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .tbss :
-    {
-        *(.tbss)
-    }
     .bss :
     {
         *(.bss)
         *(COMMON)
     }
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;

--- a/bindings/solo5_virtio.lds
+++ b/bindings/solo5_virtio.lds
@@ -38,6 +38,8 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    tdata PT_TLS;
+    tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;
@@ -115,21 +117,21 @@ SECTIONS {
     .tdata :
     {
         *(.tdata)
-    }
+    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .tbss :
-    {
-        *(.tbss)
-    }
     .bss :
     {
         *(.bss)
         *(COMMON)
     }
+    .tbss (NOLOAD) :
+    {
+        *(.tbss)
+    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;

--- a/bindings/solo5_xen.lds
+++ b/bindings/solo5_xen.lds
@@ -38,6 +38,8 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
+    tdata PT_TLS;
+    tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.xen PT_NOTE;
     note.abi PT_NOTE;
@@ -120,21 +122,21 @@ SECTIONS {
     .tdata :
     {
         *(.tdata)
-    }
+    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
 
     /* Read-write data (uninitialized) */
-    .tbss :
-    {
-        *(.tbss)
-    }
     .bss :
     {
         *(.bss)
         *(COMMON)
     }
+    .tbss (NOLOAD) :
+    {
+        *(.tbss)
+    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;

--- a/configure.sh
+++ b/configure.sh
@@ -465,6 +465,7 @@ case ${CONFIG_HOST} in
         # executables.
         TARGET_CC_LDFLAGS="-Wl,-nopie"
         TARGET_LD_LDFLAGS="-nopie"
+        TARGET_CC_CFLAGS="-fno-emulated-tls"
         ;;
     *)
         die "Unsupported host system: ${CONFIG_HOST}"

--- a/tests/test_tls/test_tls.c
+++ b/tests/test_tls/test_tls.c
@@ -27,27 +27,6 @@
  * the context of Solo5 means at all.
  */
 
-/*
- * FreeBSD clang toolchain post 8.0.1/12.1-RELEASE fails to build this test
- * with:
- *
- * ld: error: test_tls.o has an STT_TLS symbol but doesn't have an SHF_TLS section
- *
- * OpenBSD clang toolchains have unspecified non-support for TLS.
- *
- * In both cases just compile a dummy and disable this test in tests.bats.
- */
-/* XXX The above actually applies to any toolchain using lld. Either disable
- * this test entirely or fix the linker scripts? */
-#if defined(__clang__)
-
-int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
-{
-    return SOLO5_EXIT_FAILURE;
-}
-
-#else
-
 #if defined(__x86_64__) || defined(__powerpc64__)
 /* Variant II */
 struct tcb {
@@ -121,5 +100,3 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
     puts("SUCCESS\n");
     return SOLO5_EXIT_SUCCESS;
 }
-
-#endif /* defined(__clang__) */

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -416,15 +416,11 @@ xen_expect_abort() {
 }
 
 @test "tls hvt" {
-  skip_unless_host_is Linux
-
   hvt_run test_tls/test_tls.hvt
   expect_success
 }
 
 @test "tls virtio" {
-  skip_unless_host_is Linux # XXX is this necessary for virtio?
-
   virtio_run test_tls/test_tls.virtio
   virtio_expect_success
 }


### PR DESCRIPTION
Hi, this PR should fix the issue of missing thread data section in the linking step (see https://github.com/mirage/ocaml-solo5/pull/124#issuecomment-1380151218). It works (compiles + links) on a 12.2 FreeBSD as well as in my linux fedora AppVM.

I haven't added yet other than spt+hvt, not sure what is needed (maybe xen too to compiles for Xen/Qubes with llvm) and this PR should trigger a CI test to make sure that I haven't broken something.

As a comment it just add a `PT_TLS` section in the ELF binary and the linker is able to merge every TLS bits. The `tbss` part is also now after `bss` to respect the order of the `data` and `tdata` sections but that should not be mandatory.
