### PR TITLE
Be able to use `-dumpmachine` on our toolchain

### DIFF
--- a/toolchain/cc.in
+++ b/toolchain/cc.in
@@ -62,6 +62,9 @@ for arg do
     fi
 
     case "$arg" in
+        -dumpmachine)
+            M=dump
+            ;;
         -c|-S|-E)
             M=compile
             ;;
@@ -75,6 +78,10 @@ for arg do
     set -- "$@" "$arg"
 done
 case ${M} in
+    dump)
+        [ -n "${__V}" ] && set -x
+        exec @@CONFIG_TARGET_CC@@ -dumpmachine
+        ;;
     compile)
         [ -n "${__V}" ] && set -x
         exec @@CONFIG_TARGET_CC@@ \


### PR DESCRIPTION
This little patch allows us to call `cc` from our toolchain with the `-dumpmachine` argument. By this way, we are able to recognize, at least, the assembler produced by our toolchain. It's related to mirage/ocaml-solo5#128 and mirage/ocaml-gmp#22.