### PR TITLE
Fix the compilation of solo5-aarch64 and the TLS support

### DIFF
--- a/bindings/tls.c
+++ b/bindings/tls.c
@@ -78,6 +78,7 @@ uintptr_t _solo5_tls_data_offset(uintptr_t tls)
 #if defined(__x86_64__) || defined(__powerpc64__)
     data = tls;
 #elif defined(__aarch64__)
+    data = tls;
     data = data + sizeof(struct tcb);
 #else
 #error Unsupported architecture


### PR DESCRIPTION
/cc @palainp can you confirm that it's the right fix for `aarch64`?