### PR TITLE
Update virtio

### DIFF
--- a/bindings/virtio/bindings.h
+++ b/bindings/virtio/bindings.h
@@ -59,15 +59,9 @@ struct pci_config_info {
     uint8_t irq;
 };
 
-void pci_enumerate(void);
+int pci_enumerate(void);
 
-/* virtio.c: mostly net for now */
-void virtio_config_network(struct pci_config_info *);
-void virtio_config_block(struct pci_config_info *);
-
-uint8_t *virtio_net_pkt_get(size_t *size);  /* get a pointer to recv'd data */
-void virtio_net_pkt_put(void);      /* we're done with recv'd data */
-int virtio_net_xmit_packet(const void *data, size_t len);
-int virtio_net_pkt_poll(void);      /* test if packet(s) are available */
+int virtio_config_network(struct pci_config_info *, solo5_handle_t);
+int virtio_config_block(struct pci_config_info *, solo5_handle_t);
 
 #endif /* __VIRTIO_BINDINGS_H__ */

--- a/bindings/virtio/pci.c
+++ b/bindings/virtio/pci.c
@@ -53,44 +53,57 @@
 } while (0)
 
 
-static uint32_t net_devices_found;
-static uint32_t blk_devices_found;
-
+static solo5_handle_t mft_index = 0;
 #define PCI_CONF_SUBSYS_NET 1
 #define PCI_CONF_SUBSYS_BLK 2
 
-static void virtio_config(struct pci_config_info *pci)
+/*
+ * mft_index tracks the order in which devices are found (given by the
+ * PCI slots). This is used to map found devices to devices in the manifest.
+ */
+static int virtio_config(struct pci_config_info *pci)
 {
     /* we only support one net device and one blk device */
     switch (pci->subsys_id) {
     case PCI_CONF_SUBSYS_NET:
         log(INFO, "Solo5: PCI:%02x:%02x: virtio-net device, base=0x%x, irq=%u\n",
             pci->bus, pci->dev, pci->base, pci->irq);
-        if (!net_devices_found++)
-            virtio_config_network(pci);
-        else
-            log(WARN, "Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
-                pci->dev);
+        if (virtio_config_network(pci, mft_index) != 0)
+            return -1;
+        mft_index++;
         break;
     case PCI_CONF_SUBSYS_BLK:
         log(INFO, "Solo5: PCI:%02x:%02x: virtio-block device, base=0x%x, irq=%u\n",
             pci->bus, pci->dev, pci->base, pci->irq);
-        if (!blk_devices_found++)
-            virtio_config_block(pci);
-        else
-            log(WARN, "Solo5: PCI:%02x:%02x: not configured\n", pci->bus,
-                pci->dev);
+        if (virtio_config_block(pci, mft_index) != 0)
+            return -1;
+        mft_index++;
         break;
     default:
+        /* Most likely this is something like a virtio_scsi device
+           that we can not handle. Let's not handle nor count it
+           in pci_virtio_index. */
         log(WARN, "Solo5: PCI:%02x:%02x: unknown virtio device (0x%x)\n",
             pci->bus, pci->dev, pci->subsys_id);
-        return;
     }
+    return 0;
 }
 
 #define VENDOR_QUMRANET_VIRTIO 0x1af4
 
-void pci_enumerate(void)
+/*
+ * Every PCI device found in pci_enumerate is attempted to be assigned to a
+ * device from the application manifest in the order in which they are found. This
+ * order is given by the PCI slot number which is controlled in
+ * solo5-virtio-run.sh.
+ * 
+ * This funtion can fail if the type of a device just found does not match the
+ * type of the next expected device in the manifest. Devices whose type (e.g.,
+ * virtio_scsi) is unknown is just skipped.
+ * 
+ * Returns 0 on success, -1 otherwise.
+ */
+int pci_enumerate(void)
 {
     uint32_t bus;
     uint8_t dev;
@@ -116,8 +129,10 @@ void pci_enumerate(void)
                 PCI_CONF_READ(uint16_t, &pci.base, config_addr, IOBAR);
                 PCI_CONF_READ(uint8_t, &pci.irq, config_addr, IRQ);
 
-                virtio_config(&pci);
+                if (virtio_config(&pci) != 0)
+                    return -1;
             }
         }
     }
+    return 0;
 }

--- a/bindings/virtio/pci.c
+++ b/bindings/virtio/pci.c
@@ -53,7 +53,12 @@
 } while (0)
 
 
