### PR TITLE
Define a `.note.GNU-stack` in assembler files when needed

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -76,7 +76,7 @@ endif
 %.o: %.c %.d
 	$(COMPILE.c)
 
-%.o: %.S %.d
+%.o: %.S %.d noexecstack.h
 	$(COMPILE.S)
 
 %.d: ;
@@ -170,6 +170,18 @@ solo5_xen.o: $(xen_OBJS)
 
 CPPFLAGS+=-D__XEN_INTERFACE_VERSION__=__XEN_LATEST_INTERFACE_VERSION__
 endif
+
+noexecstack.c:
+	@echo GEN noexecstack.c
+	printf 'int f() {\n  return 0;\n}\n' > $@
+
+noexecstack.s: noexecstack.c
+	@echo GEN noexecstack.s
+	$(CC) $(CFLAGS) $(CPPFLAGS) -S $< -o $@
+
+noexecstack.h: noexecstack.s
+	@echo GEN noexecstack.h
+	grep -F .note.GNU-stack $< > $@ || true
 
 all: $(all_TARGETS)
 

--- a/bindings/cpu_vectors_aarch64.S
+++ b/bindings/cpu_vectors_aarch64.S
@@ -203,3 +203,5 @@ ENTRY(cpu_exception_vectors)
     EXCEPTION_ENTRY cpu_el0_fiq_invalid         // FIQ 32-bit EL0
     EXCEPTION_ENTRY cpu_el0_error_invalid       // Error 32-bit EL0
 END(cpu_exception_vectors)
+
+#include "noexecstack.h"

--- a/bindings/cpu_vectors_x86_64.S
+++ b/bindings/cpu_vectors_x86_64.S
@@ -120,3 +120,5 @@ IRQ_ENTRY 12
 IRQ_ENTRY 13
 IRQ_ENTRY 14
 IRQ_ENTRY 15
+
+#include "noexecstack.h"

--- a/bindings/virtio/boot.S
+++ b/bindings/virtio/boot.S
@@ -28,6 +28,7 @@
 
 #include "multiboot.h"
 #include "../cpu_x86_64.h"
+#include "../noexecstack.h"
 
 #define ENTRY(x) .text; .globl x; .type x,%function; x:
 #define END(x)   .size x, . - x

--- a/bindings/xen/boot.S
+++ b/bindings/xen/boot.S
@@ -18,6 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "../noexecstack.h"
 #include "../cpu_x86_64.h"
 #include "xen/elfnote.h"
 #include "../virtio/multiboot.h"

--- a/bindings/xen/hypercall_page.S
+++ b/bindings/xen/hypercall_page.S
@@ -132,3 +132,5 @@ DECLARE_HYPERCALL(arch_4)
 DECLARE_HYPERCALL(arch_5)
 DECLARE_HYPERCALL(arch_6)
 DECLARE_HYPERCALL(arch_7)
+
+#include "../noexecstack.h"


### PR DESCRIPTION
Follow what the C compiler does and add the same `.note.GNU-stack` section in assembler files as the C compiler.

This silences the warnings such as:

```
ld: warning: cpu_vectors_x86_64.o: missing .note.GNU-stack section implies executable stack
```

I checked that this indeed makes unikernel builds silent in that [run](https://github.com/shym/ocaml-solo5/actions/runs/18754758959/job/53503673443#step:6:17) of OCaml/Solo5 CI.