### PR TITLE
Check GET_TSC_KHZ return code correctly & update Intel SDM reference

### DIFF
--- a/tenders/hvt/hvt_cpu_x86_64.h
+++ b/tenders/hvt/hvt_cpu_x86_64.h
@@ -75,7 +75,7 @@
 #define X86_CR4_VMXE            _BITUL(X86_CR4_VMXE_BIT)
 
 /*
- * Intel SDM section 23.8 "Restrictions on VMX Operation" seems to imply that
+ * Intel SDM section 24.8 "Restrictions on VMX Operation" seems to imply that
  * X86_CR4_VMXE should be set on VMENTRY to support old processors, however KVM
  * (but not FreeBSD vmm) does not like us setting this bit. Leave it cleared
  * for now and revisit later.

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -75,7 +75,7 @@ struct hvt *hvt_init(size_t mem_size)
     if (hvb->vcpurun == MAP_FAILED)
         err(1, "KVM: VCPU mmap failed");
 
-    /* XXX(reynir): probably very unlikely to fail... */
+    /* (reynir, 2024-05-08): probably very unlikely to fail... */
     ret = ioctl(hvb->kvmfd, KVM_CHECK_EXTENSION, KVM_CAP_USER_MEMORY);
     if (ret == -1)
         err(1, "KVM: ioctl (KVM_CHECK_EXTENSION) failed");

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -75,6 +75,12 @@ struct hvt *hvt_init(size_t mem_size)
     if (hvb->vcpurun == MAP_FAILED)
         err(1, "KVM: VCPU mmap failed");
 
+    /* XXX(reynir): probably very unlikely to fail... */
+    ret = ioctl(hvb->kvmfd, KVM_CHECK_EXTENSION, KVM_CAP_USER_MEMORY);
+    if (ret == -1)
+        err(1, "KVM: ioctl (KVM_CHECK_EXTENSION) failed");
+    if (ret != 1)
+        errx(1, "KVM: host does not support KVM_CAP_USER_MEMORY");
     hvt->mem = mmap(NULL, mem_size, PROT_READ | PROT_WRITE,
                MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (hvt->mem == MAP_FAILED)

--- a/tenders/hvt/hvt_kvm_x86_64.c
+++ b/tenders/hvt/hvt_kvm_x86_64.c
@@ -116,7 +116,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
     if (ret != 1)
         errx(1, "KVM: host does not support KVM_CAP_GET_TSC_KHZ");
     int tsc_khz = ioctl(hvb->vcpufd, KVM_GET_TSC_KHZ);
-    if (tsc_khz == -1) {
+    if (tsc_khz < 0) {
         if (errno == EIO)
             errx(1, "KVM: host TSC is unstable, cannot continue");
         else


### PR DESCRIPTION
We check the ioctl for `KVM_GET_TSC_KHZ` being -1 only, but according to the documentation it will return `-EIO` (`-5`) when the TSC is unstable (which we check for in errno).  https://www.kernel.org/doc/html/latest/virt/kvm/api.html#kvm-get-tsc-khz

I also updated a reference to Intel SDM which now lives in chapter 24 instead of chapter 23. Maybe we should version the references somehow...