### PR TITLE
Since #584 and #517, we must take into account a possible name of the executable

### DIFF
--- a/tests/test_hello/test_hello.c
+++ b/tests/test_hello/test_hello.c
@@ -40,8 +40,10 @@ int solo5_app_main(const struct solo5_start_info *si)
 
     puts("'\n");
 
-    /* "Hello_Solo5" will be passed in via the command line */
-    if (strcmp(si->cmdline, "Hello_Solo5") == 0)
+    /* "Hello_Solo5" will be passed at the end of the command line
+     * NOTE: on hvt, we only have "Hello_Solo5", on Xen and Virtio, we have the
+     * name of the executable. */
+    if (strcmp(si->cmdline + len - 11, "Hello_Solo5") == 0)
         puts("SUCCESS\n");
 
     return SOLO5_EXIT_SUCCESS;

--- a/tests/test_net/test_net.c
+++ b/tests/test_net/test_net.c
@@ -374,12 +374,25 @@ static bool ping_serve(void)
     return true;
 }
 
+int is_alpha(char chr) {
+    return ((chr >= 0x61 && chr <= 0x7a) || (chr >= 0x41 && chr <= 0x5a));
+}
+
 int solo5_app_main(const struct solo5_start_info *si)
 {
     puts("\n**** Solo5 standalone test_net ****\n\n");
 
-    if (strlen(si->cmdline) >= 1) {
-        switch (si->cmdline[0]) {
+    /* NOTE: Since #584 & #517, [cmdline] contains the name of the executable
+     * for Xen and Virtio - but it's not the case for [hvt]. We must look from
+     * the end of [cmdline] the argument given to the unikernel in any cases. */
+    size_t len = strlen(si->cmdline);
+    const char *p = si->cmdline + len - 1;
+
+    while (p != si->cmdline && is_alpha(*p)) p--;
+    if (strlen(p) >= 1 && p[0] == ' ') p++;
+
+    if (strlen(p) >= 1) {
+        switch (p[0]) {
         case 'v':
             opt_verbose = true;
             break;

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -623,7 +623,7 @@ xen_expect_abort() {
   expect_success
 }
 
-test "net_2if virtio" {
+@test "net_2if virtio" {
   [ $(id -u) -ne 0 ] && skip "Need root to run this test, for ping -f"
   [ "${CONFIG_HOST}" = "OpenBSD" ] && skip "breaks on OpenBSD due to #374"
 


### PR DESCRIPTION
Tests expect only arguments on `cmdline` which is not true anymore for Xen and Virtio according #584 & #517. This commit is a fix for tests for Xen and Virtio cases.

A double look from @palainp and @hannesm will be appreciate :+1: (and a `{sudo|doas} ./run-test.sh` too :slightly_smiling_face:).