### PR TITLE
Remove always-true asserts

### DIFF
--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -111,7 +111,6 @@ static void usage(const char *prog)
     fprintf(stderr, "    --version (display version information)\n");
     fprintf(stderr, "Compiled-in modules: ");
     for (struct hvt_module *m = &__start_modules; m < &__stop_modules; m++) {
-        assert(m->name);
         fprintf(stderr, "%s ", m->name);
     }
     fprintf(stderr, "\n");

--- a/tenders/spt/spt_main.c
+++ b/tenders/spt/spt_main.c
@@ -104,7 +104,6 @@ static void usage(const char *prog)
     fprintf(stderr, "    --help (display this help)\n");
     fprintf(stderr, "Compiled-in modules: ");
     for (struct spt_module *m = &__start_modules; m < &__stop_modules; m++) {
-        assert(m->name);
         fprintf(stderr, "%s ", m->name);
     }
     fprintf(stderr, "\n");


### PR DESCRIPTION
Trying to build this repo (outside of opam) with GCC 15.2.1 (20260209) correctly reports that:
```
hvt/hvt_main.c:114:9: error: the comparison will always evaluate as ‘true’ for the address of ‘name’ will never be NULL [-Werror=address]
  114 |         assert(m->name);
      |         ^~~~~~
In file included from hvt/hvt_main.c:39:
hvt/hvt.h:180:16: note: ‘name’ declared here
  180 |     const char name[32];
      |                ^~~~
```
This PR removes that assert (and its equivalent in `spt`)