### PR TITLE
hvt: fix enum/int mismatch in gdb breakpoint functions

### DIFF
--- a/tenders/hvt/hvt_gdb_kvm_aarch64.c
+++ b/tenders/hvt/hvt_gdb_kvm_aarch64.c
@@ -83,13 +83,13 @@ int hvt_gdb_read_last_signal(struct hvt *hvt, int *signal)
     return -1;
 }
 
-int hvt_gdb_add_breakpoint(struct hvt *hvt, uint32_t type,
+int hvt_gdb_add_breakpoint(struct hvt *hvt, gdb_breakpoint_type type,
                             hvt_gpa_t addr, size_t len)
 {
     return -1;
 }
 
-int hvt_gdb_remove_breakpoint(struct hvt *hvt, uint32_t type,
+int hvt_gdb_remove_breakpoint(struct hvt *hvt, gdb_breakpoint_type type,
                                hvt_gpa_t addr, size_t len)
 {
     return -1;


### PR DESCRIPTION
Newer aarch64 GCC versions enforce stricter checks and one of them (-Wenum-int-mismatch) causes a build fail for hvt.

For instance building solo5 with the following compiler will fail.
```
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

```

Example output building with the above gcc version in aarch64:
```
configure.sh: Using cc for host compiler (aarch64-linux-gnu)
configure.sh: Checking that cc works: yes
configure.sh: Using cc for target compiler (aarch64-linux-gnu)
configure.sh: Checking if ld is available: yes
configure.sh: Checking if ld is LLD: no
configure.sh: Checking if ld understands aarch64: yes
configure.sh: Checking if objcopy is available: yes
configure.sh: Checking if objcopy understands aarch64: yes
configure.sh: Checking if objcopy understands -w -G: yes
configure.sh: Using ld for target linker
configure.sh: Using objcopy for target objcopy
configure.sh: Target toolchain triple is aarch64-solo5-none-static
configure.sh: Enabled bindings: stub hvt spt.
configure.sh: Enabled tenders: hvt spt.
GEN include/version.h
MAKE elftool
MAKE tenders
MAKE toolchain
make[1]: Entering directory '/home/runner/work/urunc/urunc/solo5/elftool'
HOSTCC elftool.o
make[1]: Entering directory '/home/runner/work/urunc/urunc/solo5/tenders'
HOSTCC common/elf.o
HOSTCC common/mft.o
make[1]: Entering directory '/home/runner/work/urunc/urunc/solo5/toolchain'
SUBST bin/aarch64-solo5-none-static-cc
SUBST bin/aarch64-solo5-none-static-ld
SUBST bin/aarch64-solo5-none-static-objcopy
GEN include/aarch64-solo5-none-static
HOSTCC common/block_attach.o
make[1]: Leaving directory '/home/runner/work/urunc/urunc/solo5/toolchain'
HOSTCC common/tap_attach.o
HOSTCC hvt/hvt_boot_info.o
HOSTCC hvt/hvt_core.o
HOSTCC hvt/hvt_main.o
HOSTCC hvt/hvt_cpu_aarch64.o
MAKE bindings
make[1]: Entering directory '/home/runner/work/urunc/urunc/solo5/bindings'
CC stub/stubs.o
CC hvt/start.o
HOSTCC hvt/hvt_kvm.o
HOSTCC hvt/hvt_kvm_aarch64.o
CC cpu_aarch64.o
AS cpu_vectors_aarch64.o
CC abort.o
HOSTCC hvt/hvt_module_blk.o
CC crt.o
HOSTCC hvt/hvt_module_net.o
CC printf.o
CC intr.o
HOSTCC hvt/hvt_module_gdb.o
CC lib.o
HOSTLINK solo5-elftool
make[1]: Leaving directory '/home/runner/work/urunc/urunc/solo5/elftool'
HOSTCC hvt/hvt_module_dumpcore.o
CC mem.o
In file included from hvt/hvt_module_gdb.c:66:
hvt/hvt_gdb_kvm_aarch64.c:86:5: error: conflicting types for ‘hvt_gdb_add_breakpoint’ due to enum/integer mismatch; have ‘int(struct hvt *, uint32_t,  hvt_gpa_t,  size_t)’ {aka ‘int(struct hvt *, unsigned int,  long unsigned int,  long unsigned int)’} [-Werror=enum-int-mismatch]
   86 | int hvt_gdb_add_breakpoint(struct hvt *hvt, uint32_t type,
      |     ^~~~~~~~~~~~~~~~~~~~~~
In file included from hvt/hvt_module_gdb.c:49:
hvt/hvt.h:250:5: note: previous declaration of ‘hvt_gdb_add_breakpoint’ with type ‘int(struct hvt *, gdb_breakpoint_type,  hvt_gpa_t,  size_t)’ {aka ‘int(struct hvt *, enum _gdb_breakpoint_type,  long unsigned int,  long unsigned int)’}
  250 | int hvt_gdb_add_breakpoint(struct hvt *hvt, gdb_breakpoint_type type,
      |     ^~~~~~~~~~~~~~~~~~~~~~
hvt/hvt_gdb_kvm_aarch64.c:92:5: error: conflicting types for ‘hvt_gdb_remove_breakpoint’ due to enum/integer mismatch; have ‘int(struct hvt *, uint32_t,  hvt_gpa_t,  size_t)’ {aka ‘int(struct hvt *, unsigned int,  long unsigned int,  long unsigned int)’} [-Werror=enum-int-mismatch]
   92 | int hvt_gdb_remove_breakpoint(struct hvt *hvt, uint32_t type,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
hvt/hvt.h:258:5: note: previous declaration of ‘hvt_gdb_remove_breakpoint’ with type ‘int(struct hvt *, gdb_breakpoint_type,  hvt_gpa_t,  size_t)’ {aka ‘int(struct hvt *, enum _gdb_breakpoint_type,  long unsigned int,  long unsigned int)’}
  258 | int hvt_gdb_remove_breakpoint(struct hvt *hvt, gdb_breakpoint_type type,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
CC exit.o
HOSTCC spt/spt_main.o
HOSTCC spt/spt_core.o
cc1: all warnings being treated as errors
CC log.o
make[1]: *** [GNUmakefile:45: hvt/hvt_module_gdb.o] Error 1
make[1]: *** Waiting for unfinished jobs....
CC cmdline.o
CC tls.o
CC mft.o
CC hvt/platform.o
CC hvt/platform_intr.o
CC hvt/time.o
CC hvt/platform_lifecycle.o
make: *** [GNUmakefile:81: tenders] Error 2
CC hvt/yield.o
make: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/home/runner/work/urunc/urunc/solo5/tenders'
CC hvt/tscclock.o
CC hvt/console.o
CC hvt/net.o
CC hvt/block.o
CC spt/start.o
CC spt/bindings.o
CC spt/block.o
CC spt/net.o
CC spt/platform.o
CC spt/sys_linux_aarch64.o
LD solo5_stub.o
OBJCOPY solo5_stub.o
LD solo5_hvt.o
OBJCOPY solo5_hvt.o
LD solo5_spt.o
OBJCOPY solo5_spt.o
make[1]: Leaving directory '/home/runner/work/urunc/urunc/solo5/bindings'
```
This PR resolves the issue by updating the affected function definitions.