### PR TITLE
Ensure reproducibility of Solo5

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -65,6 +65,7 @@ xen_SRCS := xen/boot.S xen/start.c $(common_SRCS) \
     xen/evtchn.c xen/time.c xen/pvclock.c xen/stubs.c
 
 CPPFLAGS+=-D__SOLO5_BINDINGS__
+CPPFLAGS+=-ffile-prefix-map=${TOPDIR}=.
 
 ifeq ($(CONFIG_TARGET_ARCH), x86_64)
 # Prevent the compiler from adding optimizations that use shared FPU state.


### PR DESCRIPTION
This patch adds a new option availabe since GCC 8 and Clang 10 which delete absolute path from produced object files. It does not have huge implication on the execution of tenders and unikernels but it allows us to install Solo5 on some systems which check that installed files (like solo5_{hvt,...}.o) don't include user informations.

- [ ] check the version of the compiler used