### PR TITLE
Fix test_ssp on OpenBSD

### DIFF
--- a/tests/test_ssp/test_ssp.c
+++ b/tests/test_ssp/test_ssp.c
@@ -25,7 +25,9 @@
  * Silence GCC's (legitimate) static buffer overflow warning
  * when smashing the stack.
  */
+#if !defined(__OpenBSD__)
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 
 static void puts(const char *s)
 {


### PR DESCRIPTION
OpenBSD's `clang` doesn't know about `-Wstringop-overflow` on -current. This can be merged now. #598 