### PR TITLE
Split out C files between muen and hvt bindings

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -32,7 +32,7 @@ common_SRCS := cpu_$(CONFIG_TARGET_ARCH).c \
     cpu_vectors_$(CONFIG_TARGET_ARCH).S \
     abort.c crt.c printf.c intr.c lib.c mem.c exit.c log.c cmdline.c tls.c mft.c
 
-common_hvt_SRCS := hvt/platform.c hvt/platform_intr.c hvt/time.c
+common_hvt_SRCS := hvt/platform.c hvt/platform_intr.c
 
 #
 # Note that the module defining _start should be listed first in <target>_SRCS,
@@ -40,7 +40,7 @@ common_hvt_SRCS := hvt/platform.c hvt/platform_intr.c hvt/time.c
 #
 stub_SRCS := stub/stubs.c
 
-hvt_SRCS := hvt/start.c $(common_SRCS) $(common_hvt_SRCS) \
+hvt_SRCS := hvt/start.c $(common_SRCS) $(common_hvt_SRCS) hvt/time.c \
     hvt/platform_lifecycle.c hvt/yield.c hvt/tscclock.c hvt/console.c \
     hvt/net.c hvt/block.c
 
@@ -55,7 +55,7 @@ virtio_SRCS := virtio/boot.S virtio/start.c $(common_SRCS) \
     virtio/virtio_net.c virtio/virtio_blk.c virtio/tscclock.c \
     virtio/clock_subr.c virtio/pvclock.c 
 
-muen_SRCS := muen/start.c $(common_SRCS) $(common_hvt_SRCS) \
+muen_SRCS := muen/start.c $(common_SRCS) $(common_hvt_SRCS) muen/time.c \
     muen/channel.c muen/reader.c muen/writer.c muen/muen-block.c \
     muen/muen-clock.c muen/muen-console.c muen/muen-net.c \
     muen/muen-platform_lifecycle.c muen/muen-yield.c muen/muen-sinfo.c

--- a/bindings/muen/time.c
+++ b/bindings/muen/time.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "bindings.h"
+
+void time_init(const struct hvt_boot_info *bi)
+{
+    assert(tscclock_init(bi->cpu_cycle_freq) == 0);
+}
+
+uint64_t solo5_clock_monotonic(void)
+{
+    return tscclock_monotonic();
+}
+
+/* return wall time in nsecs */
+uint64_t solo5_clock_wall(void)
+{
+    return tscclock_monotonic() + tscclock_epochoffset();
+}


### PR DESCRIPTION
A minimal patch which splits `time.c` between Muen and HVT bindings. Instead to re-use the same code, we copy it to be able to change the Muen clock independantly than HVT.