### PR TITLE
Silence stringop-overflow warning for SSP test

### DIFF
--- a/tests/test_ssp/test_ssp.c
+++ b/tests/test_ssp/test_ssp.c
@@ -21,6 +21,12 @@
 #include "solo5.h"
 #include "../../bindings/lib.c"
 
+/*
+ * Silence GCC's (legitimate) static buffer overflow warning
+ * when smashing the stack.
+ */
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+
 static void puts(const char *s)
 {
     solo5_console_write(s, strlen(s));


### PR DESCRIPTION
Recent versions of GCC have -Wstringop-overflow=2 enabled by default, which correctly detects a buffer overflow when we volontary smash the stack during the test. Silence it.