### PR TITLE
Fetch `stdalign.h` from system on FreeBSD

### DIFF
--- a/toolchain/gen-headers.sh
+++ b/toolchain/gen-headers.sh
@@ -72,7 +72,8 @@ if CC=${CONFIG_TARGET_CC} cc_is_clang; then
         FreeBSD|OpenBSD)
             SRCDIR=/usr/include
             SRCS="float.h stddef.h stdint.h stdbool.h stdarg.h"
-            [ "${CONFIG_HOST}" = "FreeBSD" ] && SRCS="${SRCS} stdatomic.h"
+            [ "${CONFIG_HOST}" = "FreeBSD" ] && \
+                SRCS="${SRCS} stdalign.h stdatomic.h"
             DEPS="$(mktemp)"
             CC=${CONFIG_TARGET_CC} cc_get_header_deps ${SRCDIR} ${SRCS} \
                 >${DEPS} || \


### PR DESCRIPTION
This PR adds `stdalign.h` to the set of headers that must be copied over from `/usr/include` on FreeBSD because it is not included in the clang resources on that system. `stdalign.h` is used in OCaml 5.3.0 (discovered in CI for mirage/ocaml-solo5#148).