### PR TITLE
Add -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -30,7 +30,7 @@ include $(TOPDIR)/Makeconf
 # target.
 #
 CC := __V=$(V) $(TOPDIR)/toolchain/bin/$(CONFIG_TARGET_TRIPLE)-cc
-CFLAGS := -std=c11 -Wall -Wextra -Werror -O2 -g
+CFLAGS := -std=c11 -Wall -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -Wwrite-strings -Wextra -Werror -O2 -g
 CPPFLAGS :=
 LD := __V=$(V) $(TOPDIR)/toolchain/bin/$(CONFIG_TARGET_TRIPLE)-ld
 LDFLAGS :=
@@ -56,7 +56,7 @@ endef
 # artifacts built to run on the (Solo5 tender's) *host*.
 #
 HOSTCC := $(CONFIG_HOST_CC)
-HOSTCFLAGS := -fstack-protector-strong -Wall -Werror -std=c11 -O2 -g
+HOSTCFLAGS := -fstack-protector-strong -Wall -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -Wwrite-strings -Werror -std=c11 -O2 -g
 HOSTCPPFLAGS := -I$(TOPDIR)/include
 HOSTLDFLAGS :=
 HOSTLDLIBS :=

--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -119,7 +119,7 @@ void platform_intr_mask_irq(unsigned irq);
 void platform_intr_ack_irq(unsigned irq);
 
 /* cmdline.c: command line parsing */
