### PR TITLE
Support for Solo5 unikernel lifecycle management on Muen & ABI increase

### DIFF
--- a/bindings/muen/muen-platform_lifecycle.c
+++ b/bindings/muen/muen-platform_lifecycle.c
@@ -19,10 +19,23 @@
  */
 
 #include "bindings.h"
+#include "sinfo.h"
 
 const struct mft *muen_manifest = NULL;
 
 extern const struct mft1_note __solo5_mft1_note;
+
+void trigger_exit_event()
+{
+    const struct muen_resource_type *const
+        event = muen_get_resource("solo5_exit", MUEN_RES_EVENT);
+
+    if (!event) {
+        return;
+    }
+
+    __asm__ __volatile__("vmcall": : "a"(event->data.number) : "memory");
+}
 
 void platform_init(const void *arg)
 {
@@ -47,6 +60,7 @@ void platform_exit(int status __attribute__((unused)),
 {
     const char msg[] = "Solo5: Halted\n";
     platform_puts(msg, strlen(msg));
+    trigger_exit_event();
     __asm__ __volatile__("cli; hlt");
     for (;;);
 }

--- a/bindings/muen/start.c
+++ b/bindings/muen/start.c
@@ -63,7 +63,7 @@ DECLARE_ELF_INTERP
 ABI1_NOTE_DECLARE_BEGIN
 {
     .abi_target = MUEN_ABI_TARGET,
-    .abi_version = 2
+    .abi_version = 3
 }
 ABI1_NOTE_DECLARE_END
 

--- a/bindings/solo5_muen.lds
+++ b/bindings/solo5_muen.lds
@@ -25,7 +25,7 @@
  * are unexpected input sections not named here, the result will probably not be
  * correct.
  */
-TEXT_START = 0x100000;
+TEXT_START = 0x200000;
 
 ENTRY(_start)
 

--- a/tests/test_fpu/test_fpu.c
+++ b/tests/test_fpu/test_fpu.c
@@ -30,7 +30,7 @@ int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
     puts("\n**** Solo5 standalone test_fpu ****\n\n");
 
-    float a, b, c[4];
+    float a, b, c[4] __attribute__((aligned(64)));
 
     c[0] = 2.0;
     c[1] = 5.0;


### PR DESCRIPTION
The first two commits make it possible to (re-)use the existing Subject Lifecycle Management of Muen and also apply it to Solo5 unikernels. A possible use case is to configure automatic restarting of unikernels that invoke `solo5_exit()`.

Increasing the ABI version is necessary due to the TLS changes. @dinosaure, maybe you prefer to squash this change into https://github.com/Solo5/solo5/pull/556/commits/806d40ab98595a3f7e6738d8bc29dc036fd111b7, which would be fine by me.

Finally, the adjustment to `test_fpu` has become necessary to successfully run the test on Muen, otherwise a #GP exception is raised. I guess we were lucky with alignment on other x86 bindings. Note that I have only verified that the test works on Muen but CI should show us if it unexpectedly broke `hvt` or any of the others.

Addendum: I manually ran the tests on Muen and the test that are expected to pass ran successfully.