### PR TITLE
Send FPU info to GDB in HVT server.

### DIFF
--- a/tenders/hvt/hvt_gdb_kvm_x86_64.c
+++ b/tenders/hvt/hvt_gdb_kvm_x86_64.c
@@ -31,6 +31,7 @@
  * and KVM.
  */
 
+#include <stdint.h>
 #define _GNU_SOURCE
 #include <assert.h>
 #include <err.h>
@@ -73,6 +74,8 @@ static uint32_t nr_hw_breakpoints = 0;
 static bool stepping = false;
 /* This is the trap instruction used for software breakpoints. */
 static const uint8_t int3 = 0xcc;
+
+static uint16_t to_fsave_tag(uint16_t fsw, uint8_t tag, const struct fpu_reg regs[FPU_REGS]);
 
 static int kvm_arch_insert_sw_breakpoint(struct hvt *hvt, struct breakpoint_t *bp)
 {
@@ -288,8 +291,13 @@ int hvt_gdb_read_registers(struct hvt *hvt,
 {
     struct kvm_regs kregs;
     struct kvm_sregs sregs;
+    struct kvm_fpu fregs;
     struct hvt_gdb_regs *gregs = (struct hvt_gdb_regs *) registers;
     int ret;
+
+    if (*len < sizeof(struct hvt_gdb_regs))
+        return -1;
+    *len = sizeof(struct hvt_gdb_regs);
 
     ret = ioctl(hvt->b->vcpufd, KVM_GET_REGS, &kregs);
     if (ret == -1) {
@@ -299,14 +307,19 @@ int hvt_gdb_read_registers(struct hvt *hvt,
 
     ret = ioctl(hvt->b->vcpufd, KVM_GET_SREGS, &sregs);
     if (ret == -1) {
-        err(1, "KVM_GET_REGS");
+        err(1, "KVM_GET_SREGS");
         return -1;
     }
 
-    if (*len < sizeof(struct hvt_gdb_regs))
+    ret = ioctl(hvt->b->vcpufd, KVM_GET_FPU, &fregs);
+    if (ret == -1) {
+        err(1, "KVM_GET_FPU");
         return -1;
+    }
 
-    *len = sizeof(struct hvt_gdb_regs);
+    // There's a bunch of reserved areas in the FPU section.
+    // It's easier to just zero out everything.
+    memset(gregs, 0, sizeof(*gregs));
 
     gregs->rax = kregs.rax;
     gregs->rbx = kregs.rbx;
@@ -332,6 +345,34 @@ int hvt_gdb_read_registers(struct hvt *hvt,
     gregs->es = sregs.es.selector;
     gregs->fs = sregs.fs.selector;
     gregs->gs = sregs.gs.selector;
+
+    // NOTE:
+    // The following code is tricky. KVM provides FPU state as dumped by FXSAVE
+    // x86 instruction, which has been available since Pentium 2/AMD K6.
+    // GDB on the other hand has wire format hardcoded as given by FSAVE
+    // instruction, probably for some very stupid reason. Therefore, a conversion
+    // is required.
+    // This doesn't result in an exact FPU state that could be i.e. loaded back
+    // with KVM_SET_FPU, yet this still can be handful for debugging.
+
+    // Copy STx/MMx registers.
+    for(int i = 0; i < FPU_REGS; i++) {
+        memcpy(&gregs->st[i].data, fregs.fpr[i], sizeof(gregs->st[i].data));
+    }
+    // Bottom 16 bits of these fields are reserved?
+    gregs->fctrl = (uint32_t)fregs.fcw << 16;
+    gregs->fstat = (uint32_t)fregs.fsw << 16;
+
+    gregs->ftag = to_fsave_tag(fregs.fsw, fregs.ftwx, gregs->st);
+    gregs->fop = fregs.last_opcode;
+
+    // These fields are 8 and 24 bits for segment and offset respectively in x86,
+    // but in GDB wire protocol they all are 32 bits. Hence, sending as much info
+    // as we can here.
+    gregs->fiseg = (fregs.last_ip >> 32) & 0xffffffff;
+    gregs->fioff = fregs.last_ip & 0xffffffff;
+    gregs->foseg = (fregs.last_dp >> 32) & 0xffffffff;
+    gregs->fooff = fregs.last_dp & 0xffffffff;
 
     return 0;
 }
@@ -389,13 +430,13 @@ int hvt_gdb_write_registers(struct hvt *hvt,
 
     ret = ioctl(hvt->b->vcpufd, KVM_SET_REGS, &kregs);
     if (ret == -1) {
-        err(1, "KVM_GET_REGS");
+        err(1, "KVM_SET_REGS");
         return -1;
     }
 
     ret = ioctl(hvt->b->vcpufd, KVM_SET_SREGS, &sregs);
     if (ret == -1) {
-        err(1, "KVM_GET_REGS");
+        err(1, "KVM_SET_SREGS");
         return -1;
     }
 
@@ -499,4 +540,50 @@ int hvt_gdb_read_last_signal(struct hvt *hvt, int *signal)
     }
 
     return 0;
+}
+
+// Convert FXSAVE tag to full tag format from FSAVE.
+// This is what GDB expects in its wire protocol for some dumb reason.
+static uint16_t to_fsave_tag(uint16_t fsw, uint8_t tag, const struct fpu_reg regs[FPU_REGS])
+{
+  int stack_top = (fsw >> 11) & 0x7;
+
+  uint16_t fsave_tag = 0;
+  for (int phys_idx = 0; phys_idx < FPU_REGS; phys_idx++) {
+    bool fxsave_bit = (tag & (1 << phys_idx)) != 0;
+    uint8_t fsave_bits = 0;
+
+    if (fxsave_bit) {
+      int st_idx = (phys_idx + FPU_REGS - stack_top) % FPU_REGS;
+      const unsigned char *st = regs[st_idx].data;
+      bool integer_bit = (st[7] & 0x80) != 0;
+      uint16_t exponent = ((st[9] & 0x7f) << 8) | st[8];
+      uint64_t fraction = (((uint64_t)st[7] & 0x7f) << 56)
+                        | ((uint64_t)st[6] << 48)
+                        | ((uint64_t)st[5] << 40)
+                        | ((uint64_t)st[4] << 32)
+                        | ((uint64_t)st[3] << 24)
+                        | ((uint64_t)st[2] << 16)
+                        | ((uint64_t)st[1] << 8)
+                        |  (uint64_t)st[0];
+
+      if (exponent == 0x7fff) {
+        // Infinity, NaN, pseudo-infinity, or pseudo-NaN.
+        // Mostly the case for MMX values.
+        fsave_bits = 2;
+      } else if (exponent == 0) {
+        // J bit.
+        fsave_bits = !integer_bit && !fraction ? 1 : 2;
+      } else if (integer_bit) {
+        fsave_bits = 0;
+      } else {
+        fsave_bits = 1;
+      }
+    } else {
+      fsave_bits = 3;
+    }
+    fsave_tag |= (fsave_bits << (phys_idx * 2));
+  }
+
+  return fsave_tag;
 }

--- a/tenders/hvt/hvt_gdb_x86_64.h
+++ b/tenders/hvt/hvt_gdb_x86_64.h
@@ -25,6 +25,17 @@
 #ifndef HVT_GDB_X86_64_H
 #define HVT_GDB_X86_64_H
 
+// NOTE:
+// structures defined here MUST BE packed in order to avoid padding.
+// FPU registers in x86 are 80 bits wide and C compilers WILL insert
+// padding otherwise, making serialisation trickier.
+
+// GDB expects FPU registers as 80 bit numbers,
+// but C doesn't have a type for this.
+struct fpu_reg { unsigned char data[10]; } __attribute__((packed));
+
+#define FPU_REGS 8
+
 /*
  * XXX: While there is no header file in GDB to include here,
  * the register structure is described in XML here:
@@ -58,6 +69,16 @@ struct hvt_gdb_regs {
     uint32_t es;
     uint32_t fs;
     uint32_t gs;
-};
+
+    struct fpu_reg st[FPU_REGS];
+    uint32_t fctrl;
+    uint32_t fstat;
+    uint32_t ftag;
+    uint32_t fiseg;
+    uint32_t fioff;
+    uint32_t foseg;
+    uint32_t fooff;
+    uint32_t fop;
+} __attribute__((packed));
 
 #endif /* HVT_GDB_X86_64_H */


### PR DESCRIPTION
FPU dumping code written as a part of https://github.com/Solo5/solo5/pull/567.

Needs more thorough tests before merging, but you guys can look at it in the meanwhile.