### PR TITLE
Implement MTU detection on Linux for hvt, spt

### DIFF
--- a/tenders/common/tap_attach.h
+++ b/tenders/common/tap_attach.h
@@ -32,7 +32,7 @@
  * Returns -1 and an appropriate errno on failure (ENOENT if the interface does
  * not exist), and the tap device file descriptor on success.
  */
-int tap_attach(const char *ifname);
+int tap_attach(const char *ifname, int *mtu);
 
 /*
  * Generate a random, locally-administered and unicast MAC address, and store it

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -114,8 +114,9 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
             warnx("Resource not declared in manifest: '%s'", name);
             return -1;
         }
-        int fd = tap_attach(iface);
-        if (fd < 0) {
+	int mtu = -1;
+        int fd = tap_attach(iface, &mtu);
+        if (fd < 0 || mtu < 0) {
             warnx("Could not attach interface: %s: %s", iface, strerror(errno));
             return -1;
         }
@@ -123,7 +124,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         /* e->u.net_basic.mac[] is set either by option or generated later by
          * setup().
          */
-        e->u.net_basic.mtu = 1500; /* TODO */
+        e->u.net_basic.mtu = mtu;
         e->b.hostfd = fd;
         e->attached = true;
         module_in_use = true;

--- a/tenders/spt/spt_module_net.c
+++ b/tenders/spt/spt_module_net.c
@@ -66,8 +66,9 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
             warnx("Resource not declared in manifest: '%s'", name);
             return -1;
         }
-        int fd = tap_attach(iface);
-        if (fd < 0) {
+        int mtu = -1;
+        int fd = tap_attach(iface, &mtu);
+        if (fd < 0 || mtu < 0) {
             warnx("Could not attach interface: %s: %s", iface, strerror(errno));
             return -1;
         }
@@ -75,7 +76,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
         /* e->u.net_basic.mac[] is set either by option or generated later by
          * setup().
          */
-        e->u.net_basic.mtu = 1500; /* TODO */
+        e->u.net_basic.mtu = mtu;
         e->b.hostfd = fd;
         e->attached = true;
         module_in_use = true;

--- a/tests/setup-tests.sh
+++ b/tests/setup-tests.sh
@@ -40,6 +40,8 @@ Linux)
     ip tuntap add tap101 mode tap
     ip addr add 10.1.0.1/24 dev tap101
     ip link set dev tap101 up
+    ip tuntap add tap102 mode tap
+    ip link set dev tap102 up mtu 9000
     ;;
 FreeBSD)
     kldload vmm

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -84,6 +84,7 @@ setup() {
   NET0_IP=10.0.0.2
   NET1=tap101
   NET1_IP=10.1.0.2
+  NET2=tap102
 }
 
 teardown() {
@@ -641,6 +642,20 @@ xen_expect_abort() {
   ( sleep 1; ${TIMEOUT} 60s ping -fq -c 50000 ${NET1_IP} ) &
   spt_run --net:service0=${NET0} --net:service1=${NET1} -- \
       test_net_2if/test_net_2if.spt limit
+  expect_success
+}
+
+@test "net_mtu hvt" {
+  skip_unless_root
+  hvt_run --net:service0=${NET2} -- test_net_mtu/test_net_mtu.hvt
+  [[ "$output" == *"MTU is 9000"* ]]
+  expect_success
+}
+
+@test "net_mtu spt" {
+  skip_unless_root
+  spt_run --net:service0=${NET2} -- test_net_mtu/test_net_mtu.spt
+  [[ "$output" == *"MTU is 9000"* ]]
   expect_success
 }
 


### PR DESCRIPTION
For the other tenders and other OSes it is still hardcoded to 1500.

This is an attempt at addressing #605.

For FreeBSD and OpenBSD I have not investigated how to detect the configured MTU.

There is no way to inform the unikernel if the MTU is adjusted on the host.