### PR TITLE
Tls export symbols

### DIFF
--- a/bindings/lib.c
+++ b/bindings/lib.c
@@ -67,7 +67,7 @@ void *memset(void *dest, int c, size_t n)
     return dest;
 }
 
-void *memcpy(void *restrict dest, const void *restrict src, size_t n)
+void *__attribute__ ((noinline)) memcpy(void *restrict dest, const void *restrict src, size_t n)
 {
     unsigned char *d = dest;
     const unsigned char *s = src;

--- a/bindings/solo5_hvt.lds
+++ b/bindings/solo5_hvt.lds
@@ -40,7 +40,7 @@ PHDRS {
     rodata PT_LOAD FLAGS(4);
 
     data PT_LOAD;
-    tdata PT_TLS;
+    tdata PT_LOAD;
     tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
@@ -115,13 +115,19 @@ SECTIONS {
         *(.data)
         *(.data.*)
     }
-    .tdata :
-    {
-        *(.tdata)
-    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
+
+    .tdata :
+    {
+        _stdata = .;
+        *(.tdata)
+    } :tdata
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     /* Read-write data (uninitialized) */
     .bss :
@@ -129,10 +135,6 @@ SECTIONS {
         *(.bss)
         *(COMMON)
     }
-    .tbss (NOLOAD) :
-    {
-        *(.tbss)
-    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
@@ -143,4 +145,7 @@ SECTIONS {
     /DISCARD/ : {
         *(.note.gnu.*)
     }
+
+    _ltdata = SIZEOF(.tdata);
+    _ltbss = SIZEOF(.tbss);
 }

--- a/bindings/solo5_muen.lds
+++ b/bindings/solo5_muen.lds
@@ -39,7 +39,7 @@ PHDRS {
                               FLAGS values come from PF_x in elf.h */
     rodata PT_LOAD;
     data PT_LOAD;
-    tdata PT_TLS;
+    tdata PT_LOAD;
     tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
@@ -114,13 +114,20 @@ SECTIONS {
         *(.data)
         *(.data.*)
     }
-    .tdata :
-    {
-        *(.tdata)
-    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
+
+
+    .tdata :
+    {
+        _stdata = .;
+        *(.tdata)
+    } :tdata
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     /* Read-write data (uninitialized) */
     .bss :
@@ -128,10 +135,6 @@ SECTIONS {
         *(.bss)
         *(COMMON)
     }
-    .tbss (NOLOAD) :
-    {
-        *(.tbss)
-    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
@@ -142,4 +145,7 @@ SECTIONS {
     /DISCARD/ : {
         *(.note.gnu.*)
     }
+
+    _ltdata = SIZEOF(.tdata);
+    _ltbss = SIZEOF(.tbss);
 }

--- a/bindings/solo5_spt.lds
+++ b/bindings/solo5_spt.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    tdata PT_TLS;
+    tdata PT_LOAD;
     tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
@@ -113,13 +113,19 @@ SECTIONS {
         *(.data)
         *(.data.*)
     }
-    .tdata :
-    {
-        *(.tdata)
-    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
+
+    .tdata :
+    {
+        _stdata = .;
+        *(.tdata)
+    } :tdata
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     /* Read-write data (uninitialized) */
     .bss :
@@ -127,11 +133,6 @@ SECTIONS {
         *(.bss)
         *(COMMON)
     }
-    .tbss (NOLOAD):
-    {
-        *(.tbss)
-    } :tbss
-
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
     _end = .;
@@ -141,4 +142,7 @@ SECTIONS {
     /DISCARD/ : {
         *(.note.gnu.*)
     }
+
+    _ltdata = SIZEOF(.tdata);
+    _ltbss = SIZEOF(.tbss);
 }

--- a/bindings/solo5_stub.lds
+++ b/bindings/solo5_stub.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    tdata PT_TLS;
+    tdata PT_LOAD;
     tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
@@ -113,13 +113,19 @@ SECTIONS {
         *(.data)
         *(.data.*)
     }
-    .tdata :
-    {
-        *(.tdata)
-    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
+
+    .tdata :
+    {
+        _stdata = .;
+        *(.tdata)
+    } :tdata
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     /* Read-write data (uninitialized) */
     .bss :
@@ -127,10 +133,6 @@ SECTIONS {
         *(.bss)
         *(COMMON)
     }
-    .tbss (NOLOAD):
-    {
-        *(.tbss)
-    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
@@ -141,4 +143,7 @@ SECTIONS {
     /DISCARD/ : {
         *(.note.gnu.*)
     }
+
+    _ltdata = SIZEOF(.tdata);
+    _ltbss = SIZEOF(.tbss);
 }

--- a/bindings/solo5_virtio.lds
+++ b/bindings/solo5_virtio.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    tdata PT_TLS;
+    tdata PT_LOAD;
     tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
@@ -114,13 +114,20 @@ SECTIONS {
         *(.data)
         *(.data.*)
     }
-    .tdata :
-    {
-        *(.tdata)
-    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
+
+
+    .tdata :
+    {
+        _stdata = .;
+        *(.tdata)
+    } :tdata
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     /* Read-write data (uninitialized) */
     .bss :
@@ -128,10 +135,6 @@ SECTIONS {
         *(.bss)
         *(COMMON)
     }
-    .tbss (NOLOAD) :
-    {
-        *(.tbss)
-    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
@@ -142,4 +145,7 @@ SECTIONS {
     /DISCARD/ : {
         *(.note.gnu.*)
     }
+
+    _ltdata = SIZEOF(.tdata);
+    _ltbss = SIZEOF(.tbss);
 }

--- a/bindings/solo5_xen.lds
+++ b/bindings/solo5_xen.lds
@@ -38,7 +38,7 @@ PHDRS {
     text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
                               FLAGS values come from PF_x in elf.h */
     data PT_LOAD;
-    tdata PT_TLS;
+    tdata PT_LOAD;
     tbss PT_TLS;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.xen PT_NOTE;
@@ -119,13 +119,19 @@ SECTIONS {
         *(.data)
         *(.data.*)
     }
-    .tdata :
-    {
-        *(.tdata)
-    } :tdata
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _edata = .;
+
+    .tdata :
+    {
+        _stdata = .;
+        *(.tdata)
+    } :tdata
+    .tbss (NOLOAD):
+    {
+        *(.tbss)
+    } :tbss
 
     /* Read-write data (uninitialized) */
     .bss :
@@ -133,10 +139,6 @@ SECTIONS {
         *(.bss)
         *(COMMON)
     }
-    .tbss (NOLOAD) :
-    {
-        *(.tbss)
-    } :tbss
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _ebss = .;
@@ -147,4 +149,7 @@ SECTIONS {
     /DISCARD/ : {
         *(.note.gnu.*)
     }
+
+    _ltdata = SIZEOF(.tdata);
+    _ltbss = SIZEOF(.tbss);
 }


### PR DESCRIPTION
This PR is an follow-up of the previous TLS PR. I'm currently not sure if the exported API is clear enough or makes sense at all, I'd feel better if someone could comment that.

Now we can export TDATA as the address of the the thread variables' initialization values, LTDATA the length of the tdata section, and LTBSS the length of the tbss section.
This way, we can allocate, for each thread, an area of memory (the size is calculated with `solo5_tls_size()`), set the tp pointer to its value with `solo5_tls_tp_offset(.)`, and copy the initial value of tdata into our new memory `solo5_tls_data_offset(.)`. As an example, we can do:
```C
void* tcb1;                                      // defines a TLS block
tcb1 = calloc(solo5_tls_size(), sizeof(char));   // gets memory for it, set tbss to 0
memcpy(solo5_tls_data_offset(tcb1), TDATA, LTDATA);       // copy tdata
solo5_set_tls_base(solo5_tls_tp_offset((uintptr_t)tcb1);  // sets tp ptr
```

I've come across 2 _bugs_, the first is that if tdata is not a `PT_LOAD` section, it is not loaded by the tender, so the initial values of tdata are not copied into memory, the second is that `memcpy` can be inlined and cause errors in our TLS use case (I haven't investigated this much so far, I'm going to try it out with ocaml-solo5 to see if this could be a bigger issue).