### PR TITLE
hvt: x86_64: Allow for up to 4GB guest size

### DIFF
--- a/tenders/hvt/hvt_cpu_x86_64.c
+++ b/tenders/hvt/hvt_cpu_x86_64.c
@@ -52,6 +52,11 @@ void hvt_x86_setup_pagetables(uint8_t *mem, size_t mem_size)
     uint64_t *pde = (uint64_t *)(mem + X86_PDE_BASE);
     uint64_t *pt0e = (uint64_t *)(mem + X86_PT0E_BASE);
     uint64_t paddr;
+    /*
+     * See Intel SDM Volume 3A, section 4.5 "4-Level Paging and 5-Level Paging"
+     * and Figure 4-9. "Linear-Address Translation to a 2-MByte Page using
+     * 4-Level Paging"
+     */
 
     /*
      * We currently use 2MB pages.  Sanity check that the guest size is a

--- a/tenders/hvt/hvt_cpu_x86_64.h
+++ b/tenders/hvt/hvt_cpu_x86_64.h
@@ -199,16 +199,22 @@ static const struct x86_sreg hvt_x86_sreg_unusable = {
 #define X86_PDPTE_BASE          0x3000
 #define X86_PDPTE_SIZE          0x1000
 #define X86_PDE_BASE            0x4000
-#define X86_PDE_SIZE            0x1000
-#define X86_PT0E_BASE           0x5000
+#define X86_PDE_SIZE            0x4000
+#define X86_PT0E_BASE           0x8000
 #define X86_PTE_SIZE            0x1000
 #define X86_BOOT_INFO_BASE      0x10000
 #define X86_PT0_MAP_START       X86_BOOT_INFO_BASE
 #define X86_GUEST_MIN_BASE      HVT_GUEST_MIN_BASE
 
-#define X86_GUEST_PAGE_SIZE     0x200000
+#define X86_GUEST_PAGE_SIZE     0x200000UL
 
 #define X86_CR3_INIT            X86_PML4_BASE
+
+/*
+ * Maximum guest allocation size; must fit in 4 PDE entries.
+ */
+#define X86_GUEST_MAX_MEM_SIZE  (2048UL * X86_GUEST_PAGE_SIZE)
+
 
 /*
  * Initial RFLAGS value. Bit 1 is reserved and must be set.

--- a/tenders/hvt/hvt_cpu_x86_64.h
+++ b/tenders/hvt/hvt_cpu_x86_64.h
@@ -199,6 +199,7 @@ static const struct x86_sreg hvt_x86_sreg_unusable = {
 #define X86_PDPTE_BASE          0x3000
 #define X86_PDPTE_SIZE          0x1000
 #define X86_PDE_BASE            0x4000
+/* 4 PDE entries of 0x1000 bytes each */
 #define X86_PDE_SIZE            0x4000
 #define X86_PT0E_BASE           0x8000
 #define X86_PTE_SIZE            0x1000

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -97,7 +97,7 @@ setup_block() {
 }
 
 hvt_run() {
-  run ${TIMEOUT} --foreground 60s "${HVT_TENDER}" --mem=2 "$@"
+  run ${TIMEOUT} --foreground 60s "${HVT_TENDER}" --mem=4096 "$@"
 }
 
 spt_run() {


### PR DESCRIPTION
The following is a commit done by @mato. I am creating this draft PR to open up for review and hopefully eventually have it merged. I may add comments or changes that I find helpful in understanding the code.

----

Allow for up to 4GB guest size on x86_64 by using up to four PDE entries.

TODO: Lightly tested only, not sure if this arrangement will conflict with any platform memory holes that "plain" KVM may map into guest memory.