### PR TITLE
hvt block: remove redundant check and assignment

### DIFF
--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -184,8 +184,6 @@ static int setup(struct hvt *hvt, struct mft *mft)
     for (unsigned i = 0; i != mft->entries; i++) {
         if (mft->e[i].type != MFT_DEV_BLOCK_BASIC || !mft->e[i].attached)
             continue;
-        if (mft->e[i].u.block_basic.block_size == 0)
-            mft->e[i].u.block_basic.block_size = 512;
 
         /*
          * We now set default block_size if needed, and check that the capacity


### PR DESCRIPTION
The very same condition and assignment is still present 2 just after the comment

Discovered while looking for the default sector size with @PizieDust