### PR TITLE
Fix noexec test

### DIFF
--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -196,7 +196,7 @@ xen_expect_abort() {
   run test_hello/test_hello.hvt
   case "${CONFIG_HOST}" in
   Linux)
-    [ "$status" -eq 127 ] && [[ "$output" == *"No such file or directory"* ]]
+    [ "$status" -eq 127 ] && ([[ "$output" == *"No such file or directory"* ]] || [[ "$output" == *"required file not found"* ]])
     ;;
   FreeBSD)
     # XXX: imgact_elf.c:load_interp() outputs the "ELF interpreter ... not


### PR DESCRIPTION
Since some point recently, this test fails (as it is expected to) but with a different error message. This PR adds a case for this.

Alternatively, I propose removing the error message check altogether, since it is too fragile and might be affected - among other things - by locale settings.