### PR TITLE
Don't remove the first command line token

### DIFF
--- a/bindings/virtio/platform.c
+++ b/bindings/virtio/platform.c
@@ -39,18 +39,6 @@ void platform_init(const void *arg)
         char *mi_cmdline = (char *)(uint64_t)mi->cmdline;
         size_t cmdline_len = strlen(mi_cmdline);
 
-        /*
-         * Skip the first token in the cmdline as it is an opaque "name" for
-         * the kernel coming from the bootloader.
-         */
-        for (; *mi_cmdline; mi_cmdline++, cmdline_len--) {
-            if (*mi_cmdline == ' ') {
-                mi_cmdline++;
-                cmdline_len--;
-                break;
-            }
-        }
-
         if (cmdline_len >= sizeof(cmdline)) {
             cmdline_len = sizeof(cmdline) - 1;
             log(WARN, "Solo5: warning: command line too long, truncated\n");


### PR DESCRIPTION
Dear devs,
To match the code from Xen binding (see commit 5d3a214), if virtio boots via multiboot, do not remove the first token (it is actually an argument).
Best.