-char *cmdline_parse(const char *cmdline);
+const char *cmdline_parse(const char *cmdline);
 
 /* log.c: */
 typedef enum {
@@ -142,7 +142,7 @@ void log_set_level(log_level_t level);
  */
 static inline bool atomic_sync_bts(int nr, volatile void *bits)
 {
-    uint8_t *byte = ((uint8_t *)bits) + (nr >> 3);
+    volatile uint8_t *byte = ((volatile uint8_t *)bits) + (nr >> 3);
     uint8_t bit = 1 << (nr & 7);
     uint8_t orig;
 
@@ -155,7 +155,7 @@ static inline bool atomic_sync_bts(int nr, volatile void *bits)
  */
 static inline bool atomic_sync_btc(int nr, volatile void *bits)
 {
-    uint8_t *byte = ((uint8_t *)bits) + (nr >> 3);
+    volatile uint8_t *byte = ((volatile uint8_t *)bits) + (nr >> 3);
     uint8_t bit = 1 << (nr & 7);
     uint8_t orig;
 
@@ -168,7 +168,7 @@ static inline bool atomic_sync_btc(int nr, volatile void *bits)
  */
 static inline bool sync_bt(int nr, const volatile void *bits)
 {
-    const uint8_t *byte = ((uint8_t *)bits) + (nr >> 3);
+    const volatile uint8_t *byte = ((const volatile uint8_t *)bits) + (nr >> 3);
     uint8_t bit = 1 << (nr & 7);
     uint8_t result;
 

--- a/bindings/cmdline.c
+++ b/bindings/cmdline.c
@@ -19,7 +19,7 @@
  */
 #include "bindings.h"
 
-char *cmdline_parse(const char *cmdline)
+const char *cmdline_parse(const char *cmdline)
 {
     const char opt_quiet[] = "--solo5:quiet";
     const char opt_error[] = "--solo5:error";
@@ -29,7 +29,7 @@ char *cmdline_parse(const char *cmdline)
 
     const char *p = cmdline;
     bool matched;
-    char *after;
+    const char *after;
 
     while (*p && isspace(*p))
         p++;
@@ -41,7 +41,7 @@ char *cmdline_parse(const char *cmdline)
                 strncmp(p, opt_error, (sizeof(opt_error) - 1)) == 0) {
             _Static_assert(sizeof(opt_quiet) == sizeof(opt_error),
                     "sizeof(--solo5:quiet) != sizeof(--solo5:error");
-            after = (char *) (p + (sizeof(opt_quiet) - 1));
+            after = (const char *) (p + (sizeof(opt_quiet) - 1));
             if (isspace(*after) || *after == '\0') {
                 log_set_level(ERROR);
                 p += (sizeof(opt_quiet) - 1);
@@ -49,7 +49,7 @@ char *cmdline_parse(const char *cmdline)
             }
         }
         else if (strncmp(p, opt_warn, (sizeof(opt_warn) - 1)) == 0) {
-            after = (char *) (p + (sizeof(opt_warn) - 1));
+            after = (const char *) (p + (sizeof(opt_warn) - 1));
             if (isspace(*after) || *after == '\0') {
                 log_set_level(WARN);
                 p += (sizeof(opt_warn) - 1);
@@ -57,7 +57,7 @@ char *cmdline_parse(const char *cmdline)
             }
         }
         else if (strncmp(p, opt_info, (sizeof(opt_info) - 1)) == 0) {
-            after = (char *) (p + (sizeof(opt_info) - 1));
+            after = (const char *) (p + (sizeof(opt_info) - 1));
             if (isspace(*after) || *after == '\0') {
                 log_set_level(INFO);
                 p += (sizeof(opt_info) - 1);
@@ -65,7 +65,7 @@ char *cmdline_parse(const char *cmdline)
             }
         }
         else if (strncmp(p, opt_debug, (sizeof(opt_debug) - 1)) == 0) {
-            after = (char *) (p + (sizeof(opt_debug) - 1));
+            after = (const char *) (p + (sizeof(opt_debug) - 1));
             if (isspace(*after) || *after == '\0') {
                 log_set_level(DEBUG);
                 p += (sizeof(opt_debug) - 1);
@@ -81,5 +81,5 @@ char *cmdline_parse(const char *cmdline)
         }
     }
 
-    return (char *) p;
+    return (const char *) p;
 }

--- a/bindings/cpu_x86_64.c
+++ b/bindings/cpu_x86_64.c
@@ -165,7 +165,7 @@ void cpu_init(void)
     idt_init();
 }
 
-static char *traps[32] = {
+static const char *traps[32] = {
     "#DE", "#DB", "#NMI", "#BP", "#OF", "#BR", "#UD", "#NM", "#DF", "#9", "#TS",
     "#NP", "#SS", "#GP", "#PF", "#15", "#MF", "#AC", "#MC", "#XM", "#VE", "#21",
     "#22", "#23", "#24", "#25", "#26", "#27", "#28", "#29", "#30", "#31"

--- a/bindings/hvt/console.c
+++ b/bindings/hvt/console.c
@@ -24,7 +24,7 @@ int platform_puts(const char *buf, int n)
 {
     struct hvt_hc_puts str;
 
-    str.data = (char *)buf;
+    str.data = (const char *)buf;
     str.len = n;
 
     hvt_do_hypercall(HVT_HYPERCALL_PUTS, &str);

--- a/bindings/lib.c
+++ b/bindings/lib.c
@@ -93,7 +93,7 @@ void *memmove(void *dest, const void *src, size_t n)
                 if (!n--) return dest;
                 *d++ = *s++;
             }
-            for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(WT *)s;
+            for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(const WT *)s;
         }
         for (; n; n--) *d++ = *s++;
     } else {
@@ -102,7 +102,7 @@ void *memmove(void *dest, const void *src, size_t n)
                 if (!n--) return dest;
                 d[n] = s[n];
             }
-            while (n>=WS) n-=WS, *(WT *)(d+n) = *(WT *)(s+n);
+            while (n>=WS) n-=WS, *(WT *)(d+n) = *(const WT *)(s+n);
         }
         while (n) n--, d[n] = s[n];
     }
@@ -120,7 +120,7 @@ int memcmp(const void *vl, const void *vr, size_t n)
 int strcmp(const char *l, const char *r)
 {
     for (; *l==*r && *l; l++, r++);
-    return *(unsigned char *)l - *(unsigned char *)r;
+    return *(const unsigned char *)l - *(const unsigned char *)r;
 }
 
 char *strcpy(char *restrict dest, const char *restrict src)
