### PR TITLE
support FreeBSD14 in hvt

### DIFF
--- a/tenders/hvt/hvt_freebsd_x86_64.c
+++ b/tenders/hvt/hvt_freebsd_x86_64.c
@@ -163,6 +163,10 @@ int hvt_vcpu_loop(struct hvt *hvt)
 {
     struct hvt_b *hvb = hvt->b;
     int ret;
+#if __FreeBSD_version >= 1400000
+    struct vm_exit vmexit;
+    hvb->vmrun.vm_exit = &vmexit;
+#endif
 
     while (1) {
         ret = ioctl(hvt->b->vmfd, VM_RUN, &hvb->vmrun);
@@ -178,7 +182,11 @@ int hvt_vcpu_loop(struct hvt *hvt)
         if (handled)
             continue;
 
+#if __FreeBSD_version >= 1400000
+        struct vm_exit *vme = &vmexit;
+#else
         struct vm_exit *vme = &hvb->vmrun.vm_exit;
+#endif
 
         switch (vme->exitcode) {
         case VM_EXITCODE_INOUT: {

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -153,13 +153,11 @@ int main(int argc, char **argv)
      * which will be the ELF file to load. Stop if a "terminal" option such as
      * --help is encountered.
      */
-    int argc1 = argc;
     char **argv1 = argv;
     while (*argv1 && *argv1[0] == '-') {
         if (strcmp("--", *argv1) == 0)
         {
             /* Consume and stop option processing */
-            argc1--;
             argv1++;
             break;
         }
@@ -169,7 +167,6 @@ int main(int argc, char **argv)
         else if(strcmp("--version", *argv1) == 0)
             version(prog);
 
-        argc1--;
         argv1++;
     }
     if (*argv1 == NULL) {

--- a/tenders/spt/spt_main.c
+++ b/tenders/spt/spt_main.c
@@ -146,13 +146,11 @@ int main(int argc, char **argv)
      * which will be the ELF file to load. Stop if a "terminal" option such as
      * --help is encountered.
      */
-    int argc1 = argc;
     char **argv1 = argv;
     while (*argv1 && *argv1[0] == '-') {
         if (strcmp("--", *argv1) == 0)
         {
             /* Consume and stop option processing */
-            argc1--;
             argv1++;
             break;
         }
@@ -162,7 +160,6 @@ int main(int argc, char **argv)
         else if(strcmp("--version", *argv1) == 0)
             version(prog);
 
-        argc1--;
         argv1++;
     }
     if (*argv1 == NULL) {


### PR DESCRIPTION
The API around VM_RUN changed. With this change, all tests pass. The first commit is to avoid the clang warning:

```
# cc -MT hvt/hvt_main.o -MMD -MP -MF hvt/hvt_main.Td -fstack-protector-strong -Wall -Werror -std=c11 -O2 -g -I/.opam/4.13.1/.opam-switch/build/solo5.0.8.0/include -c hvt/hvt_main.c -o hvt/hvt_main.o
# hvt/hvt_main.c:156:9: error: variable 'argc1' set but not used [-Werror,-Wunused-but-set-variable]
#     int argc1 = argc;
#         ^
# 1 error generated.
```

I'm still dubious whether shipping releases of solo5 with `-Werror` is a good idea. IMHO it is nice for development, but since C compilers add new warnings in every release, it breaks the software.

FWIW, considering releases -- I'm still using the 0.7 series of solo5, and would appreciate a release in that series if possible. I have a branch (hannesm fork, FreeBSD14-0.7) that includes exactly these two patches, and it would be great to have them merged after review. If you could create a 0.7 branch (off of the v0.7.5 tag), I can open a separate PR.