### PR TITLE
spt: Fix hang in solo5_yield

### DIFF
--- a/bindings/spt/net.c
+++ b/bindings/spt/net.c
@@ -107,6 +107,12 @@ void solo5_yield(solo5_time_t deadline, solo5_handle_set_t *ready_set)
         }
     };
     /*
+     * Ensure that it.it_value is always non-zero, otherwise the following
+     * epoll_wait() will hang if there are no other descriptors in the waitset
+     * due to the timer never firing. See timefd_settime(2).
+     */
+    it.it_value.tv_nsec |= 1;
+    /*
      * On spt, given that Solo5 monotonic time is identical to CLOCK_MONOTONIC,
      * we can just pass the deadline into the timerfd as an absolute timeout,
      * saving a clock_gettime() call in the process.


### PR DESCRIPTION
Same fix as in 97a66f6645499fafe77deadbce6d80c73641ea19

Calling solo5_yield(0, ...) results in  passing a struct itimerspec with an it_value of zero in both fields to timerfd_settime(), which disarms the timer, which causes the subsequent call to epoll_pwait() to hang forever if no other file descriptors (external events) have been registered with the waitset.

This addresses https://github.com/mirage/mirage-solo5/issues/97

Dune cache was interfering and this patch only worked once I disabled the dune cache.