### PR TITLE
Fix .bss initialization

### DIFF
--- a/bindings/solo5_hvt.lds
+++ b/bindings/solo5_hvt.lds
@@ -119,7 +119,7 @@ SECTIONS {
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     /*
-     * tdata and tbss have to be side by side to help the linker caculate the
+     * tdata and tbss have to be side by side to help the linker calculate the
      * various __thread variables offsets.
      */
     .tdata :

--- a/bindings/solo5_hvt.lds
+++ b/bindings/solo5_hvt.lds
@@ -42,7 +42,7 @@ PHDRS {
     data PT_LOAD;
     tdata PT_LOAD FLAGS(4); /* RO: this have to be copied into each thread */
     tbss PT_TLS FLAGS(0); /* no perm needed */
-    bss PT_NULL FLAGS(0);
+    bss PT_LOAD;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;

--- a/bindings/solo5_muen.lds
+++ b/bindings/solo5_muen.lds
@@ -41,7 +41,7 @@ PHDRS {
     data PT_LOAD;
     tdata PT_LOAD FLAGS(4); /* RO: this have to be copied into each thread */
     tbss PT_TLS FLAGS(0); /* no perm needed */
-    bss PT_NULL FLAGS(0);
+    bss PT_LOAD;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;

--- a/bindings/solo5_muen.lds
+++ b/bindings/solo5_muen.lds
@@ -118,7 +118,7 @@ SECTIONS {
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     /*
-     * tdata and tbss have to be side by side to help the linker caculate the
+     * tdata and tbss have to be side by side to help the linker calculate the
      * various __thread variables offsets.
      */
     .tdata :

--- a/bindings/solo5_spt.lds
+++ b/bindings/solo5_spt.lds
@@ -40,7 +40,7 @@ PHDRS {
     data PT_LOAD;
     tdata PT_LOAD FLAGS(4); /* RO: this have to be copied into each thread */
     tbss PT_TLS FLAGS(0); /* no perm needed */
-    bss PT_NULL FLAGS(0);
+    bss PT_LOAD;
     note.not_openbsd PT_NOTE; /* Must come first. */
     note.abi PT_NOTE;
     note.manifest PT_NOTE;

--- a/bindings/solo5_spt.lds
+++ b/bindings/solo5_spt.lds
@@ -117,7 +117,7 @@ SECTIONS {
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     /*
-     * tdata and tbss have to be side by side to help the linker caculate the
+     * tdata and tbss have to be side by side to help the linker calculate the
      * various __thread variables offsets.
      */
     .tdata :

--- a/bindings/solo5_stub.lds
+++ b/bindings/solo5_stub.lds
@@ -117,7 +117,7 @@ SECTIONS {
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     /*
-     * tdata and tbss have to be side by side to help the linker caculate the
+     * tdata and tbss have to be side by side to help the linker calculate the
      * various __thread variables offsets.
      */
     .tdata :

--- a/bindings/solo5_virtio.lds
+++ b/bindings/solo5_virtio.lds
@@ -118,7 +118,7 @@ SECTIONS {
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     /*
-     * tdata and tbss have to be side by side to help the linker caculate the
+     * tdata and tbss have to be side by side to help the linker calculate the
      * various __thread variables offsets.
      */
     .tdata :

--- a/bindings/solo5_xen.lds
+++ b/bindings/solo5_xen.lds
@@ -123,7 +123,7 @@ SECTIONS {
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     /*
-     * tdata and tbss have to be side by side to help the linker caculate the
+     * tdata and tbss have to be side by side to help the linker calculate the
      * various __thread variables offsets.
      */
     .tdata :


### PR DESCRIPTION
With the changes to the linker scripts in #546, the ELF segment containing the bss section is no longer of type PT_LOAD. This means it is not being processed by the Muen script and thus no longer initialized to zero. Explicitly set it to PT_LOAD in the linker script again to restore the original behavior. This was discovered when running Muen test unikernels on hardware, where memory is actually uninitialized and not zeroized as is done on most hypervisors.

Note that the same behavior goes for the common tender ELF loader, see https://github.com/Solo5/solo5/blob/7d5b70f5937abf1e18c2353ffb93d0581ec31a0f/tenders/common/elf.c#L249-L250, thus I believe the same issue is present and the same fix is necessary for the other bindings. 