@@ -154,7 +154,7 @@ int isspace(int c)
 
 int strncmp(const char *_l, const char *_r, size_t n)
 {
-    const unsigned char *l=(void *)_l, *r=(void *)_r;
+    const unsigned char *l=(const void *)_l, *r=(const void *)_r;
     if (!n--) return 0;
     for (; *l && *r && n && *l == *r ; l++, r++, n--);
     return *l - *r;

--- a/bindings/virtio/platform.c
+++ b/bindings/virtio/platform.c
@@ -33,7 +33,7 @@ void platform_init(const void *arg)
      * The multiboot structures may be anywhere in memory, so take a copy of
      * the command line before we initialise memory allocation.
      */
-    const struct multiboot_info *mi = (struct multiboot_info *)arg;
+    const struct multiboot_info *mi = (const struct multiboot_info *)arg;
 
     if (mi->flags & MULTIBOOT_INFO_CMDLINE) {
         char *mi_cmdline = (char *)(uint64_t)mi->cmdline;

--- a/bindings/virtio/start.c
+++ b/bindings/virtio/start.c
@@ -54,14 +54,14 @@ extern const struct mft1_note __solo5_mft1_note;
  * Will be initialised at start-up, and used by bindings to access (and
  * modify!) the in-built manifest.
  */
-struct mft *virtio_manifest = NULL;
+const struct mft *virtio_manifest = NULL;
 
 /* Will abort the program if any of the devices is not acquired. */
 static void mft_check_all_acquired()
 {
     bool fail = false;
     for (unsigned i = 0; i != virtio_manifest->entries; i++) {
-        if (!virtio_manifest->e[i].attached) {
+        if (i > 0 && !virtio_manifest->e[i].attached) {
             log(WARN, "Solo5: Device '%s' of type %s not attached.",
                     virtio_manifest->e[i].name, mft_type_to_string(virtio_manifest->e[i].type));
             fail = true;
@@ -89,9 +89,9 @@ static void _start2(void *arg __attribute__((unused)))
      * Get the built-in manifest out of the ELF NOTE and validate it.
      * Once validated, it is available for access globally by the bindings.
      */
-    struct mft *mft;
+    const struct mft *mft;
     size_t mft_size;
-    mft_get_builtin_mft1_unconst(&__solo5_mft1_note, &mft, &mft_size);
+    mft_get_builtin_mft1(&__solo5_mft1_note, &mft, &mft_size);
     if (mft_validate(mft, mft_size) != 0) {
         log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
         solo5_abort();
@@ -102,12 +102,11 @@ static void _start2(void *arg __attribute__((unused)))
      * Attach the first entry if its type is really MFT_RESERVED_FIRST.
      * Abort otherwise.
      */
-    struct mft_entry *e = mft_get_by_index(virtio_manifest, 0, MFT_RESERVED_FIRST);
+    const struct mft_entry *e = mft_get_by_index(virtio_manifest, 0, MFT_RESERVED_FIRST);
     if (e == NULL) {
         log(ERROR, "Solo5: first entry in manifest is not of type MFT_RESERVED_FIRST\n");
         solo5_abort();
     }
-    e->attached = true;
 
     mem_init();
     time_init();

--- a/bindings/virtio/virtio_blk.c
+++ b/bindings/virtio/virtio_blk.c
@@ -277,8 +277,11 @@ solo5_result_t solo5_block_write(solo5_handle_t h, solo5_off_t offset,
      * implementation which does a memcpy() on VIRTIO_BLK_T_OUT, however the
      * internal interfaces should be refactored to reflect this.
      */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
     int rv = virtio_blk_op_sync(bd, VIRTIO_BLK_T_OUT, sector,
         (uint8_t *)buf, size);
+#pragma GCC diagnostic pop
     return (rv == 0) ? SOLO5_R_OK : SOLO5_R_EUNSPEC;
 }
 

--- a/bindings/xen/platform.c
+++ b/bindings/xen/platform.c
@@ -234,7 +234,7 @@ static void parse_multiboot(const void *arg)
      * The multiboot structures may be anywhere in memory, so take a copy of
      * the command line before we initialise memory allocation.
      */
-    const struct multiboot_info *mi = (struct multiboot_info *)arg;
+    const struct multiboot_info *mi = (const struct multiboot_info *)arg;
 
     if (mi->flags & MULTIBOOT_INFO_CMDLINE) {
         char *mi_cmdline = (char *)(uint64_t)mi->cmdline;
@@ -256,7 +256,7 @@ static void parse_hvm_start_info(const void *arg)
      * The Xen hvm_start_info may be anywhere in memory, so take a copy of
      * the command line before we initialise memory allocation.
      */
-    const struct hvm_start_info *si = (struct hvm_start_info *)arg;
+    const struct hvm_start_info *si = (const struct hvm_start_info *)arg;
     if (si->cmdline_paddr) {
         char *hvm_cmdline = (char *)si->cmdline_paddr;
         size_t cmdline_len = strlen(hvm_cmdline);
@@ -276,7 +276,7 @@ void platform_init(const void *arg)
 {
     bool is_direct_pvh_boot;
 
-    if (*((uint32_t*)arg) == XEN_HVM_START_MAGIC_VALUE)
+    if (*((const uint32_t*)arg) == XEN_HVM_START_MAGIC_VALUE)
         is_direct_pvh_boot = true;
     else
         is_direct_pvh_boot = false;

--- a/bindings/xen/start.c
+++ b/bindings/xen/start.c
@@ -44,7 +44,7 @@ extern const struct mft1_note __solo5_mft1_note;
  * Will be initialised at start-up, and used by bindings to access (and
  * modify!) the in-built manifest.
  */
-struct mft *xen_manifest = NULL;
+const struct mft *xen_manifest = NULL;
 
 static void _start2(void *arg __attribute__((unused)))
 {
@@ -62,9 +62,9 @@ static void _start2(void *arg __attribute__((unused)))
      * Get the built-in manifest out of the ELF NOTE and validate it.
      * Once validated, it is available for access globally by the bindings.
      */
-    struct mft *mft;
+    const struct mft *mft;
     size_t mft_size;
-    mft_get_builtin_mft1_unconst(&__solo5_mft1_note, &mft, &mft_size);
+    mft_get_builtin_mft1(&__solo5_mft1_note, &mft, &mft_size);
     if (mft_validate(mft, mft_size) != 0) {
         log(ERROR, "Solo5: Built-in manifest validation failed. Aborting.\n");
         solo5_abort();

--- a/tenders/common/elf.c
+++ b/tenders/common/elf.c
@@ -253,7 +253,7 @@ void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
               " elf", bin_name, nbytes);
         goto mem_cleanup;
     }
-    if (nbytes != ph_size) {
+    if ((size_t)nbytes != ph_size) {
         warnx("%s: %s: program header does not match the expected size"
               " (%zu != %zu while loading elf)", bin_name, INV_EXE, nbytes,
               ph_size);
@@ -418,7 +418,7 @@ void elf_load(int bin_fd, const char *bin_name, uint8_t *mem, size_t mem_size,
                   nbytes);
             goto mem_cleanup;
         }
-        if (nbytes != p_filesz) {
+        if ((size_t)nbytes != p_filesz) {
             warnx("%s: phdr[%u] host file segment mismatched (pread_in_full"
                   " returned %zu != %llu (p_filesz))", bin_name, ph_i, nbytes,
                   (unsigned long long)p_filesz);
@@ -522,7 +522,7 @@ int elf_load_note(int bin_fd, const char *bin_name, uint32_t note_type,
               " note", bin_name, nbytes);
         goto mem_cleanup;
     }
-    if (nbytes != ph_size) {
+    if ((size_t)nbytes != ph_size) {
         warnx("%s: %s: program header does not match the expected size"
               " (%zu != %zu while loading note)", bin_name, INV_EXE, nbytes,
               ph_size);
@@ -640,7 +640,7 @@ int elf_load_note(int bin_fd, const char *bin_name, uint32_t note_type,
               bin_name, ph_i, nbytes);
         goto mem_cleanup;
     }
-    if (nbytes != note_size) {
+    if ((size_t)nbytes != note_size) {
         warnx("%s: phdr[%u] bytes read mismatches note size (%zu != %zu)",
               bin_name, ph_i, nbytes, note_size);
         goto mem_cleanup;

--- a/tenders/common/mft.c
+++ b/tenders/common/mft.c
@@ -83,18 +83,6 @@ int mft_validate(const struct mft *mft, size_t mft_size)
     return 0;
 }
 
-void mft_get_builtin_mft1_unconst(const struct mft1_note *note,
-        struct mft **out_mft, size_t *out_mft_size)
-{
-    /*
-     * Get the built-in manifest out of the ELF NOTE. Note that the size must
-     * be adjusted from n_descsz to remove any internal alignment.
-     */
-    *out_mft = (struct mft *)&note->m;
-    *out_mft_size = note->h.n_descsz -
-        (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
-}
-
 void mft_get_builtin_mft1(const struct mft1_note *note,
         const struct mft **out_mft, size_t *out_mft_size)
 {
@@ -107,7 +95,7 @@ void mft_get_builtin_mft1(const struct mft1_note *note,
         (offsetof(struct mft1_note, m) - sizeof (struct mft1_nhdr));
 }
 
-struct mft_entry *mft_get_by_name(const struct mft *mft, const char *name,
+struct mft_entry *_mft_get_by_name(const struct mft *mft, const char *name,
         mft_type_t type, unsigned *index)
 {
     for (unsigned i = 0; i != mft->entries; i++) {
@@ -115,20 +103,20 @@ struct mft_entry *mft_get_by_name(const struct mft *mft, const char *name,
                 && strncmp(mft->e[i].name, name, MFT_NAME_SIZE) == 0) {
             if (index != NULL)
                 *index = i;
-            return (struct mft_entry *)&mft->e[i];
+            return (struct mft_entry *)(uintptr_t)&mft->e[i];
         }
     }
     return NULL;
 }
 
-struct mft_entry *mft_get_by_index(const struct mft *mft, unsigned index,
+struct mft_entry *_mft_get_by_index(const struct mft *mft, unsigned index,
         mft_type_t type)
 {
     if (index >= mft->entries)
         return NULL;
-    else if (mft->e[index].type == type)
-        return (struct mft_entry *)&mft->e[index];
-    else
+    else if (mft->e[index].type == type) {
+        return (struct mft_entry *)(uintptr_t)&mft->e[index];
+    } else
         return NULL;
 }
 

--- a/tenders/common/mft.h
+++ b/tenders/common/mft.h
@@ -39,6 +39,14 @@
  */
 int mft_validate(const struct mft *mft, size_t mft_size);
 
+/* If PTR is a pointer to const, return CALL cast to type CTYPE,
+ * otherwise return CALL.  Pointers to types with non-const qualifiers
+ * are not valid.
+ *
+ * NOTE(dinosaure): for more details, see:
+ * - https://inbox.sourceware.org/libc-alpha/mvm5x8wpsmi.fsf@suse.de/T/
+ * - and https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2973.pdf
+ */
 #define __const_generic(PTR, CTYPE, CALL) \
   _Generic (0 ? (PTR) : (void *) 1,       \
       const void *: (CTYPE) (CALL),       \

--- a/tenders/common/mft.h
+++ b/tenders/common/mft.h
@@ -39,6 +39,11 @@
  */
 int mft_validate(const struct mft *mft, size_t mft_size);
 
+#define __const_generic(PTR, CTYPE, CALL) \
+  _Generic (0 ? (PTR) : (void *) 1,       \
+      const void *: (CTYPE) (CALL),       \
+      void *: (CALL))
+
 /*
  * Given the address of a MFT1 ELF note at (note), returns the address of the
  * embedded struct mft in (*out_mft) and its expected size in (*out_size).
@@ -50,8 +55,6 @@ int mft_validate(const struct mft *mft, size_t mft_size);
  * The two versions of this function provided differ only in the const-ness of
  * the returned (*out_mft).
  */
-void mft_get_builtin_mft1_unconst(const struct mft1_note *note,
-        struct mft **out_mft, size_t *out_mft_size);
 void mft_get_builtin_mft1(const struct mft1_note *note,
         const struct mft **out_mft, size_t *out_mft_size);
 
@@ -60,16 +63,22 @@ void mft_get_builtin_mft1(const struct mft1_note *note,
  * found. If found, the array index of the manifest entry will be stored in
  * (*index).
  */
-struct mft_entry *mft_get_by_name(const struct mft *mft, const char *name,
+struct mft_entry *_mft_get_by_name(const struct mft *mft, const char *name,
         mft_type_t type, unsigned *index);
+
+#define mft_get_by_name(X, N, T, I) \
+  __const_generic(X, const struct mft_entry *, _mft_get_by_name(X, N, T, I))
 
 /*
  * Return the manifest entry at (index), of type (type), or NULL if the entry
  * at (index) is not of type (type).
  */
 
-struct mft_entry *mft_get_by_index(const struct mft *mft, unsigned index,
+struct mft_entry *_mft_get_by_index(const struct mft *mft, unsigned index,
         mft_type_t type);
+
+#define mft_get_by_index(X, I, T) \
+  __const_generic(X, const struct mft_entry *, _mft_get_by_index(X, I, T))
 
 /*
  * Return a string representation of (type).

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -173,7 +173,7 @@ extern hvt_vmexit_fn_t hvt_core_vmexits[];
 struct hvt_module_ops {
     int (*setup)(struct hvt *hvt, struct mft *mft);
     int (*handle_cmdarg)(char *cmdarg, struct mft *mft);
-    char *(*usage)(void);
+    const char *(*usage)(void);
 };
 
 struct hvt_module {

--- a/tenders/hvt/hvt_module_blk.c
+++ b/tenders/hvt/hvt_module_blk.c
@@ -48,7 +48,7 @@ static void hypercall_block_write(struct hvt *hvt, hvt_gpa_t gpa)
 {
     struct hvt_hc_block_write *wr =
         HVT_CHECKED_GPA_P(hvt, gpa, sizeof (struct hvt_hc_block_write));
-    struct mft_entry *e = mft_get_by_index(host_mft, wr->handle,
+    const struct mft_entry *e = mft_get_by_index(host_mft, wr->handle,
             MFT_DEV_BLOCK_BASIC);
     if (e == NULL) {
         wr->ret = SOLO5_R_EINVAL;
@@ -64,18 +64,18 @@ static void hypercall_block_write(struct hvt *hvt, hvt_gpa_t gpa)
     }
     pos = wr->offset;
     if (add_overflow(pos, wr->len, end)
-            || (end > e->u.block_basic.capacity)) {
+            || (end > (off_t) e->u.block_basic.capacity)) {
         wr->ret = SOLO5_R_EINVAL;
         return;
     }
 
     ret = pwrite(e->b.hostfd, HVT_CHECKED_GPA_P(hvt, wr->data, wr->len),
             wr->len, pos);
-    if (ret != wr->len) {
-        if (ret == -1)
-            fprintf(stderr, "Fatal error when writing: %s\n", strerror(errno));
-        else
-            fprintf(stderr, "Fatal error: wrote only %ld out of %ld bytes\n",
+    if (ret == -1) {
+        fprintf(stderr, "Fatal error when writing: %s\n", strerror(errno));
+        exit(1);
+    } else if ((size_t) ret != wr->len) {
+        fprintf(stderr, "Fatal error: wrote only %ld out of %ld bytes\n",
                 ret, wr->len);
         exit(1);
     }
@@ -86,7 +86,7 @@ static void hypercall_block_read(struct hvt *hvt, hvt_gpa_t gpa)
 {
     struct hvt_hc_block_read *rd =
         HVT_CHECKED_GPA_P(hvt, gpa, sizeof (struct hvt_hc_block_read));
-    struct mft_entry *e = mft_get_by_index(host_mft, rd->handle,
+    const struct mft_entry *e = mft_get_by_index(host_mft, rd->handle,
             MFT_DEV_BLOCK_BASIC);
     if (e == NULL) {
         rd->ret = SOLO5_R_EINVAL;
@@ -102,18 +102,18 @@ static void hypercall_block_read(struct hvt *hvt, hvt_gpa_t gpa)
     }
     pos = rd->offset;
     if (add_overflow(pos, rd->len, end)
-            || (end > e->u.block_basic.capacity)) {
+            || (end > (off_t) e->u.block_basic.capacity)) {
         rd->ret = SOLO5_R_EINVAL;
         return;
     }
 
     ret = pread(e->b.hostfd, HVT_CHECKED_GPA_P(hvt, rd->data, rd->len), rd->len,
             pos);
-    if (ret != rd->len) {
-        if (ret == -1)
-            fprintf(stderr, "Fatal error when reading: %s\n", strerror(errno));
-        else
-            fprintf(stderr, "Fatal error: read only %ld out of %ld bytes\n",
+    if (ret == -1) {
+        fprintf(stderr, "Fatal error when reading: %s\n", strerror(errno));
+        exit(1);
+    } else if ((size_t) ret != rd->len) {
+        fprintf(stderr, "Fatal error: read only %ld out of %ld bytes\n",
                 ret, rd->len);
         exit(1);
     }
@@ -229,7 +229,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
     return 0;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)\n"
 	"  [ --block-sector-size:NAME=SECTORSIZE ] (set sector size for block device NAME; must be a power of two greater than or equal 512)";

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -154,14 +154,14 @@ void hvt_dumpcore_hook(struct hvt *hvt, int status, void *cookie)
         .n_descsz = hvt_dumpcore_prstatus_size(),
     };
 
-    struct iovec iov[] = {
+    const struct iovec iov[] = {
         { .iov_base = &ehdr, .iov_len = sizeof ehdr },
         { .iov_base = &pnote, .iov_len = sizeof pnote },
         { .iov_base = &pload, .iov_len = sizeof pload },
         { .iov_base = &nhdr, .iov_len = sizeof nhdr },
-        { .iov_base = (void *)name, .iov_len = nhdr.n_namesz }
+        { .iov_base = (void *)(uintptr_t)name, .iov_len = nhdr.n_namesz }
     };
-    size_t iovlen = sizeof ehdr + sizeof pnote + sizeof pload + sizeof nhdr \
+    ssize_t iovlen = sizeof ehdr + sizeof pnote + sizeof pload + sizeof nhdr \
                     + nhdr.n_namesz;
     if (writev(fd, iov, 5) != iovlen) {
         warn("dumpcore: Error writing ELF headers");
@@ -240,7 +240,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
     return 0;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--dumpcore=DIR (enable guest core dump on abort/trap)";
 }

--- a/tenders/hvt/hvt_module_gdb.c
+++ b/tenders/hvt/hvt_module_gdb.c
@@ -306,7 +306,7 @@ retry:
  * Send packet of the form $<packet info>#<checksum> without waiting for an ACK
  * from the debugger. Only send_response
  */
-static void send_packet_no_ack(char *buffer)
+static void send_packet_no_ack(const char *buffer)
 {
     unsigned char checksum;
     int count;
@@ -340,7 +340,7 @@ static void send_packet_no_ack(char *buffer)
  * Send a packet and wait for a successful ACK of '+' from the debugger.
  * An ACK of '-' means that we have to resend.
  */
-static void send_packet(char *buffer)
+static void send_packet(const char *buffer)
 {
     char ch;
 
@@ -662,7 +662,7 @@ static int handle_cmdarg(char *cmdarg, struct mft *mft)
     return -1;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--gdb (optional flag for running in a gdb debug session)\n"
         "  [ --gdb-port=1234 ] (port to use) ";

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -58,11 +58,11 @@ static void hypercall_net_write(struct hvt *hvt, hvt_gpa_t gpa)
 
     ret = write(e->b.hostfd, HVT_CHECKED_GPA_P(hvt, wr->data, wr->len),
             wr->len);
-    if (ret != wr->len) {
-        if (ret == -1)
-            fprintf(stderr, "Fatal error when writing: %s\n", strerror(errno));
-        else
-            fprintf(stderr, "Fatal error: wrote only %ld out of %ld bytes\n",
+    if (ret == -1) {
+        fprintf(stderr, "Fatal error when writing: %s\n", strerror(errno));
+        exit(1);
+    } else if ((size_t) ret != wr->len) {
+        fprintf(stderr, "Fatal error: wrote only %ld out of %ld bytes\n",
                 ret, wr->len);
         exit(1);
     }
@@ -195,7 +195,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
     return 0;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--net:NAME=IFACE | @NN (attach tap at IFACE or at fd @NN as network NAME)\n"
         "  [ --net-mac:NAME=HWADDR ] (set HWADDR for network NAME)";

--- a/tenders/hvt/hvt_openbsd.h
+++ b/tenders/hvt/hvt_openbsd.h
@@ -30,8 +30,8 @@
 
 struct hvt_b {
     int      vmd_fd;
-    uint32_t vcp_id;
-    uint32_t vcpu_id;
+    int32_t  vcp_id;
+    int32_t  vcpu_id;
 };
 
 #endif /* HVT_HV_OPENBSD_H */

--- a/tenders/spt/spt.h
+++ b/tenders/spt/spt.h
@@ -60,7 +60,7 @@ void spt_run(struct spt *spt, uint64_t p_entry);
 struct spt_module_ops {
     int (*setup)(struct spt *spt, struct mft *mft);
     int (*handle_cmdarg)(char *cmdarg, struct mft *mft);
-    char *(*usage)(void);
+    const char *(*usage)(void);
 };
 
 struct spt_module {

--- a/tenders/spt/spt_core.c
+++ b/tenders/spt/spt_core.c
@@ -355,7 +355,7 @@ static int setup(struct spt *spt, struct mft *mft)
     return 0;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--x-exec-heap (make the heap executable)."
            " WARNING: This option is dangerous and not recommended as it"

--- a/tenders/spt/spt_module_block.c
+++ b/tenders/spt/spt_module_block.c
@@ -164,7 +164,7 @@ static int setup(struct spt *spt, struct mft *mft)
     return 0;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--block:NAME=PATH (attach block device/file at PATH as block storage NAME)\n"
 	"  [ --block-sector-size:NAME=SECTORSIZE ] (set sector size for block device NAME; must be a power of two greater than or equal 512)";

--- a/tenders/spt/spt_module_net.c
+++ b/tenders/spt/spt_module_net.c
@@ -143,7 +143,7 @@ static int setup(struct spt *spt, struct mft *mft)
     return 0;
 }
 
-static char *usage(void)
+static const char *usage(void)
 {
     return "--net:NAME=IFACE | @NN (attach tap at IFACE or at fd @NN as network NAME)\n"
         "  [ --net-mac:NAME=HWADDR ] (set HWADDR for network NAME)";

--- a/tests/test_buggyelf/GNUmakefile
+++ b/tests/test_buggyelf/GNUmakefile
@@ -20,5 +20,6 @@ test_NAME := test_buggyelf
 
 # Nothing to build here, the buggy ELF file has been crafted using fuzzing
 
-.PHONY: all
+.PHONY: all clean
 all:
+clean:

--- a/tests/test_output/test_output.c
+++ b/tests/test_output/test_output.c
@@ -28,7 +28,7 @@ static void puts(const char *s)
 
 int solo5_app_main(const struct solo5_start_info *si __attribute__((unused)))
 {
-    char* str =
+    const char* str =
       "**** Solo5 standalone test_output **** (55 characters)\n"
       "**** Solo5 standalone test_output **** (111 characters)\n"
       "**** Solo5 standalone test_output **** (167 characters)\n"

--- a/tests/test_too_many_entries/GNUmakefile
+++ b/tests/test_too_many_entries/GNUmakefile
@@ -18,6 +18,7 @@
 
 test_NAME := test_too_many_entries
 
-.PHONY: all
+.PHONY: all clean
 all:
+clean:
 


### PR DESCRIPTION
This patch mainly try to lint our codebase with few warnings. It introduces also the usage of _Generic (C11) to be able to keep const qualifier between arguments and returned values (à la Rust).