-static solo5_handle_t mft_index = 0;
+/* in tenders/common/mft.c:
+ * The manifest must contain at least one entry, and the first entry must
+ * be of type MFT_RESERVED_FIRST with an empty name.
+ * -> Therefore we need to start mft_index at 1
+ */
+static solo5_handle_t mft_index = 1;
 #define PCI_CONF_SUBSYS_NET 1
 #define PCI_CONF_SUBSYS_BLK 2
 
@@ -63,7 +68,6 @@ static solo5_handle_t mft_index = 0;
  */
 static int virtio_config(struct pci_config_info *pci)
 {
-    /* we only support one net device and one blk device */
     switch (pci->subsys_id) {
     case PCI_CONF_SUBSYS_NET:
         log(INFO, "Solo5: PCI:%02x:%02x: virtio-net device, base=0x%x, irq=%u\n",

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -93,16 +93,27 @@ static void _start2(void *arg __attribute__((unused)))
     size_t mft_size;
     mft_get_builtin_mft1_unconst(&__solo5_mft1_note, &mft, &mft_size);
     if (mft_validate(mft, mft_size) != 0) {
-	    log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
-	    solo5_abort();
+        log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
+        solo5_abort();
     }
     virtio_manifest = mft;
+
+    /*
+     * Attach the first entry if its type is really MFT_RESERVED_FIRST.
+     * Abort otherwise.
+     */
+    struct mft_entry *e = mft_get_by_index(virtio_manifest, 0, MFT_RESERVED_FIRST);
+    if (e == NULL) {
+        log(ERROR, "Solo5: first entry in manifest is not of type MFT_RESERVED_FIRST\n");
+        solo5_abort();
+    }
+    e->attached = true;
 
     mem_init();
     time_init();
     if (pci_enumerate() != 0) {
-	    log(ERROR, "Solo5: PCI enumeration failed. Aborting.\n");
-	    solo5_abort();
+        log(ERROR, "Solo5: PCI enumeration failed. Aborting.\n");
+        solo5_abort();
     }
     mft_check_all_acquired();
     cpu_intr_enable();

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -36,8 +36,6 @@
 #define VIRTIO_BLK_S_IOERR  1
 #define VIRTIO_BLK_S_UNSUPP 2
 
-static uint64_t virtio_blk_sectors;
-
 #define VIRTIO_BLK_SECTOR_SIZE    512
 
 struct virtio_blk_hdr {
@@ -46,31 +44,36 @@ struct virtio_blk_hdr {
     uint64_t sector;
 };
 
-static struct virtq blkq;
 #define VIRTQ_BLK  0
+struct virtio_blk_desc {
+    uint16_t pci_base; /* base in PCI config space */
+    struct virtq blkq;
+    uint64_t sectors;
+    uint16_t sector_size;
+};
 
-static uint16_t virtio_blk_pci_base; /* base in PCI config space */
+#define VIRTIO_BLK_MAX_ENTRIES  MFT_MAX_ENTRIES
+static struct virtio_blk_desc bd_table[VIRTIO_BLK_MAX_ENTRIES];
+static unsigned bd_num_entries = 0;
 
-static bool blk_configured;
-static bool blk_acquired;
-static solo5_handle_t blk_handle;
 extern struct mft *virtio_manifest;
 
 /* Returns the index to the head of the buffers chain. */
-static uint16_t virtio_blk_op(uint32_t type,
+static uint16_t virtio_blk_op(struct virtio_blk_desc *bd,
+                              uint32_t type,
                               uint64_t sector,
                               void *data, size_t len)
 {
-    uint16_t mask = blkq.num - 1;
+    uint16_t mask = bd->blkq.num - 1;
     struct virtio_blk_hdr hdr;
     struct io_buffer *head_buf, *data_buf, *status_buf;
-    uint16_t head = blkq.next_avail & mask;
+    uint16_t head = bd->blkq.next_avail & mask;
 
     assert(len <= VIRTIO_BLK_SECTOR_SIZE);
 
-    head_buf = &blkq.bufs[head];
-    data_buf = &blkq.bufs[(head + 1) & mask];
-    status_buf = &blkq.bufs[(head + 2) & mask];
+    head_buf = &bd->blkq.bufs[head];
+    data_buf = &bd->blkq.bufs[(head + 1) & mask];
+    status_buf = &bd->blkq.bufs[(head + 2) & mask];
 
     hdr.type = type;
     hdr.ioprio = 0;
@@ -93,9 +96,9 @@ static uint16_t virtio_blk_op(uint32_t type,
     status_buf->len = sizeof(uint8_t);
     status_buf->extra_flags = VIRTQ_DESC_F_WRITE;
 
-    assert(virtq_add_descriptor_chain(&blkq, head, 3) == 0);
+    assert(virtq_add_descriptor_chain(&bd->blkq, head, 3) == 0);
 
-    outw(virtio_blk_pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_BLK);
+    outw(bd->pci_base + VIRTIO_PCI_QUEUE_NOTIFY, VIRTQ_BLK);
 
     return head;
 }
@@ -107,33 +110,34 @@ static uint16_t virtio_blk_op(uint32_t type,
  * time.  That is true as long as we use only synchronous IO calls, and if
  * there is just a sync call at a time (which is true for solo5).
  */
-static int virtio_blk_op_sync(uint32_t type,
+static int virtio_blk_op_sync(struct virtio_blk_desc *bd,
+                              uint32_t type,
                               uint64_t sector,
                               void *data, size_t len)
 {
-    uint16_t mask = blkq.num - 1;
+    uint16_t mask = bd->blkq.num - 1;
     uint16_t head;
     struct io_buffer *data_buf, *status_buf;
     uint8_t status;
 
-    head = virtio_blk_op(type, sector, data, len);
-    data_buf = &blkq.bufs[(head + 1) & mask];
-    status_buf = &blkq.bufs[(head + 2) & mask];
+    head = virtio_blk_op(bd, type, sector, data, len);
+    data_buf = &bd->blkq.bufs[(head + 1) & mask];
+    status_buf = &bd->blkq.bufs[(head + 2) & mask];
 
     /* Loop until the device used all of our descriptors. */
-    while (blkq.used->idx != blkq.avail->idx)
+    while (bd->blkq.used->idx != bd->blkq.avail->idx)
         ;
 
     /* Consume all the recently used descriptors. */
-    for (; blkq.used->idx != blkq.last_used; blkq.last_used++) {
+    for (; bd->blkq.used->idx != bd->blkq.last_used; bd->blkq.last_used++) {
         struct virtq_used_elem *e;
 
         /* Assert that the used descriptor matches the descriptor of the
          * IO we started at the start of this function. */
-        e = &(blkq.used->ring[blkq.last_used & mask]);
+        e = &(bd->blkq.used->ring[bd->blkq.last_used & mask]);
         assert(head == e->id);
 
-        blkq.num_avail += 3; /* 3 descriptors per chain */
+        bd->blkq.num_avail += 3; /* 3 descriptors per chain */
     }
 
     status = (*(uint8_t *)status_buf);
@@ -146,7 +150,8 @@ static int virtio_blk_op_sync(uint32_t type,
     return 0;
 }
 
-void virtio_config_block(struct pci_config_info *pci)
+static void virtio_blk_config(struct virtio_blk_desc *bd,
+                                struct pci_config_info *pci)
 {
     uint8_t ready_for_init = VIRTIO_PCI_STATUS_ACK | VIRTIO_PCI_STATUS_DRIVER;
     uint32_t host_features, guest_features;
@@ -161,61 +166,75 @@ void virtio_config_block(struct pci_config_info *pci)
     guest_features = 0;
     outl(pci->base + VIRTIO_PCI_GUEST_FEATURES, guest_features);
 
-    virtio_blk_sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
+    bd->sector_size = VIRTIO_BLK_SECTOR_SIZE;
+    bd->sectors = inq(pci->base + VIRTIO_PCI_CONFIG_OFF);
     log(INFO, "Solo5: PCI:%02x:%02x: configured, capacity=%llu sectors, "
         "features=0x%x\n",
-        pci->bus, pci->dev, (unsigned long long)virtio_blk_sectors,
+        pci->bus, pci->dev, (unsigned long long)bd->sectors,
         host_features);
 
-    virtq_init_rings(pci->base, &blkq, 0);
+    virtq_init_rings(pci->base, &bd->blkq, 0);
 
-    pgs = (((blkq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
-    blkq.bufs = mem_ialloc_pages(pgs);
-    assert(blkq.bufs);
-    memset(blkq.bufs, 0, pgs << PAGE_SHIFT);
+    pgs = (((bd->blkq.num * sizeof (struct io_buffer)) - 1) >> PAGE_SHIFT) + 1;
+    bd->blkq.bufs = mem_ialloc_pages(pgs);
+    assert(bd->blkq.bufs);
+    memset(bd->blkq.bufs, 0, pgs << PAGE_SHIFT);
 
-    virtio_blk_pci_base = pci->base;
-    blk_configured = 1;
+    bd->pci_base = pci->base;
 
     /*
      * We don't need to get interrupts every time the device uses our
      * descriptors.
      */
 
-    blkq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
+    bd->blkq.avail->flags |= VIRTQ_AVAIL_F_NO_INTERRUPT;
 
     outb(pci->base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
 }
 
-/*
- * FIXME: This is a single-device implementation of the new manifest-based
- * APIs. On virtio, this call has the following semantics:
- *
- * 1. The first call to solo5_block_acquire() asking for a handle to a valid
- *    block device (one specified in the application manifest) will succeed,
- *    and return a handle for the sole virtio block device.
- * 2. All subsequent calls will return an error.
- *
- * Note that the presence of a virtio block device is registered during boot
- * in (blk_configured), and the initial acquisition by solo5_block_acquire() is
- * registered in (blk_acquired).
- */
+int virtio_config_block(struct pci_config_info *pci,solo5_handle_t mft_index)
+{
+    unsigned bd_index = bd_num_entries;
+
+    if (bd_index >= VIRTIO_BLK_MAX_ENTRIES) {
+        log(WARN, "Solo5: Virtio blk: PCI:%02x:%02x not configured: "
+            "too many devices.\n", pci->bus, pci->dev);
+        return -1;
+    }
+
+    struct mft_entry *e = mft_get_by_index(virtio_manifest, mft_index,
+            MFT_DEV_BLOCK_BASIC);
+    if (e == NULL) {
+        log(WARN, "Solo5: Virtio blk: PCI:%02x:%02x not in manifest\n",
+             pci->bus, pci->dev);
+        return -1;
+    }
+
+    struct virtio_blk_desc *bd = &bd_table[bd_index];
+
+    virtio_blk_config(bd, pci);
+    e->b.hostfd = bd_index;
+    e->u.block_basic.capacity = bd->sectors;
+    e->u.block_basic.block_size = bd->sector_size;
+    e->attached = true;
+
+    bd_num_entries++;
+    return 0;
+}
+
 solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *h,
         struct solo5_block_info *info)
 {
-    if (!blk_configured || blk_acquired)
-        return SOLO5_R_EUNSPEC;
-
     unsigned mft_index;
-    struct mft_entry *mft_e = mft_get_by_name(virtio_manifest, name,
+    struct mft_entry *e = mft_get_by_name(virtio_manifest, name,
         MFT_DEV_BLOCK_BASIC, &mft_index);
-    if (mft_e == NULL)
+    if (e == NULL)
         return SOLO5_R_EINVAL;
-    blk_handle = mft_index;
-    blk_acquired = true;
+    assert(e->attached);
+    assert(e->b.hostfd < VIRTIO_BLK_MAX_ENTRIES);
 
     info->block_size = VIRTIO_BLK_SECTOR_SIZE;
-    info->capacity = virtio_blk_sectors * VIRTIO_BLK_SECTOR_SIZE;
+    info->capacity = e->u.block_basic.capacity * VIRTIO_BLK_SECTOR_SIZE;
     *h = mft_index;
     log(INFO, "Solo5: Application acquired '%s' as block device\n", name);
     return SOLO5_R_OK;
@@ -224,8 +243,11 @@ solo5_result_t solo5_block_acquire(const char *name, solo5_handle_t *h,
 solo5_result_t solo5_block_write(solo5_handle_t h, solo5_off_t offset,
         const uint8_t *buf, size_t size)
 {
-    if (!blk_acquired || h != blk_handle)
+    struct mft_entry *e = mft_get_by_index(virtio_manifest, h, MFT_DEV_BLOCK_BASIC);
+    if (e == NULL)
         return SOLO5_R_EINVAL;
+    assert(e->attached);
+    assert(e->b.hostfd < VIRTIO_BLK_MAX_ENTRIES);
 
     /*
      * XXX: This does not check for writes ending past the end of the device,
@@ -234,24 +256,30 @@ solo5_result_t solo5_block_write(solo5_handle_t h, solo5_off_t offset,
      */
     uint64_t sector = offset / VIRTIO_BLK_SECTOR_SIZE;
     if ((offset % VIRTIO_BLK_SECTOR_SIZE != 0) ||
-        (sector >= virtio_blk_sectors) ||
+        (sector >= e->u.block_basic.capacity) ||
         (size != VIRTIO_BLK_SECTOR_SIZE))
         return SOLO5_R_EINVAL;
+
+    struct virtio_blk_desc *bd = &bd_table[e->b.hostfd];
 
     /*
      * XXX: removing the const qualifier from buf here is fine with the current
      * implementation which does a memcpy() on VIRTIO_BLK_T_OUT, however the
      * internal interfaces should be refactored to reflect this.
      */
-    int rv = virtio_blk_op_sync(VIRTIO_BLK_T_OUT, sector, (uint8_t *)buf, size);
+    int rv = virtio_blk_op_sync(bd, VIRTIO_BLK_T_OUT, sector,
+        (uint8_t *)buf, size);
     return (rv == 0) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }
 
 solo5_result_t solo5_block_read(solo5_handle_t h, solo5_off_t offset,
         uint8_t *buf, size_t size)
 {
-    if (!blk_acquired || h != blk_handle)
+    struct mft_entry *e = mft_get_by_index(virtio_manifest, h, MFT_DEV_BLOCK_BASIC);
+    if (e == NULL)
         return SOLO5_R_EINVAL;
+    assert(e->attached);
+    assert(e->b.hostfd < VIRTIO_BLK_MAX_ENTRIES);
 
     /*
      * XXX: This does not check for reads ending past the end of the device,
@@ -260,10 +288,12 @@ solo5_result_t solo5_block_read(solo5_handle_t h, solo5_off_t offset,
      */
     uint64_t sector = offset / VIRTIO_BLK_SECTOR_SIZE;
     if ((offset % VIRTIO_BLK_SECTOR_SIZE != 0) ||
-        (sector >= virtio_blk_sectors) ||
+        (sector >= e->u.block_basic.capacity) ||
         (size != VIRTIO_BLK_SECTOR_SIZE))
         return SOLO5_R_EINVAL;
 
-    int rv = virtio_blk_op_sync(VIRTIO_BLK_T_IN, sector, buf, size);
+    struct virtio_blk_desc *bd = &bd_table[e->b.hostfd];
+
+    int rv = virtio_blk_op_sync(bd, VIRTIO_BLK_T_IN, sector, buf, size);
     return (rv == 0) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }

--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -243,8 +243,7 @@ static void virtio_net_config(struct virtio_net_desc *nd,
     outb(pci->base + VIRTIO_PCI_STATUS, VIRTIO_PCI_STATUS_DRIVER_OK);
 }
 
-/* Returns 1 if there is a pending used descriptors for us to read.
-FIXME: palainp, the description does not match the behaviour of the function */
+/* Set ready for each net interface if there is pending data to read. */
 static void virtio_net_pkt_poll(virtio_set_t *ready_set)
 {
     unsigned idx;

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -623,6 +623,17 @@ xen_expect_abort() {
   expect_success
 }
 
+test "net_2if virtio" {
+  [ $(id -u) -ne 0 ] && skip "Need root to run this test, for ping -f"
+  [ "${CONFIG_HOST}" = "OpenBSD" ] && skip "breaks on OpenBSD due to #374"
+
+  ( sleep 2; ${TIMEOUT} 60s ping -fq -c 50000 ${NET0_IP} ) &
+  ( sleep 2; ${TIMEOUT} 60s ping -fq -c 50000 ${NET1_IP} ) &
+  virtio_run -n ${NET0} -n ${NET1} -- \
+      test_net_2if/test_net_2if.virtio limit
+  virtio_expect_success
+}
+
 @test "net_2if spt" {
   skip_unless_root
 


### PR DESCRIPTION
Dear Madam or Sir,

I recently needed to use multiple network devices with virtio, and as @hannesm pointed out in #580, there was some work done by @ricarkol a while back. So this PR is an update from #377 to the current head, and tested with https://github.com/palainp/simple-fw.

After an online discussion, @reynir suggested following the naming conventions for devices in the linux ecosystem (e.g. sd[a-z] for block devices - unsure what is after sdz -, and eth[0-9] for network devices - I don't know if it's better to extend to "10" or "a" to keep a 4 letter device -). To me that seems a good solution to tackle the problem of naming and discovering the corresponding devices, currently they are assigned in the manifest order. What I'm wondering is how to deal with the mapping between manifest index and device index for blocks and networks that will be unaligned.

Best.