### PR TITLE
Fetch `stdatomic.h` from system on FreeBSD

### DIFF
--- a/toolchain/gen-headers.sh
+++ b/toolchain/gen-headers.sh
@@ -72,6 +72,7 @@ if CC=${CONFIG_TARGET_CC} cc_is_clang; then
         FreeBSD|OpenBSD)
             SRCDIR=/usr/include
             SRCS="float.h stddef.h stdint.h stdbool.h stdarg.h"
+            [ "${CONFIG_HOST}" = "FreeBSD" ] && SRCS="${SRCS} stdatomic.h"
             DEPS="$(mktemp)"
             CC=${CONFIG_TARGET_CC} cc_get_header_deps ${SRCDIR} ${SRCS} \
                 >${DEPS} || \


### PR DESCRIPTION
This PR adds `stdatomic.h` to the set of headers that must be copied over from `/usr/include` on FreeBSD because it is not included in the clang resources on that system.

`stdatomic.h` is not listed in the C standard as a freestanding header but many atomic operations (in particular all the atomic operations the OCaml runtime uses) are really compiler builtins.