### PR TITLE
As unikraft, we increase the ringbuffer to have a better throughput on our network device

### DIFF
--- a/bindings/virtio/virtio_ring.c
+++ b/bindings/virtio/virtio_ring.c
@@ -26,7 +26,7 @@
  * There is no official max queue size. But we've seen 4096, so let's use the
  * double of that.
  */
-#define VIRTQ_MAX_QUEUE_SIZE 8192
+#define VIRTQ_MAX_QUEUE_SIZE 32768
 
 
 /*


### PR DESCRIPTION
As spotted here: https://github.com/unikraft/unikraft/blob/staging/drivers/virtio/ring/virtio_ring.c#L54. The throughput up to ~300MB/s instead of 260MB/s (/cc @shym who did some benchmarks on `hvt`).