### PR TITLE
Fix prototype for solo5_tls_size.

### DIFF
--- a/bindings/stub/stubs.c
+++ b/bindings/stub/stubs.c
@@ -105,7 +105,7 @@ solo5_result_t solo5_block_read(solo5_handle_t handle U, solo5_off_t offset U,
     return SOLO5_R_EUNSPEC;
 }
 
-size_t solo5_tls_size()
+size_t solo5_tls_size(void)
 {
     return 0;
 }

--- a/bindings/tls.c
+++ b/bindings/tls.c
@@ -51,7 +51,7 @@ extern char _ltdata[], _ltbss[];
 #error Unsupported architecture
 #endif
 
-size_t solo5_tls_size()
+size_t solo5_tls_size(void)
 {
     return (LTDATA + LTBSS + sizeof(struct tcb));
 }

--- a/include/solo5.h
+++ b/include/solo5.h
@@ -142,7 +142,7 @@ void solo5_abort(void) __attribute__((noreturn));
 /*
  * Returns the size needed for the thread local storage.
  */
-size_t solo5_tls_size();
+size_t solo5_tls_size(void);
 
 /*
  * Returns the tp base address for the TLS block.


### PR DESCRIPTION
This prevents a warning when built with -Wstrict-prototypes.