### PR TITLE
Fix tests with QEMU 9.0

### DIFF
--- a/scripts/virtio-run/solo5-virtio-run.sh
+++ b/scripts/virtio-run/solo5-virtio-run.sh
@@ -146,7 +146,7 @@ kvm|qemu)
     hv_addargs -m ${MEM}
 
     # Kill all default devices provided by QEMU, we don't need them.
-    hv_addargs -nodefaults -no-acpi
+    hv_addargs -nodefaults -machine acpi=off
 
     # Console. We could use just "-nograhic -vga none", however that MUXes the
     # QEMU monitor on stdio which requires ^Ax to exit. This makes things look


### PR DESCRIPTION
`-no-acpi` was removed in QEMU 9.0, see https://www.qemu.org/docs/master/about/removed-features.html#no-acpi-removed-in-9-0.