### PR TITLE
Adapt the OpenBSD hvt tender to the new vmm(4)

### DIFF
--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -185,7 +185,7 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
      * Ensure that guest-executable pages are not also executable, but are
      * readable in the host.
      */
-    host_prot = prot;
+    int host_prot = prot;
     host_prot &= ~(PROT_EXEC);
     host_prot |= PROT_READ;
     if(mprotect(vaddr_start, size, host_prot) == -1)

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -82,7 +82,6 @@ struct hvt *hvt_init(size_t mem_size)
     struct hvt_b *hvb;
     struct vm_create_params *vcp;
     struct vm_mem_range *vmr;
-    void *p;
 
     if(geteuid() != 0) {
         errno = EPERM;
@@ -121,18 +120,12 @@ struct hvt *hvt_init(size_t mem_size)
     vcp->vcp_memranges[0].vmr_size = mem_size;
 
     vmr = &vcp->vcp_memranges[0];
-    p = mmap(NULL, vmr->vmr_size, PROT_READ | PROT_WRITE,
-        MAP_PRIVATE | MAP_ANON, -1, 0);
-    if (p == MAP_FAILED)
-        err(1, "mmap");
-
-    vmr->vmr_va = (vaddr_t)p;
-    hvt->mem = p;
-    hvt->mem_size = mem_size;
 
     if (ioctl(hvb->vmd_fd, VMM_IOC_CREATE, vcp) < 0)
         err(1, "create vmm ioctl failed - exiting");
 
+    hvt->mem = (uint8_t *)vmr->vmr_va;
+    hvt->mem_size = mem_size;
     hvb->vcp_id = vcp->vcp_id;
     hvb->vcpu_id = 0; // the first and only cpu is at 0
 
@@ -175,7 +168,6 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
         int prot)
 {
     struct hvt *hvt = t_arg;
-    int host_prot, ret;
 
     assert(addr_start <= hvt->mem_size);
     assert(addr_end <= hvt->mem_size);
@@ -186,6 +178,7 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
     size_t size = addr_end - addr_start;
     assert(size > 0 && size <= hvt->mem_size);
 
+#if defined(VMM_IOC_MPROTECT_EPT)
     /*
      * Host-side page protections:
      *
@@ -198,8 +191,6 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
     if(mprotect(vaddr_start, size, host_prot) == -1)
         return -1;
 
-    ret = 0;
-#if defined(VMM_IOC_MPROTECT_EPT)
     /*
      * Guest-side page protections:
      */
@@ -223,5 +214,5 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
        err(1, "mprotect ept vmm ioctl failed - exiting");
     }
 #endif
-    return ret;
+    return 0;
 }


### PR DESCRIPTION
For now, this PR only works on -current and breaks released versions of OpenBSD. AFAICT there is no way to know at compile time if we're on -current or not, but we can check the latest released version with the `OpenBSD` macro from `<sys/param.h>`. We could wait until OpenBSD 7.8 is released to add some `#if OpenBSD >= [7.8 version number]` and support both 7.8 and earlier releases. 