### PR TITLE
VirtIO: read (maximum) MTU if provided by host

### DIFF
--- a/bindings/virtio/virtio_net.c
+++ b/bindings/virtio/virtio_net.c
@@ -197,11 +197,10 @@ static void virtio_net_config(struct virtio_net_desc *nd,
        - 16 bit status[2]
        - 16 bit max_virtqueue_pairs[2]
        - 16 bit mtu[2]
-       So we read offset 10 and 11.
+       So we read 16 bit at offset 10.
     */
     if (host_features & VIRTIO_NET_F_MTU) {
-      nd->mtu = inb(pci->base + VIRTIO_PCI_CONFIG_OFF + 6 + 2 + 2 + 1) << 8;
-      nd->mtu = nd->mtu + inb(pci->base + VIRTIO_PCI_CONFIG_OFF + 6 + 2 + 2);
+      nd->mtu = inw(pci->base + VIRTIO_PCI_CONFIG_OFF + 6 + 2 + 2);
     } else
       nd->mtu = VIRTIO_NET_MTU;
 


### PR DESCRIPTION
Depending on the feature flag VIRTIO_NET_F_MTU, if provided by the host, we can read their maximum MTU and use it. Otherwise we use 1500 as our default.

See #606 #605 

The way I tested this (on FreeBSD/BHyve):
```
--- a/scripts/virtio-run/solo5-virtio-run.sh
+++ b/scripts/virtio-run/solo5-virtio-run.sh
@@ -107,7 +107,7 @@ bhyve_add_device ()
         hv_addargs -s ${PCI_SLOT}:0,virtio-blk,"${NAME}"
         ;;
     NET)
-        hv_addargs -s ${PCI_SLOT}:0,virtio-net,"${NAME}"
+        hv_addargs -s ${PCI_SLOT}:0,virtio-net,"${NAME},mtu=1234"
         ;;
     *)
         die "Unknown device type"
```

And I'm sure your recent qemu also has the host-mtu option.