### PR TITLE
hvt_module_net: do not return EAGAIN on a read of 0 bytes

### DIFF
--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -75,8 +75,7 @@ static void hypercall_net_read(struct hvt *hvt, hvt_gpa_t gpa)
     int ret;
 
     ret = read(e->b.hostfd, HVT_CHECKED_GPA_P(hvt, rd->data, rd->len), rd->len);
-    if ((ret == 0) ||
-        (ret == -1 && errno == EAGAIN)) {
+    if (ret == -1 && errno == EAGAIN) {
         rd->ret = SOLO5_R_AGAIN;
         return;
     }


### PR DESCRIPTION
fixes #559 //cc @reynir 