### PR TITLE
Initial support for OpenBSD 7.5

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -109,14 +109,16 @@ EOM
 
 cc_check_header()
 {
-    ${CC} ${PKG_CFLAGS} -x c -o /dev/null - <<EOM >/dev/null 2>&1
-#include <$@>
+    (
+        for h in "$@"; do echo "#include <$h>"; done
+        cat << EOM
 
 int main(int argc, char *argv[])
 {
     return 0;
 }
 EOM
+    ) | ${CC} ${PKG_CFLAGS} -x c -o /dev/null - >/dev/null 2>&1
 }
 
 cc_check_lib()

--- a/configure.sh
+++ b/configure.sh
@@ -284,6 +284,15 @@ case ${HOST_CC_MACHINE} in
     amd64-*openbsd*)
         CONFIG_HOST_ARCH=x86_64 CONFIG_HOST=OpenBSD
         CONFIG_HVT_TENDER=1
+        echo "${prog_NAME}: Checking for dev/vmm/vmm.h availability: "
+        if CC="${HOST_CC}" PKG_CFLAGS="" \
+            cc_check_header sys/types.h machine/vmmvar.h dev/vmm/vmm.h; then
+            echo "yes"
+            echo "#define HAVE_VMM_H 1" >tenders/hvt/hvt_openbsd_config.h
+        else
+            echo "no"
+            echo "#undef HAVE_VMM_H" >tenders/hvt/hvt_openbsd_config.h
+        fi
         ;;
     *)
         die "Unsupported host toolchain: ${HOST_CC_MACHINE}"

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -42,6 +42,11 @@
 #include <machine/vmmvar.h>
 #include <sys/param.h>
 
+#include "hvt_openbsd_config.h"
+#ifdef HAVE_VMM_H
+#include <dev/vmm/vmm.h>
+#endif
+
 #include "hvt.h"
 #include "hvt_openbsd.h"
 

--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -51,6 +51,11 @@
 #include "hvt_openbsd.h"
 #include "hvt_cpu_x86_64.h"
 
+/* XCR0_X87 is the pre-7.5 name for XFEATURE_X87 */
+#ifndef XFEATURE_X87
+#define XFEATURE_X87 XCR0_X87
+#endif
+
 static struct vcpu_segment_info sreg_to_vsi(const struct x86_sreg *);
 
 static uint64_t get_tsc_freq(void)
@@ -129,7 +134,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
             .vrs_msrs[VCPU_REGS_CSTAR] = 0ULL,
             .vrs_msrs[VCPU_REGS_SFMASK] = 0ULL,
             .vrs_msrs[VCPU_REGS_KGSBASE] = 0ULL,
-            .vrs_crs[VCPU_REGS_XCR0] = XCR0_X87
+            .vrs_crs[VCPU_REGS_XCR0] = XFEATURE_X87
         }
     };
 

--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -42,6 +42,11 @@
 #include <machine/vmmvar.h>
 #include <machine/specialreg.h>
 
+#include "hvt_openbsd_config.h"
+#ifdef HAVE_VMM_H
+#include <dev/vmm/vmm.h>
+#endif
+
 #include "hvt.h"
 #include "hvt_openbsd.h"
 #include "hvt_cpu_x86_64.h"


### PR DESCRIPTION
This PR is a WIP as tests are failing but it makes at least the build succeed on OpenBSD 7.5.
Credits to @dustanddreams for identifying the breaking changes.

All the tests errors I see now are:

```
ld.lld: error: relocation refers to a symbol in a discarded section: __retguard_546
>>> defined in /home/build/solo5/toolchain/bin/../lib/x86_64-solo5-none-static/solo5_hvt.o
```

or similar with `solo5_stub.o`.

I think I’ve read somewhere similar errors being tackled previously. Any idea for a fix?