### PR TITLE
hvt: optimize net interface

### DIFF
--- a/bindings/hvt/net.c
+++ b/bindings/hvt/net.c
@@ -94,7 +94,7 @@ solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf,
         memcpy(write_bufs[idx], buf, size);
         ent->operation = HVT_RING_NET_WRITE;
         ent->handle = handle;
-        ent->data = (uint64_t)(uintptr_t)write_bufs[idx];
+        ent->data = write_bufs[idx];
         ent->len = size;
         ent->id = ring_req_id++;
         ring_submit(net_ring);
@@ -142,7 +142,7 @@ solo5_result_t solo5_net_read(solo5_handle_t handle, uint8_t *buf, size_t size,
 
         ent->operation = HVT_RING_NET_READ;
         ent->handle = handle;
-        ent->data = (uint64_t)(uintptr_t)buf;
+        ent->data = buf;
         ent->len = size;
         ent->id = ring_req_id++;
 

--- a/bindings/hvt/net.c
+++ b/bindings/hvt/net.c
@@ -19,12 +19,91 @@
  */
 
 #include "bindings.h"
+#include "hvt_ring.h"
 
 static const struct mft *mft;
+static struct hvt_ring *net_ring;
+static uint32_t ring_req_id;
+/* Here, we’re doing things differently from VirtIO, which allocates buffers
+ * using `malloc()`. Our buffers will be in the .bss section! */
+static uint8_t write_bufs[HVT_RING_SIZE][HVT_RING_BUF_SIZE];
+
+static inline void cpu_relax(void)
+{
+#if defined(__x86_64__)
+    __asm__ __volatile__("pause" ::: "memory");
+#elif defined(__aarch64__)
+    __asm__ __volatile__("yield" ::: "memory");
+#endif
+}
+
+/*
+ * Submit a request to the ring and kick if needed.
+ * Does NOT wait for completion, caller decides whether to wait.
+ */
+static inline void ring_submit(struct hvt_ring *ring)
+{
+    /* as VirtIO, we add wmb() here to add a new entry. */
+    hvt_wmb();
+    ring->ent_tail++;
+
+    /* Kick suppression: only signal the I/O thread via ioeventfd if it has
+     * indicated it is about to sleep (needs_kick == 1). When the thread is
+     * actively polling, the kick is unnecessary overhead.
+     *
+     * IMPORTANT: hvt_mb() (mfence on x86) is required here, not just hvt_rmb().
+     * We need a Store-Load barrier to ensure our store to ent_tail is globally
+     * visible before we load needs_kick. Otherwise on x86, the load of
+     * needs_kick can bypass the store to ent_tail (store-buffer forwarding),
+     * and both sides can miss each other's updates (which results in a
+     * deadlock).
+     *
+     * As VirtIO, we need to use mb() when we would like to "kick"/NOTIFY the
+     * host thread.
+     */
+    hvt_mb();
+    if (ring->needs_kick)
+        hvt_ring_kick(0);
+}
 
 solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf,
                                size_t size)
 {
+    if (net_ring) {
+        /*
+         * Flow control: wait if the ring is full. The host advances ent_head
+         * after processing each write, freeing slots.
+         */
+        while ((net_ring->ent_tail - net_ring->ent_head) >= (HVT_RING_SIZE - 1))
+            cpu_relax();
+
+        uint32_t idx = net_ring->ent_tail & HVT_RING_MASK;
+        struct hvt_ring_entry *ent = &net_ring->entries[idx];
+
+        /* Fall back to hypercall for packets that do not fit in the
+         * per-slot buffer (e.g. jumbo frames with MTU > HVT_RING_BUF_SIZE).
+         */
+        if (size > HVT_RING_BUF_SIZE)
+            goto hypercall_write;
+
+        /* Copy data into a per-slot static buffer so the caller can safely
+         * reuse its buffer after we return (fire-and-forget). write_bufs[] is
+         * in guest BSS (low memory), well below the stack and the ring which
+         * are at the top of guest memory.
+         */
+        memcpy(write_bufs[idx], buf, size);
+        ent->operation = HVT_RING_NET_WRITE;
+        ent->handle = handle;
+        ent->data = (uint64_t)(uintptr_t)write_bufs[idx];
+        ent->len = size;
+        ent->id = ring_req_id++;
+        ring_submit(net_ring);
+
+        /* Fire-and-forget: no completion wait for writes */
+        return SOLO5_R_OK;
+    }
+
+hypercall_write:;
     volatile struct hvt_hc_net_write wr;
 
     wr.handle = handle;
@@ -37,9 +116,58 @@ solo5_result_t solo5_net_write(solo5_handle_t handle, const uint8_t *buf,
     return wr.ret;
 }
 
+/*
+ * Wait for the host to post a completion entry.
+ */
+static inline void ring_wait_commit(struct hvt_ring *ring)
+{
+    while (ring->com_head == ring->com_tail)
+        cpu_relax();
+    hvt_rmb();
+}
+
 solo5_result_t solo5_net_read(solo5_handle_t handle, uint8_t *buf, size_t size,
                               size_t *read_size)
 {
+    if (net_ring) {
+        /*
+         * Each read is synchronous (submit + wait_commit), so ent_head
+         * has advanced before the next read. The ring cannot be full here
+         * unless there is a bug in the write batching logic.
+         */
+        assert((net_ring->ent_tail - net_ring->ent_head) < (HVT_RING_SIZE - 1));
+
+        uint32_t idx = net_ring->ent_tail & HVT_RING_MASK;
+        struct hvt_ring_entry *ent = &net_ring->entries[idx];
+
+        ent->operation = HVT_RING_NET_READ;
+        ent->handle = handle;
+        ent->data = (uint64_t)(uintptr_t)buf;
+        ent->len = size;
+        ent->id = ring_req_id++;
+
+        /* NOTE(dinosaure): it seems that (in terms of performance) it is better
+         * to offload frame reading to the host pthread and wait for commit of
+         * the operation (and certainly avoid any VM exits under high load) than
+         * to make a hypercall.
+         *
+         * During an iperf3 benchmark, the unikernel appears to be fast enough
+         * to overwhelm the host’s pthread (meaning it does not need to be
+         * "kicked"). In such a situation, waiting via our ring seems more
+         * advantageous than the execution path involving a hypercall.
+         */
+        ring_submit(net_ring);
+        ring_wait_commit(net_ring);
+
+        uint32_t commit_idx = net_ring->com_head & HVT_RING_MASK;
+        struct hvt_ring_commit *commit = &net_ring->commits[commit_idx];
+        solo5_result_t ret = (solo5_result_t)commit->ret;
+        *read_size = commit->len;
+        net_ring->com_head++;
+
+        return ret;
+    }
+
     volatile struct hvt_hc_net_read rd;
 
     rd.handle = handle;
@@ -72,4 +200,10 @@ solo5_result_t solo5_net_acquire(const char *name, solo5_handle_t *handle,
 void net_init(const struct hvt_boot_info *bi)
 {
     mft = bi->mft;
+    net_ring = NULL;
+    ring_req_id = 0;
+
+    if (bi->host_features & HVT_FEATURE_RING_IO) {
+        net_ring = (struct hvt_ring *)(uintptr_t)bi->net_ring;
+    }
 }

--- a/include/hvt_abi.h
+++ b/include/hvt_abi.h
@@ -149,6 +149,10 @@ static inline void hvt_do_hypercall(int n, volatile void *arg)
 /*
  * A pointer to this structure is passed by the tender as the sole argument to
  * the guest entrypoint.
+ *
+ * New fields are appended at the end for forward compatibility. Old guests
+ * compiled against ABI v2 will not access the new fields; the tender detects
+ * this and falls back to hypercall-based I/O.
  */
 struct hvt_boot_info {
     uint64_t mem_size; /* Memory size in bytes */
@@ -157,6 +161,10 @@ struct hvt_boot_info {
     HVT_GUEST_PTR(const char *)
     cmdline; /* Address of command line (C string) */
     HVT_GUEST_PTR(const void *) mft; /* Address of application manifest */
+
+    /* Extended fields (ring I/O negotiation) */
+    uint32_t host_features; /* Features offered by the tender */
+    uint32_t guest_features; /* Features accepted by the guest */
 };
 
 /*

--- a/include/hvt_abi.h
+++ b/include/hvt_abi.h
@@ -54,6 +54,12 @@
  */
 #define HVT_HYPERCALL_PIO_BASE 0x500
 
+/*
+ * PIO port used by the guest to kick the host I/O thread via ioeventfd.
+ * This does NOT cause a VM exit when KVM_IOEVENTFD is registered.
+ */
+#define HVT_RING_KICK_PIO_BASE 0x600
+
 #ifdef HVT_HOST
 /*
  * Non-dereferencable tender-side type representing a guest physical address.
@@ -78,6 +84,19 @@ static inline void hvt_do_hypercall(int n, volatile void *arg)
                            "d"((uint16_t)(HVT_HYPERCALL_PIO_BASE + n))
                          : "memory");
 }
+
+/*
+ * Kick the host I/O thread via ioeventfd. The PIO write is trapped by KVM
+ * and signals the eventfd WITHOUT causing a VM exit.
+ */
+static inline void hvt_ring_kick(int ring_id)
+{
+    __asm__ __volatile__("outl %0, %1"
+                         :
+                         : "a"((uint32_t)ring_id),
+                           "d"((uint16_t)(HVT_RING_KICK_PIO_BASE))
+                         : "memory");
+}
 #endif
 
 #elif defined(__aarch64__)
@@ -89,6 +108,13 @@ static inline void hvt_do_hypercall(int n, volatile void *arg)
  * MMIO start from 4GB, this value can be changed by AARCH64_MMIO_BASE.
  */
 #define HVT_HYPERCALL_MMIO_BASE  (0x100000000UL)
+
+/*
+ * MMIO address used by the guest to kick the host I/O thread via ioeventfd.
+ * Placed well after the hypercall range (max 16 hypercalls * 8 = 128 bytes),
+ * 64-bit aligned.
+ */
+#define HVT_RING_KICK_MMIO_BASE  (HVT_HYPERCALL_MMIO_BASE + 0x100)
 
 /*
  * On aarch64, the MMIO address must be 64-bit aligned, because we configured
@@ -126,6 +152,19 @@ static inline void hvt_do_hypercall(int n, volatile void *arg)
                            "r"((uint64_t)HVT_HYPERCALL_ADDRESS(n))
                          : "memory");
 }
+
+/*
+ * Kick the host I/O thread via ioeventfd. The MMIO write is trapped by KVM
+ * and signals the eventfd WITHOUT causing a VM exit.
+ */
+static inline void hvt_ring_kick(int ring_id)
+{
+    __asm__ __volatile__("str %w0, [%1]"
+                         :
+                         : "rZ"((uint32_t)ring_id),
+                           "r"((uint64_t)HVT_RING_KICK_MMIO_BASE)
+                         : "memory");
+}
 #endif
 #else
 #error Unsupported architecture
@@ -147,6 +186,11 @@ static inline void hvt_do_hypercall(int n, volatile void *arg)
 #endif
 
 /*
+ * Feature flags for host/guest negotiation.
+ */
+#define HVT_FEATURE_RING_IO (1U << 0)
+
+/*
  * A pointer to this structure is passed by the tender as the sole argument to
  * the guest entrypoint.
  *
@@ -165,6 +209,7 @@ struct hvt_boot_info {
     /* Extended fields (ring I/O negotiation) */
     uint32_t host_features; /* Features offered by the tender */
     uint32_t guest_features; /* Features accepted by the guest */
+    HVT_GUEST_PTR(void *) net_ring; /* GPA of network ring, 0 if absent */
 };
 
 /*

--- a/include/hvt_ring.h
+++ b/include/hvt_ring.h
@@ -52,7 +52,7 @@
 struct hvt_ring_entry {
     uint32_t operation;
     uint32_t handle;
-    uint64_t data; /* GPA of the data buffer */
+    HVT_GUEST_PTR(const void *) data; /* GPA of the data buffer */
     uint32_t len;
     uint32_t id;
     uint64_t _reserved;

--- a/include/hvt_ring.h
+++ b/include/hvt_ring.h
@@ -27,6 +27,7 @@
 #ifndef HVT_RING_H
 #define HVT_RING_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #define HVT_RING_SIZE 1024
@@ -93,6 +94,16 @@ struct hvt_ring {
     struct hvt_ring_entry entries[HVT_RING_SIZE];
     struct hvt_ring_commit commits[HVT_RING_SIZE];
 };
+
+/*
+ * Verify that guest-written and host-written fields live on distinct cache
+ * lines (64 bytes each), and that the data arrays start after exactly 2
+ * cache lines of index/control fields.
+ */
+_Static_assert(offsetof(struct hvt_ring, ent_head) == 64,
+               "ent_head must start at cache line 1 (offset 64)");
+_Static_assert(offsetof(struct hvt_ring, entries) == 128,
+               "entries[] must start after 2 cache lines (offset 128)");
 
 /*
  * Memory barriers.

--- a/include/hvt_ring.h
+++ b/include/hvt_ring.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * hvt_ring.h: Shared ring buffer definitions for ioeventfd-base I/O.
+ *
+ * This header file is used by both the tender (host) and the guest (bindings).
+ */
+
+#ifndef HVT_RING_H
+#define HVT_RING_H
+
+#include <stdint.h>
+
+#define HVT_RING_SIZE 1024
+#define HVT_RING_MASK (HVT_RING_SIZE - 1)
+#define HVT_RING_BUF_SIZE                                                      \
+    2048 /* per-slot data buffer (>= max ethernet frame) */
+
+/*
+ * Number of spin iterations the I/O thread performs before blocking on
+ * the eventfd. Tuned for ~1-2ns of spinning at typical CPU frequencies.
+ */
+#define HVT_RING_POLL_ITERS 4096
+
+/*
+ * Ring operations.
+ */
+#define HVT_RING_NET_WRITE 1
+#define HVT_RING_NET_READ  2
+
+/*
+ * Submission entry: written by the guest, consumed by the host.
+ */
+struct hvt_ring_entry {
+    uint32_t operation;
+    uint32_t handle;
+    uint64_t data; /* GPA of the data buffer */
+    uint32_t len;
+    uint32_t id;
+    uint64_t _reserved;
+};
+
+/*
+ * Commit entry: written by the host, consumed by the guest.
+ */
+struct hvt_ring_commit {
+    uint32_t id;
+    int32_t ret;
+    uint32_t len;
+    uint32_t _reserved;
+};
+
+/*
+ * Shared ring structure. Indices are separated into distinct cache lines to
+ * avoid false sharing between guest and host.
+ *
+ * Cache line 0: written ONLY by the guest (ent_tail, com_head)
+ * Cache line 1: written ONLY by thes host (ent_head, com_tail, needs_kick)
+ *
+ * This ensures each side only writes to its own cache line, eliminating
+ * false sharing bounces.
+ */
+struct hvt_ring {
+    /* Cache line 0: written ONLY by the guest */
+    volatile uint32_t ent_tail; /* produced by guest */
+    volatile uint32_t com_head; /* consumed by guest */
+    uint8_t _pad0[56];
+
+    /* Cache line 1: written ONLY by the host */
+    volatile uint32_t ent_head; /* consumed by host */
+    volatile uint32_t com_tail; /* produced by host */
+    volatile uint32_t needs_kick; /* set by host before sleeping */
+    uint8_t _pad1[52];
+
+    struct hvt_ring_entry entries[HVT_RING_SIZE];
+    struct hvt_ring_commit commits[HVT_RING_SIZE];
+};
+
+/*
+ * Memory barriers.
+ *
+ * hvt_wmb() / hvt_rmb(): used for the SPSC ring indices ([ent_tail],
+ * [com_tail]). On x86 TSO, stores are not re-ordered with sotrees and loads
+ * are not re-ordered with loads, so a compiler barrier suffices.
+ *
+ * hvt_mb(): full Store-Load barrier. Required for the [needs_kick] protocol
+ * where both sides do "store mine; load theirs". x86 TSO allows a younger load
+ * to bypass an older store to a different address (stored-buffer forwarding),
+ * so [mfence] is needed here.
+ *
+ * On aarch64 (weakly ordered): real fence instructions are always required.
+ */
+#ifdef __x86_64__
+static inline void hvt_wmb(void)
+{
+    __asm__ __volatile__("" ::: "memory");
+}
+
+static inline void hvt_rmb(void)
+{
+    __asm__ __volatile__("" ::: "memory");
+}
+
+static inline void hvt_mb(void)
+{
+    __asm__ __volatile__("mfence" ::: "memory");
+}
+#elif defined(__aarch64__)
+static inline void hvt_wmb(void)
+{
+    __asm__ __volatile__("dmb ishst" ::: "memory");
+}
+
+static inline void hvt_rmb(void)
+{
+    __asm__ __volatile__("dmb ishld" ::: "memory");
+}
+
+static inline void hvt_mb(void)
+{
+    __asm__ __volatile__("dmb ish" ::: "memory");
+}
+#else
+#error Unsupported architecture
+#endif
+
+#endif /* HVT_RING_H */

--- a/tenders/GNUmakefile
+++ b/tenders/GNUmakefile
@@ -64,10 +64,12 @@ ifeq ($(CONFIG_HOST), Linux)
     all_TARGETS += hvt/solo5-hvt hvt/solo5-hvt-debug
 
     HOSTLDFLAGS += -Wl,-z -Wl,noexecstack
+    HOSTLDLIBS += -lpthread
 else ifeq ($(CONFIG_HOST), FreeBSD)
     hvt_SRCS += hvt/hvt_freebsd.c hvt/hvt_freebsd_$(CONFIG_HOST_ARCH).c
     hvt_debug_MODULES ?= gdb dumpcore
     all_TARGETS += hvt/solo5-hvt hvt/solo5-hvt-debug
+    HOSTLDLIBS += -lpthread
 ifeq ($(CONFIG_HVT_TENDER_ENABLE_CAPSICUM), 1)
     HOSTLDLIBS += -lnv
     CFLAGS += -DDHVT_FREEBSD_ENABLE_CAPSICUM=1
@@ -75,6 +77,7 @@ endif
 else ifeq ($(CONFIG_HOST), OpenBSD)
     hvt_SRCS += hvt/hvt_openbsd.c hvt/hvt_openbsd_$(CONFIG_HOST_ARCH).c
     all_TARGETS += hvt/solo5-hvt
+    HOSTLDLIBS += -lpthread
 endif
 
 hvt_SRCS += $(patsubst %,hvt/hvt_module_%.c,$(hvt_MODULES))

--- a/tenders/common/tap_attach.c
+++ b/tenders/common/tap_attach.c
@@ -43,6 +43,8 @@
 #include <sys/socket.h>
 #include <linux/if.h>
 #include <linux/if_tun.h>
+#include <linux/ethtool.h>
+#include <linux/sockios.h>
 
 #elif defined(__FreeBSD__)
 
@@ -210,8 +212,36 @@ int tap_attach(const char *ifname, int *mtu)
         errno = err;
         return -1;
     }
-    close(sock);
     *mtu = ifr.ifr_mtu;
+
+#if defined(__linux__)
+    /*
+     * Disable GRO/GSO offloads on the TAP interface.
+     *
+     * Without IFF_VNET_HDR, the kernel can still deliver GRO-aggregated frames
+     * (up to 64KB) via read() on the TAP fd. The guest reads with buffer of at
+     * most HVT_RING_BUF_SIZE (2048) bytes, so large frames are silently
+     * truncated - the delivered packet has an IP total_length that exceeds the
+     * actual data, corrupting the guest TCP stack.
+     *
+     * Equivalent to: ethtool -K <iface> gro off gso off
+     */
+    {
+        static const uint32_t cmds[] = {ETHTOOL_SGRO, ETHTOOL_SGSO};
+        for (unsigned i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+            struct ethtool_value eval;
+            memset(&eval, 0, sizeof(eval));
+            eval.cmd = cmds[i];
+            eval.data = 0;
+            memset(&ifr, 0, sizeof(ifr));
+            strncpy(ifr.ifr_name, ifname, IFNAMSIZ - 1);
+            ifr.ifr_data = (void *)&eval;
+            ioctl(sock, SIOCETHTOOL, &ifr);
+        }
+    }
+#endif
+
+    close(sock);
 
     return fd;
 }

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -54,7 +54,8 @@
  */
 struct hvt {
     uint8_t *mem;
-    size_t mem_size;
+    size_t guest_mem_size;
+    size_t mem_alloc_size;
     uint64_t cpu_cycle_freq;
     hvt_gpa_t cpu_boot_info_base;
     struct hvt_b *b;
@@ -72,8 +73,8 @@ inline void *hvt_checked_gpa_p(struct hvt *hvt, hvt_gpa_t gpa, size_t sz,
 {
     hvt_gpa_t r;
 
-    if ((gpa >= hvt->mem_size) || add_overflow(gpa, sz, r) ||
-        (r >= hvt->mem_size)) {
+    if ((gpa >= hvt->guest_mem_size) || add_overflow(gpa, sz, r) ||
+        (r >= hvt->guest_mem_size)) {
         errx(1, "%s:%d: Invalid guest access: gpa=0x%" PRIx64 ", sz=%zu", file,
              line, gpa, sz);
     } else {
@@ -82,8 +83,9 @@ inline void *hvt_checked_gpa_p(struct hvt *hvt, hvt_gpa_t gpa, size_t sz,
 }
 
 /*
- * Initialise hypervisor, with (mem_size) bytes of guest memory.
- * (hvt->mem) and (hvt->mem_size) are valid after this function has been called.
+ * Initialise hypervisor, with (guest_mem_size) bytes of guest memory.
+ * (hvt->mem) and (hvt->guest_mem_size) are valid after this function has been
+ * called.
  */
 struct hvt *hvt_init(size_t mem_size);
 

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -97,6 +97,20 @@ struct hvt *hvt_init(size_t mem_size);
 void hvt_net_reserve_ring(struct hvt *hvt, struct mft *mft);
 
 /*
+ * Rounds up (mem_size) to the next architecture page boundary.
+ * Unlike hvt_mem_size() which rounds down, this is used when adding overhead
+ * (e.g. ring buffer) to an already-aligned base size.
+ */
+void hvt_mem_size_roundup(size_t *mem_size);
+
+/*
+ * Returns the extra guest memory needed for the network ring buffer, or 0 if
+ * no NET_BASIC device is attached in the manifest. Must be called after
+ * command-line parsing has set the attached flags.
+ */
+size_t hvt_net_mem_overhead(struct mft *mft);
+
+/*
  * Computes the memory size to use for this tender, based on the user-provided
  * value (rounding down if necessary).
  */

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -90,6 +90,13 @@ inline void *hvt_checked_gpa_p(struct hvt *hvt, hvt_gpa_t gpa, size_t sz,
 struct hvt *hvt_init(size_t mem_size);
 
 /*
+ * Reserve guest memory for the network ring buffer, if a NET_BASIC device is
+ * present in the manifest. Must be called before hvt_vcpu_init() so that the
+ * initial stack pointer is placed below the ring area.
+ */
+void hvt_net_reserve_ring(struct hvt *hvt, struct mft *mft);
+
+/*
  * Computes the memory size to use for this tender, based on the user-provided
  * value (rounding down if necessary).
  */

--- a/tenders/hvt/hvt_boot_info.c
+++ b/tenders/hvt/hvt_boot_info.c
@@ -61,7 +61,7 @@ void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
      */
     struct hvt_boot_info *bi = (struct hvt_boot_info *)(hvt->mem + lowmem_pos);
     lowmem_pos += sizeof(struct hvt_boot_info);
-    bi->mem_size = hvt->mem_size;
+    bi->mem_size = hvt->guest_mem_size;
     bi->kernel_end = gpa_kend;
     bi->cpu_cycle_freq = hvt->cpu_cycle_freq;
     /*

--- a/tenders/hvt/hvt_boot_info.c
+++ b/tenders/hvt/hvt_boot_info.c
@@ -30,6 +30,14 @@
 
 #include "hvt.h"
 
+#if defined(__linux__)
+#include "hvt_kvm.h"
+#elif defined(__FreeBSD__)
+#include "hvt_freebsd.h"
+#elif defined(__OpenBSD__)
+#include "hvt_openbsd.h"
+#endif
+
 static void setup_cmdline(uint8_t *cmdline, int argc, char **argv)
 {
     size_t cmdline_free = HVT_CMDLINE_SIZE;
@@ -78,4 +86,30 @@ void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
     bi->cmdline = lowmem_pos;
     setup_cmdline(hvt->mem + lowmem_pos, cmdline_argc, cmdline_argv);
     lowmem_pos += HVT_CMDLINE_SIZE;
+
+    /*
+     * Extended fields for ring I/O negotiation.
+     */
+    bi->host_features = 0;
+    bi->guest_features = 0;
+    bi->net_ring = 0;
+
+    {
+        struct hvt_b *hvb = hvt->b;
+        int ring_active = 0;
+#if defined(__linux__)
+        ring_active = hvb->has_ioeventfd && hvb->kick_net_efd != -1;
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+        ring_active = hvb->kick_net_pipe[0] != -1;
+#endif
+        if (ring_active) {
+            bi->host_features |= HVT_FEATURE_RING_IO;
+            bi->net_ring = hvb->net_ring_gpa;
+            /*
+             * Exclude the ring area from usable guest memory so the
+             * guest's heap allocator does not grow on it.
+             */
+            bi->mem_size = hvb->net_ring_gpa;
+        }
+    }
 }

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -101,6 +101,8 @@ struct hvt *hvt_init(size_t mem_size)
     memset(hvb, 0, sizeof(struct hvt_b));
     hvt->b = hvb;
     hvb->vmfd = -1;
+    hvb->kick_net_pipe[0] = -1;
+    hvb->kick_net_pipe[1] = -1;
 
     int namelen = asprintf(&hvb->vmname, "solo5-%d", getpid());
     if (namelen == -1)

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -146,7 +146,8 @@ struct hvt *hvt_init(size_t mem_size)
         mmap(NULL, mem_size, PROT_READ | PROT_WRITE, MAP_SHARED, hvb->vmfd, 0);
     if (hvt->mem == MAP_FAILED)
         err(1, "mmap");
-    hvt->mem_size = mem_size;
+    hvt->guest_mem_size = mem_size;
+    hvt->mem_alloc_size = mem_size;
 
 #if HVT_FREEBSD_ENABLE_CAPSICUM
     cap_rights_t rights;
@@ -204,14 +205,14 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
 {
     struct hvt *hvt = t_arg;
 
-    assert(addr_start <= hvt->mem_size);
-    assert(addr_end <= hvt->mem_size);
+    assert(addr_start <= hvt->guest_mem_size);
+    assert(addr_end <= hvt->guest_mem_size);
     assert(addr_start < addr_end);
 
     uint8_t *vaddr_start = hvt->mem + addr_start;
     assert(vaddr_start >= hvt->mem);
     size_t size = addr_end - addr_start;
-    assert(size > 0 && size <= hvt->mem_size);
+    assert(size > 0 && size <= hvt->guest_mem_size);
 
     /*
      * Host-side page protections:

--- a/tenders/hvt/hvt_freebsd.h
+++ b/tenders/hvt/hvt_freebsd.h
@@ -25,6 +25,12 @@
 #ifndef HVT_HV_FREEBSD_H
 #define HVT_HV_FREEBSD_H
 
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <machine/vmm.h>
+#include <machine/vmm_dev.h>
+#include <pthread.h>
+
 #define VMM_USER   "nobody"
 #define VMM_CHROOT "/var/empty"
 
@@ -32,6 +38,11 @@ struct hvt_b {
     char *vmname;
     int vmfd;
     struct vm_run vmrun;
+
+    /* Ring I/O (pipe-based notification) */
+    int kick_net_pipe[2];
+    pthread_t io_thread_net;
+    hvt_gpa_t net_ring_gpa;
 };
 
 #endif /* HVT_HV_FREEBSD_H */

--- a/tenders/hvt/hvt_freebsd_x86_64.c
+++ b/tenders/hvt/hvt_freebsd_x86_64.c
@@ -91,7 +91,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
     struct hvt_b *hvb = hvt->b;
 
     hvt_x86_setup_gdt(hvt->mem);
-    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_size);
+    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_alloc_size);
 
     vmm_set_reg(hvb->vmfd, VM_REG_GUEST_CR0, X86_CR0_INIT);
     vmm_set_reg(hvb->vmfd, VM_REG_GUEST_CR3, X86_CR3_INIT);
@@ -127,7 +127,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
 
     vmm_set_reg(hvb->vmfd, VM_REG_GUEST_RIP, gpa_ep);
     vmm_set_reg(hvb->vmfd, VM_REG_GUEST_RFLAGS, X86_RFLAGS_INIT);
-    vmm_set_reg(hvb->vmfd, VM_REG_GUEST_RSP, hvt->mem_size - 8);
+    vmm_set_reg(hvb->vmfd, VM_REG_GUEST_RSP, hvt->guest_mem_size - 8);
     vmm_set_reg(hvb->vmfd, VM_REG_GUEST_RDI, X86_BOOT_INFO_BASE);
 
     struct vm_activate_cpu ac = {.vcpuid = 0};

--- a/tenders/hvt/hvt_freebsd_x86_64.c
+++ b/tenders/hvt/hvt_freebsd_x86_64.c
@@ -51,6 +51,15 @@ void hvt_mem_size(size_t *mem_size)
     hvt_x86_mem_size(mem_size);
 }
 
+void hvt_mem_size_roundup(size_t *mem_size)
+{
+    size_t mem = ((*mem_size + X86_GUEST_PAGE_SIZE - 1) / X86_GUEST_PAGE_SIZE) *
+                 X86_GUEST_PAGE_SIZE;
+    if (mem > X86_GUEST_MAX_MEM_SIZE)
+        mem = X86_GUEST_MAX_MEM_SIZE;
+    *mem_size = mem;
+}
+
 static void vmm_set_desc(int vmfd, int reg, uint64_t base, uint32_t limit,
                          uint32_t access)
 {

--- a/tenders/hvt/hvt_freebsd_x86_64.c
+++ b/tenders/hvt/hvt_freebsd_x86_64.c
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -181,6 +182,14 @@ int hvt_vcpu_loop(struct hvt *hvt)
 
         switch (vme->exitcode) {
         case VM_EXITCODE_INOUT: {
+            if (vme->u.inout.port == HVT_RING_KICK_PIO_BASE &&
+                !vme->u.inout.in && vme->u.inout.bytes == 4) {
+                if (hvb->kick_net_pipe[1] != -1) {
+                    uint8_t byte = 1;
+                    write(hvb->kick_net_pipe[1], &byte, 1);
+                }
+                break;
+            }
             if (vme->u.inout.in || vme->u.inout.bytes != 4)
                 errx(1, "Invalid guest port access: port=0x%x",
                      vme->u.inout.port);

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -97,6 +97,13 @@ struct hvt *hvt_init(size_t mem_size)
     if (ret == -1)
         err(1, "KVM: ioctl (SET_USER_MEMORY_REGION) failed");
 
+    /*
+     * Check for ioventfd support; used for ring-based I/O if available.
+     */
+    ret = ioctl(hvb->kvmfd, KVM_CHECK_EXTENSION, KVM_CAP_IOEVENTFD);
+    hvb->has_ioeventfd = (ret > 0);
+    hvb->kick_net_efd = -1;
+
     hvt->b = hvb;
     return hvt;
 }

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -84,12 +84,13 @@ struct hvt *hvt_init(size_t mem_size)
                     MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     if (hvt->mem == MAP_FAILED)
         err(1, "Error allocating guest memory");
-    hvt->mem_size = mem_size;
+    hvt->guest_mem_size = mem_size;
+    hvt->mem_alloc_size = mem_size;
 
     struct kvm_userspace_memory_region region = {
         .slot = 0,
         .guest_phys_addr = 0,
-        .memory_size = hvt->mem_size,
+        .memory_size = hvt->guest_mem_size,
         .userspace_addr = (uint64_t)hvt->mem,
     };
     ret = ioctl(hvb->vmfd, KVM_SET_USER_MEMORY_REGION, &region);
@@ -128,14 +129,14 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
 {
     struct hvt *hvt = t_arg;
 
-    assert(addr_start <= hvt->mem_size);
-    assert(addr_end <= hvt->mem_size);
+    assert(addr_start <= hvt->guest_mem_size);
+    assert(addr_end <= hvt->guest_mem_size);
     assert(addr_start < addr_end);
 
     uint8_t *vaddr_start = hvt->mem + addr_start;
     assert(vaddr_start >= hvt->mem);
     size_t size = addr_end - addr_start;
-    assert(size > 0 && size <= hvt->mem_size);
+    assert(size > 0 && size <= hvt->guest_mem_size);
 
     /*
      * Host-side page protections:

--- a/tenders/hvt/hvt_kvm.h
+++ b/tenders/hvt/hvt_kvm.h
@@ -25,11 +25,19 @@
 #ifndef HVT_HV_KVM_H
 #define HVT_HV_KVM_H
 
+#include <pthread.h>
+
 struct hvt_b {
     int kvmfd;
     int vmfd;
     int vcpufd;
     struct kvm_run *vcpurun;
+
+    /* ioeventfd-based ring I/O */
+    int has_ioeventfd;
+    int kick_net_efd;
+    pthread_t io_thread_net;
+    hvt_gpa_t net_ring_gpa;
 };
 
 #endif /* HVT_HV_KVM_H */

--- a/tenders/hvt/hvt_kvm_aarch64.c
+++ b/tenders/hvt/hvt_kvm_aarch64.c
@@ -268,7 +268,8 @@ static void aarch64_setup_core_registers(struct hvt *hvt, hvt_gpa_t gpa_ep)
      * Set Stack Poniter for Guest. ARM64 require stack be 16-bytes
      * alignment by default.
      */
-    ret = aarch64_set_one_register(hvb->vcpufd, SP_EL1, hvt->mem_size - 16);
+    ret =
+        aarch64_set_one_register(hvb->vcpufd, SP_EL1, hvt->guest_mem_size - 16);
     if (ret == -1)
         err(1, "Initialize sp[EL1] failed!\n");
 
@@ -300,7 +301,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
      * RAM space and 1GB for MMIO space. Although the guest can use up
      * to 1TB address space which we configured in TCR_EL1.
      */
-    aarch64_setup_memory_mapping(hvt->mem, hvt->mem_size);
+    aarch64_setup_memory_mapping(hvt->mem, hvt->mem_alloc_size);
 
     /* Select preferred target for guest */
     aarch64_setup_preferred_target(hvb->vmfd, hvb->vcpufd);

--- a/tenders/hvt/hvt_kvm_aarch64.c
+++ b/tenders/hvt/hvt_kvm_aarch64.c
@@ -399,3 +399,13 @@ void hvt_mem_size(size_t *mem_size)
 {
     aarch64_mem_size(mem_size);
 }
+
+void hvt_mem_size_roundup(size_t *mem_size)
+{
+    size_t mem = ((*mem_size + AARCH64_GUEST_BLOCK_SIZE - 1) /
+                  AARCH64_GUEST_BLOCK_SIZE) *
+                 AARCH64_GUEST_BLOCK_SIZE;
+    if (mem > AARCH64_MMIO_BASE)
+        mem = AARCH64_MMIO_BASE;
+    *mem_size = mem;
+}

--- a/tenders/hvt/hvt_kvm_x86_64.c
+++ b/tenders/hvt/hvt_kvm_x86_64.c
@@ -89,7 +89,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
     int ret;
 
     hvt_x86_setup_gdt(hvt->mem);
-    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_size);
+    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_alloc_size);
 
     setup_cpuid(hvb);
 
@@ -142,7 +142,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
     struct kvm_regs regs = {
         .rip = gpa_ep,
         .rflags = X86_RFLAGS_INIT,
-        .rsp = hvt->mem_size - 8,
+        .rsp = hvt->guest_mem_size - 8,
         .rdi = X86_BOOT_INFO_BASE,
     };
     ret = ioctl(hvb->vcpufd, KVM_SET_REGS, &regs);

--- a/tenders/hvt/hvt_kvm_x86_64.c
+++ b/tenders/hvt/hvt_kvm_x86_64.c
@@ -43,6 +43,15 @@ void hvt_mem_size(size_t *mem_size)
     hvt_x86_mem_size(mem_size);
 }
 
+void hvt_mem_size_roundup(size_t *mem_size)
+{
+    size_t mem = ((*mem_size + X86_GUEST_PAGE_SIZE - 1) / X86_GUEST_PAGE_SIZE) *
+                 X86_GUEST_PAGE_SIZE;
+    if (mem > X86_GUEST_MAX_MEM_SIZE)
+        mem = X86_GUEST_MAX_MEM_SIZE;
+    *mem_size = mem;
+}
+
 static void setup_cpuid(struct hvt_b *hvb)
 {
     struct kvm_cpuid2 *kvm_cpuid;

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -252,6 +252,13 @@ int main(int argc, char **argv)
         err(1, "Could not install signal handler");
 
     hvt_mem_size(&mem_size);
+
+    size_t net_overhead = hvt_net_mem_overhead(mft);
+    if (net_overhead > 0) {
+        mem_size += net_overhead;
+        hvt_mem_size_roundup(&mem_size);
+    }
+
     struct hvt *hvt = hvt_init(mem_size);
 
     elf_load(elf_fd, elf_filename, hvt->mem, hvt->guest_mem_size,

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -258,6 +258,7 @@ int main(int argc, char **argv)
              HVT_GUEST_MIN_BASE, hvt_guest_mprotect, hvt, &gpa_ep, &gpa_kend);
     close(elf_fd); /* Done with ELF binary */
 
+    hvt_net_reserve_ring(hvt, mft);
     hvt_vcpu_init(hvt, gpa_ep);
 
     setup_modules(hvt, mft);

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -254,8 +254,8 @@ int main(int argc, char **argv)
     hvt_mem_size(&mem_size);
     struct hvt *hvt = hvt_init(mem_size);
 
-    elf_load(elf_fd, elf_filename, hvt->mem, hvt->mem_size, HVT_GUEST_MIN_BASE,
-             hvt_guest_mprotect, hvt, &gpa_ep, &gpa_kend);
+    elf_load(elf_fd, elf_filename, hvt->mem, hvt->guest_mem_size,
+             HVT_GUEST_MIN_BASE, hvt_guest_mprotect, hvt, &gpa_ep, &gpa_kend);
     close(elf_fd); /* Done with ELF binary */
 
     hvt_vcpu_init(hvt, gpa_ep);

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -138,8 +138,8 @@ void hvt_dumpcore_hook(struct hvt *hvt, int status, void *cookie)
                         .p_align = 0,
                         .p_paddr = 0,
                         .p_vaddr = 0,
-                        .p_memsz = hvt->mem_size,
-                        .p_filesz = hvt->mem_size,
+                        .p_memsz = hvt->guest_mem_size,
+                        .p_filesz = hvt->guest_mem_size,
                         .p_flags = 0,
                         .p_offset = offset};
 
@@ -189,12 +189,12 @@ void hvt_dumpcore_hook(struct hvt *hvt, int status, void *cookie)
         warn("dumpcore: Could not determine _SC_PAGESIZE");
         goto failure;
     }
-    assert(hvt->mem_size % page_size == 0);
-    size_t npages = hvt->mem_size / page_size;
+    assert(hvt->guest_mem_size % page_size == 0);
+    size_t npages = hvt->guest_mem_size / page_size;
     size_t ndumped = 0;
     host_mvec_t mvec = malloc(npages);
     assert(mvec);
-    if (mincore(hvt->mem, hvt->mem_size, mvec) == -1) {
+    if (mincore(hvt->mem, hvt->guest_mem_size, mvec) == -1) {
         warn("dumpcore: mincore() failed");
         goto failure;
     }

--- a/tenders/hvt/hvt_module_gdb.c
+++ b/tenders/hvt/hvt_module_gdb.c
@@ -456,8 +456,9 @@ static void gdb_handle_exception(struct hvt *hvt, int sigval)
                 break;
             }
 
-            if ((addr > hvt->mem_size) || add_overflow(addr, len, result) ||
-                (result > hvt->mem_size)) {
+            if ((addr > hvt->guest_mem_size) ||
+                add_overflow(addr, len, result) ||
+                (result > hvt->guest_mem_size)) {
                 /* Don't panic about this, just return error so the debugger
                  * tries again. */
                 send_error_msg();
@@ -476,8 +477,9 @@ static void gdb_handle_exception(struct hvt *hvt, int sigval)
                 break;
             }
 
-            if ((addr > hvt->mem_size) || add_overflow(addr, len, result) ||
-                (result > hvt->mem_size)) {
+            if ((addr > hvt->guest_mem_size) ||
+                add_overflow(addr, len, result) ||
+                (result > hvt->guest_mem_size)) {
                 /* Don't panic about this, just return error so the debugger
                  * tries again. */
                 send_error_msg();
@@ -535,8 +537,9 @@ static void gdb_handle_exception(struct hvt *hvt, int sigval)
                 break;
             }
 
-            if ((addr > hvt->mem_size) || add_overflow(addr, len, result) ||
-                (result > hvt->mem_size)) {
+            if ((addr > hvt->guest_mem_size) ||
+                add_overflow(addr, len, result) ||
+                (result > hvt->guest_mem_size)) {
                 /* Don't panic about this, just return error so the debugger
                  * tries again. */
                 send_error_msg();
@@ -639,8 +642,8 @@ static int setup(struct hvt *hvt, struct mft *mft)
      * GDB clients can change memory, and software breakpoints work by
      * replacing instructions with int3's.
      */
-    if (mprotect(hvt->mem, hvt->mem_size, PROT_READ | PROT_WRITE | PROT_EXEC) ==
-        -1)
+    if (mprotect(hvt->mem, hvt->guest_mem_size,
+                 PROT_READ | PROT_WRITE | PROT_EXEC) == -1)
         err(1, "GDB: Cannot remove guest memory protection");
 
     /* Notify the debugger that we are dying. */

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -170,8 +170,10 @@ static inline void process_read_entry(struct hvt *hvt, struct hvt_ring *ring,
         commit->ret = SOLO5_R_EINVAL;
         commit->len = 0;
     } else {
-        void *data = HVT_CHECKED_GPA_P(hvt, ent->data, ent->len);
-        ssize_t nr = read(e->b.hostfd, data, ent->len);
+        uint64_t ent_data = ent->data;
+        uint32_t ent_len = ent->len;
+        void *data = HVT_CHECKED_GPA_P(hvt, ent_data, ent_len);
+        ssize_t nr = read(e->b.hostfd, data, ent_len);
 
         if (nr == 0 || (nr == -1 && errno == EAGAIN)) {
             commit->ret = SOLO5_R_AGAIN;
@@ -223,15 +225,17 @@ static inline void process_ring_commits(struct hvt *hvt, struct hvt_ring *ring)
                     mft_get_by_index(host_mft, ent->handle, MFT_DEV_NET_BASIC);
 
                 if (e != NULL) {
-                    void *data = HVT_CHECKED_GPA_P(hvt, ent->data, ent->len);
-                    ssize_t ret = write(e->b.hostfd, data, ent->len);
+                    uint64_t ent_data = ent->data;
+                    uint32_t ent_len = ent->len;
+                    void *data = HVT_CHECKED_GPA_P(hvt, ent_data, ent_len);
+                    ssize_t ret = write(e->b.hostfd, data, ent_len);
                     if (ret == -1)
                         err(1, "Fatal write error on net device");
-                    if ((size_t)ret != ent->len)
+                    if ((size_t)ret != ent_len)
                         errx(1,
                              "Fatal write error: wrote only %zd"
                              " out of %u bytes",
-                             ret, ent->len);
+                             ret, ent_len);
                 }
                 processed++;
             } else if (ent->operation == HVT_RING_NET_READ) {

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -40,8 +40,46 @@
 #include "hvt.h"
 #include "solo5.h"
 
+#include <pthread.h>
+#include "hvt_ring.h"
+
+#if defined(__linux__)
+#include <sys/eventfd.h>
+#include <sys/ioctl.h>
+#include <linux/kvm.h>
+#include "hvt_kvm.h"
+#elif defined(__FreeBSD__)
+#include "hvt_freebsd.h"
+#elif defined(__OpenBSD__)
+#include "hvt_openbsd.h"
+#endif
+
 static bool module_in_use;
 static struct mft *host_mft;
+static volatile int io_thread_stop;
+static hvt_gpa_t reserved_ring_gpa;
+
+void hvt_net_reserve_ring(struct hvt *hvt, struct mft *mft)
+{
+    /* A ring is allocated only if there is at least one network interface
+     * listed in the manifest. The ring is then used by all interfaces. */
+    for (unsigned i = 0; i != mft->entries; i++) {
+        if (mft->e[i].type == MFT_DEV_NET_BASIC && mft->e[i].attached) {
+            size_t ring_size = sizeof(struct hvt_ring);
+            hvt_gpa_t gpa_ring = (hvt->guest_mem_size - ring_size) & ~0xFFFULL;
+
+            if (gpa_ring < 0x200000) {
+                warnx("Not enough guest memory for ring allocation");
+                return;
+            }
+
+            memset(hvt->mem + gpa_ring, 0, ring_size);
+            reserved_ring_gpa = gpa_ring;
+            hvt->guest_mem_size = gpa_ring;
+            return;
+        }
+    }
+}
 
 static void hypercall_net_write(struct hvt *hvt, hvt_gpa_t gpa)
 {

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -59,6 +59,15 @@ static struct mft *host_mft;
 static volatile int io_thread_stop;
 static hvt_gpa_t reserved_ring_gpa;
 
+size_t hvt_net_mem_overhead(struct mft *mft)
+{
+    for (unsigned i = 0; i != mft->entries; i++) {
+        if (mft->e[i].type == MFT_DEV_NET_BASIC && mft->e[i].attached)
+            return sizeof(struct hvt_ring);
+    }
+    return 0;
+}
+
 void hvt_net_reserve_ring(struct hvt *hvt, struct mft *mft)
 {
     /* A ring is allocated only if there is at least one network interface

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -438,6 +438,93 @@ static int setup(struct hvt *hvt, struct mft *mft)
         assert(hvt_core_register_pollfd(mft->e[i].b.hostfd, i) == 0);
     }
 
+    if (reserved_ring_gpa != 0) {
+        struct hvt_b *hvb = hvt->b;
+        struct hvt_ring *ring =
+            (struct hvt_ring *)(hvt->mem + reserved_ring_gpa);
+        hvb->net_ring_gpa = reserved_ring_gpa;
+        int notify_fd = -1;
+
+#if defined(__linux__)
+        if (!hvb->has_ioeventfd)
+            goto skip_ring;
+
+        int efd = eventfd(0, EFD_CLOEXEC);
+        if (efd == -1) {
+            warn("eventfd() failed, falling back to hypercalls");
+            goto skip_ring;
+        }
+        hvb->kick_net_efd = efd;
+
+        struct kvm_ioeventfd ioev = {
+            .datamatch = 0,
+#if defined(__x86_64__)
+            .addr = HVT_RING_KICK_PIO_BASE,
+            .len = 4,
+            .fd = efd,
+            .flags = KVM_IOEVENTFD_FLAG_PIO,
+#elif defined(__aarch64__)
+            .addr = HVT_RING_KICK_MMIO_BASE,
+            .len = 4,
+            .fd = efd,
+            .flags = 0,
+#endif
+        };
+
+        if (ioctl(hvb->vmfd, KVM_IOEVENTFD, &ioev) == -1) {
+            warn("KVM_IOEVENTFD failed, falling back to hypercalls");
+            close(efd);
+            hvb->kick_net_efd = -1;
+            goto skip_ring;
+        }
+        notify_fd = efd;
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+        if (pipe(hvb->kick_net_pipe) == -1) {
+            warn("pipe() failed, falling back to hypercalls");
+            goto skip_ring;
+        }
+        notify_fd = hvb->kick_net_pipe[0];
+#endif
+
+        struct io_thread_arg *ta = malloc(sizeof(*ta));
+        if (ta == NULL)
+            err(1, "malloc");
+
+        ta->hvt = hvt;
+        ta->ring = ring;
+        ta->notify_fd = notify_fd;
+        ta->ready = 0;
+        io_thread_stop = 0;
+
+        if (pthread_create(&hvb->io_thread_net, NULL, io_thread_net_fn, ta) !=
+            0) {
+            warn("pthread_create() failed, falling back to hypercalls");
+            free(ta);
+#if defined(__linux__)
+            close(hvb->kick_net_efd);
+            hvb->kick_net_efd = -1;
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+            close(hvb->kick_net_pipe[0]);
+            close(hvb->kick_net_pipe[1]);
+            hvb->kick_net_pipe[0] = -1;
+            hvb->kick_net_pipe[1] = -1;
+#endif
+            goto skip_ring;
+        }
+
+        /*
+         * Wait for the I/O thread to signal that it is fully initialized.
+         * This ensures all pthread runtime setup (TLS, stack, libc internals)
+         * completes before hvt_drop_privileges() restricts syscalls via
+         * pledge() on OpenBSD.
+         */
+        while (!ta->ready)
+            ;
+
+        assert(hvt_core_register_halt_hook(kill_net_pthread) == 0);
+    skip_ring:;
+    }
+
 #if HVT_FREEBSD_ENABLE_CAPSICUM
     cap_rights_t rights;
     cap_rights_init(&rights, CAP_EVENT, CAP_WRITE, CAP_READ);

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -136,6 +136,224 @@ static void hypercall_net_read(struct hvt *hvt, hvt_gpa_t gpa)
     rd->ret = SOLO5_R_OK;
 }
 
+struct io_thread_arg {
+    struct hvt *hvt;
+    struct hvt_ring *ring;
+    int notify_fd;
+    volatile int ready; /* set by the I/O thread once fully initialized */
+};
+
+/* Process a NET_READ submission entry. Reads directly from the TAP fd into
+ * guest memory and posts a commit.
+ */
+static inline void process_read_entry(struct hvt *hvt, struct hvt_ring *ring,
+                                      struct hvt_ring_entry *ent)
+{
+    uint32_t commit_idx = ring->com_tail & HVT_RING_MASK;
+    struct hvt_ring_commit *commit = &ring->commits[commit_idx];
+
+    commit->id = ent->id;
+
+    struct mft_entry *e =
+        mft_get_by_index(host_mft, ent->handle, MFT_DEV_NET_BASIC);
+
+    if (e == NULL) {
+        commit->ret = SOLO5_R_EINVAL;
+        commit->len = 0;
+    } else {
+        void *data = HVT_CHECKED_GPA_P(hvt, ent->data, ent->len);
+        ssize_t nr = read(e->b.hostfd, data, ent->len);
+
+        if (nr == 0 || (nr == -1 && errno == EAGAIN)) {
+            commit->ret = SOLO5_R_AGAIN;
+            commit->len = 0;
+        } else if (nr > 0) {
+            commit->ret = SOLO5_R_OK;
+            commit->len = nr;
+        } else {
+            commit->ret = SOLO5_R_EINVAL;
+            commit->len = 0;
+        }
+    }
+
+    hvt_wmb();
+    ring->com_tail++;
+    ring->ent_head++;
+}
+
+/*
+ * Process all pending ring commits with batched ent_head updates for
+ * consecutive writes. For N consecutive NET_WRITE entries, only a single
+ * hvt_wmb() + ent_head update is issued instead of N.
+ */
+static inline void process_ring_commits(struct hvt *hvt, struct hvt_ring *ring)
+{
+    /*
+     * Snapshot ent_tail after the caller's hvt_rmb(). On aarch64 (weakly
+     * ordered), re-reading the volatile ent_tail inside the loop would let
+     * the CPU observe a new tail value without a barrier, potentially
+     * loading stale entry data for entries the guest just submitted.
+     * Snapshotting avoids this: every entry up to tail_snap is guaranteed
+     * visible by the preceding hvt_rmb().
+     *
+     * On x86 (TSO) this is harmless, loads are never reordered with loads.
+     */
+    uint32_t tail_snap = ring->ent_tail;
+
+    while (ring->ent_head != tail_snap) {
+        uint32_t batch_start = ring->ent_head;
+        uint32_t processed = 0;
+
+        /* Batch consecutive NET_WRITE entries */
+        while (ring->ent_head + processed != tail_snap) {
+            uint32_t idx = (batch_start + processed) & HVT_RING_MASK;
+            struct hvt_ring_entry *ent = &ring->entries[idx];
+
+            if (ent->operation == HVT_RING_NET_WRITE) {
+                struct mft_entry *e =
+                    mft_get_by_index(host_mft, ent->handle, MFT_DEV_NET_BASIC);
+
+                if (e != NULL) {
+                    void *data = HVT_CHECKED_GPA_P(hvt, ent->data, ent->len);
+                    ssize_t ret = write(e->b.hostfd, data, ent->len);
+                    if (ret == -1)
+                        err(1, "Fatal write error on net device");
+                    if ((size_t)ret != ent->len)
+                        errx(1,
+                             "Fatal write error: wrote only %zd"
+                             " out of %u bytes",
+                             ret, ent->len);
+                }
+                processed++;
+            } else if (ent->operation == HVT_RING_NET_READ) {
+                /*
+                 * Flush the batch of writes before processing the read, which
+                 * requires an immediate completion.
+                 */
+                if (processed > 0) {
+                    hvt_wmb();
+                    ring->ent_head += processed;
+                    processed = 0;
+                }
+                process_read_entry(hvt, ring, ent);
+                break; /* re-evaluate the outer loop */
+            } else {
+                /* Unknown operation: include in the batch to skip */
+                processed++;
+            }
+        }
+
+        if (processed > 0) {
+            hvt_wmb();
+            ring->ent_head += processed;
+        }
+    }
+}
+
+static void *io_thread_net_fn(void *arg)
+{
+    struct io_thread_arg *ta = arg;
+    struct hvt *hvt = ta->hvt;
+    struct hvt_ring *ring = ta->ring;
+    int nfd = ta->notify_fd;
+
+    /*
+     * Signal the main thread that this thread is fully initialized.
+     * On OpenBSD, hvt_drop_privileges() calls pledge("stdio vmm") after
+     * setup_modules() returns. We must ensure that all pthread runtime
+     * initialization (TLS, stack setup, etc.) has completed before pledge
+     * restricts the available syscalls.
+     */
+    ta->ready = 1;
+
+    while (!io_thread_stop) {
+        /* Adaptive polling: spin-poll the ring for new submissions before
+         * falling back to blocking on the notification fd. This eliminates the
+         * read() syscall overhead during sustained traffic bursts.
+         */
+        int found = 0;
+
+        for (int i = 0; i < HVT_RING_POLL_ITERS; i++) {
+            hvt_rmb();
+            if (ring->ent_head != ring->ent_tail) {
+                found = 1;
+                break;
+            }
+#if defined(__x86_64__)
+            __asm__ __volatile__("pause");
+#elif defined(__aarch64__)
+            __asm__ __volatile__("yield");
+#endif
+        }
+
+        if (!found) {
+            /*
+             * No work found after spinning. Set needs_kick so the guest knows
+             * to signal us, then check once more to avoid a race where the
+             * guest submitted between our last poll and setting the flag.
+             */
+            ring->needs_kick = 1;
+            hvt_mb();
+
+            if (ring->ent_head == ring->ent_tail) {
+                /* Truly idle: block on notification fd.
+                 * eventfd returns 8 bytes (KVM), pipe returns 1 byte
+                 * (FreeBSD/OpenBSD).
+                 */
+                uint64_t val;
+                ssize_t r = read(nfd, &val, sizeof(val));
+
+                if (r <= 0) {
+                    if (errno == EINTR)
+                        continue;
+                    break;
+                }
+            }
+
+            ring->needs_kick = 0;
+            hvt_wmb();
+        }
+
+        /*
+         * Process all pending submissions with batched ent_head updates.
+         */
+        hvt_rmb();
+        process_ring_commits(hvt, ring);
+    }
+
+    free(ta);
+    return NULL;
+}
+
+static void kill_net_pthread(struct hvt *hvt, int status, void *cookie)
+{
+    (void)status;
+    (void)cookie;
+    struct hvt_b *hvb = hvt->b;
+
+    io_thread_stop = 1;
+
+#if defined(__linux__)
+    if (hvb->kick_net_efd != -1) {
+        uint64_t val = 1;
+        (void)!write(hvb->kick_net_efd, &val, sizeof(val));
+        pthread_join(hvb->io_thread_net, NULL);
+        close(hvb->kick_net_efd);
+        hvb->kick_net_efd = -1;
+    }
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+    if (hvb->kick_net_pipe[1] != -1) {
+        uint8_t byte = 1;
+        (void)!write(hvb->kick_net_pipe[1], &byte, 1);
+        pthread_join(hvb->io_thread_net, NULL);
+        close(hvb->kick_net_pipe[0]);
+        close(hvb->kick_net_pipe[1]);
+        hvb->kick_net_pipe[0] = -1;
+        hvb->kick_net_pipe[1] = -1;
+    }
+#endif
+}
+
 static int handle_cmdarg(char *cmdarg, struct mft *mft)
 {
     enum { opt_net, opt_net_mac } which;

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -101,6 +101,8 @@ struct hvt *hvt_init(size_t mem_size)
 
     hvt->b = hvb;
     hvb->vmd_fd = -1;
+    hvb->kick_net_pipe[0] = -1;
+    hvb->kick_net_pipe[1] = -1;
 
     hvb->vmd_fd = open(VMM_NODE, O_RDWR);
     if (hvb->vmd_fd == -1)

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -131,7 +131,8 @@ struct hvt *hvt_init(size_t mem_size)
 
     vmr->vmr_va = (vaddr_t)p;
     hvt->mem = p;
-    hvt->mem_size = mem_size;
+    hvt->guest_mem_size = mem_size;
+    hvt->mem_alloc_size = mem_size;
 #endif
 
     if (ioctl(hvb->vmd_fd, VMM_IOC_CREATE, vcp) < 0)
@@ -139,7 +140,8 @@ struct hvt *hvt_init(size_t mem_size)
 
 #if OpenBSD > 202504
     hvt->mem = (uint8_t *)vmr->vmr_va;
-    hvt->mem_size = mem_size;
+    hvt->guest_mem_size = mem_size;
+    hvt->mem_alloc_size = mem_size;
 #endif
     hvb->vcp_id = vcp->vcp_id;
     hvb->vcpu_id = 0; // the first and only cpu is at 0
@@ -183,14 +185,14 @@ int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
 {
     struct hvt *hvt = t_arg;
 
-    assert(addr_start <= hvt->mem_size);
-    assert(addr_end <= hvt->mem_size);
+    assert(addr_start <= hvt->guest_mem_size);
+    assert(addr_end <= hvt->guest_mem_size);
     assert(addr_start < addr_end);
 
     uint8_t *vaddr_start = hvt->mem + addr_start;
     assert(vaddr_start >= hvt->mem);
     size_t size = addr_end - addr_start;
-    assert(size > 0 && size <= hvt->mem_size);
+    assert(size > 0 && size <= hvt->guest_mem_size);
 
 #if defined(VMM_IOC_MPROTECT_EPT)
     /*

--- a/tenders/hvt/hvt_openbsd.h
+++ b/tenders/hvt/hvt_openbsd.h
@@ -25,6 +25,8 @@
 #ifndef HVT_HV_OPENBSD_H
 #define HVT_HV_OPENBSD_H
 
+#include <pthread.h>
+
 #define VMM_NODE "/dev/vmm"
 #define VMD_USER "_vmd"
 
@@ -32,6 +34,11 @@ struct hvt_b {
     int vmd_fd;
     int32_t vcp_id;
     int32_t vcpu_id;
+
+    /* Ring I/O (pipe-based notification) */
+    int kick_net_pipe[2];
+    pthread_t io_thread_net;
+    hvt_gpa_t net_ring_gpa;
 };
 
 #endif /* HVT_HV_OPENBSD_H */

--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -98,6 +98,15 @@ void hvt_mem_size(size_t *mem_size)
     hvt_x86_mem_size(mem_size);
 }
 
+void hvt_mem_size_roundup(size_t *mem_size)
+{
+    size_t mem = ((*mem_size + X86_GUEST_PAGE_SIZE - 1) / X86_GUEST_PAGE_SIZE) *
+                 X86_GUEST_PAGE_SIZE;
+    if (mem > X86_GUEST_MAX_MEM_SIZE)
+        mem = X86_GUEST_MAX_MEM_SIZE;
+    *mem_size = mem;
+}
+
 void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
 {
     struct hvt_b *hvb = hvt->b;

--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -168,6 +168,15 @@ int hvt_vcpu_loop(struct hvt *hvt)
             switch (vrp->vrp_exit_reason) {
             case VMX_EXIT_IO:
             case SVM_VMEXIT_IOIO:
+                if (vei->vei.vei_port == HVT_RING_KICK_PIO_BASE &&
+                    vei->vei.vei_dir == VEI_DIR_OUT && vei->vei.vei_size == 4) {
+                    if (hvb->kick_net_pipe[1] != -1) {
+                        uint8_t byte = 1;
+                        write(hvb->kick_net_pipe[1], &byte, 1);
+                    }
+                    vei->vrs.vrs_gprs[VCPU_REGS_RIP] += vei->vei.vei_insn_len;
+                    break;
+                }
                 if (vei->vei.vei_dir != VEI_DIR_OUT || vei->vei.vei_size != 4)
                     errx(1, "Invalid guest port access: port=0x%x",
                          vei->vei.vei_port);

--- a/tenders/hvt/hvt_openbsd_x86_64.c
+++ b/tenders/hvt/hvt_openbsd_x86_64.c
@@ -108,7 +108,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
         .vrp_init_state = {
             .vrs_gprs[VCPU_REGS_RFLAGS] = X86_RFLAGS_INIT,
             .vrs_gprs[VCPU_REGS_RIP] = gpa_ep,
-            .vrs_gprs[VCPU_REGS_RSP] = hvt->mem_size - 8,
+            .vrs_gprs[VCPU_REGS_RSP] = hvt->guest_mem_size - 8,
             .vrs_gprs[VCPU_REGS_RDI] = X86_BOOT_INFO_BASE,
             .vrs_crs[VCPU_REGS_CR0] = X86_CR0_INIT,
             .vrs_crs[VCPU_REGS_CR3] = X86_CR3_INIT,
@@ -132,7 +132,7 @@ void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
             .vrs_crs[VCPU_REGS_XCR0] = XFEATURE_X87}};
 
     hvt_x86_setup_gdt(hvt->mem);
-    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_size);
+    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_alloc_size);
 
     hvt->cpu_cycle_freq = get_tsc_freq();
 

--- a/tests/test_net_ring/GNUmakefile
+++ b/tests/test_net_ring/GNUmakefile
@@ -1,0 +1,23 @@
+# Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+#
+# This file is part of Solo5, a sandboxed execution environment.
+#
+# Permission to use, copy, modify, and/or distribute this software
+# for any purpose with or without fee is hereby granted, provided
+# that the above copyright notice and this permission notice appear
+# in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+# AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+# CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+# OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+# CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+include $(TOPDIR)/Makefile.common
+
+test_NAME := test_net_ring
+
+include ../Makefile.tests

--- a/tests/test_net_ring/manifest.json
+++ b/tests/test_net_ring/manifest.json
@@ -1,0 +1,5 @@
+{
+    "type": "solo5.manifest",
+    "version": 1,
+    "devices": [ { "name": "service0", "type": "NET_BASIC" } ]
+}

--- a/tests/test_net_ring/test_net_ring.c
+++ b/tests/test_net_ring/test_net_ring.c
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * test_net_ring.c: Network data integrity test for ioeventfd ring I/O.
+ *
+ * This test acts as an ICMP echo server (like test_net) but additionally
+ * verifies the integrity of every received packet payload. The host side
+ * sends pings with a known repeating pattern (0xdeadbeef); the guest
+ * checks that every ICMP echo request carries that exact pattern.
+ *
+ * This exercises the ring-based I/O path (when ioeventfd is available)
+ * and catches data corruption that could result from ring index errors,
+ * missing barriers, or buffer management bugs.
+ */
+
+#include "solo5.h"
+#include "../../bindings/lib.c"
+
+static void puts(const char *s)
+{
+    solo5_console_write(s, strlen(s));
+}
+
+static void put_uint(unsigned long v)
+{
+    char buf[21];
+    int i = sizeof(buf) - 1;
+
+    buf[i] = '\0';
+    if (v == 0) {
+        buf[--i] = '0';
+    } else {
+        while (v > 0) {
+            buf[--i] = '0' + (v % 10);
+            v /= 10;
+        }
+    }
+    puts(&buf[i]);
+}
+
+#define ETHERTYPE_IP  0x0800
+#define ETHERTYPE_ARP 0x0806
+#define HLEN_ETHER    6
+#define PLEN_IPV4     4
+
+struct ether {
+    uint8_t target[HLEN_ETHER];
+    uint8_t source[HLEN_ETHER];
+    uint16_t type;
+};
+
+struct arp {
+    uint16_t htype;
+    uint16_t ptype;
+    uint8_t hlen;
+    uint8_t plen;
+    uint16_t op;
+    uint8_t sha[HLEN_ETHER];
+    uint8_t spa[PLEN_IPV4];
+    uint8_t tha[HLEN_ETHER];
+    uint8_t tpa[PLEN_IPV4];
+};
+
+struct ip {
+    uint8_t version_ihl;
+    uint8_t type;
+    uint16_t length;
+    uint16_t id;
+    uint16_t flags_offset;
+    uint8_t ttl;
+    uint8_t proto;
+    uint16_t checksum;
+    uint8_t src_ip[PLEN_IPV4];
+    uint8_t dst_ip[PLEN_IPV4];
+};
+
+struct ping {
+    uint8_t type;
+    uint8_t code;
+    uint16_t checksum;
+    uint16_t id;
+    uint16_t seqnum;
+    uint8_t data[0];
+};
+
+struct arppkt {
+    struct ether ether;
+    struct arp arp;
+};
+
+struct pingpkt {
+    struct ether ether;
+    struct ip ip;
+    struct ping ping;
+};
+
+static uint16_t checksum(uint16_t *addr, size_t count)
+{
+    register long sum = 0;
+
+    while (count > 1) {
+        sum += *(unsigned short *)addr++;
+        count -= 2;
+    }
+    if (count > 0)
+        sum += *(unsigned char *)addr;
+    while (sum >> 16)
+        sum = (sum & 0xffff) + (sum >> 16);
+    return ~sum;
+}
+
+static uint16_t htons(uint16_t x)
+{
+    return (x << 8) + (x >> 8);
+}
+
+static uint16_t ntohs(uint16_t x)
+{
+    return (x << 8) + (x >> 8);
+}
+
+/*
+ * The expected repeating 4-byte pattern.
+ * The host sends pings with: ping -p deadbeef
+ */
+static const uint8_t expected_pattern[4] = {0xde, 0xad, 0xbe, 0xef};
+
+static solo5_handle_t net_handle;
+static struct solo5_net_info net_info;
+static uint8_t ipaddr[4] = {0x0a, 0x00, 0x00, 0x02}; /* 10.0.0.2 */
+static uint8_t ipaddr_brd[4] = {0x0a, 0x00, 0x00, 0xff}; /* 10.0.0.255 */
+static uint8_t ipaddr_brdall[4] = {0xff, 0xff, 0xff, 0xff};
+static uint8_t macaddr_brd[HLEN_ETHER] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+static unsigned long n_verified = 0;
+static unsigned long n_corrupted = 0;
+
+/*
+ * Verify that the ICMP payload contains the expected repeating pattern.
+ * Returns true if the payload is correct or empty, false if corrupted.
+ */
+static bool verify_payload(uint8_t *payload, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        if (payload[i] != expected_pattern[i % 4])
+            return false;
+    }
+    return true;
+}
+
+static bool handle_arp(uint8_t *buf)
+{
+    struct arppkt *p = (struct arppkt *)buf;
+
+    if (p->arp.htype != htons(1))
+        return false;
+    if (p->arp.ptype != htons(ETHERTYPE_IP))
+        return false;
+    if (p->arp.hlen != HLEN_ETHER || p->arp.plen != PLEN_IPV4)
+        return false;
+    if (p->arp.op != htons(1))
+        return false;
+    if (memcmp(p->arp.tpa, ipaddr, PLEN_IPV4))
+        return false;
+
+    memcpy(p->ether.target, p->ether.source, HLEN_ETHER);
+    memcpy(p->ether.source, net_info.mac_address, HLEN_ETHER);
+    memcpy(p->arp.tha, p->arp.sha, HLEN_ETHER);
+    memcpy(p->arp.sha, net_info.mac_address, HLEN_ETHER);
+    p->arp.op = htons(2);
+    memcpy(p->arp.tpa, p->arp.spa, PLEN_IPV4);
+    memcpy(p->arp.spa, ipaddr, PLEN_IPV4);
+    return true;
+}
+
+static bool handle_ip(uint8_t *buf)
+{
+    struct pingpkt *p = (struct pingpkt *)buf;
+
+    if (p->ip.version_ihl != 0x45)
+        return false;
+    if (p->ip.proto != 0x01)
+        return false;
+    if (memcmp(p->ip.dst_ip, ipaddr, PLEN_IPV4) &&
+        memcmp(p->ip.dst_ip, ipaddr_brd, PLEN_IPV4) &&
+        memcmp(p->ip.dst_ip, ipaddr_brdall, PLEN_IPV4))
+        return false;
+    if (p->ping.type != 0x08 || p->ping.code != 0x00)
+        return false;
+
+    /*
+     * Verify payload integrity: the ICMP data starts after the ping header.
+     * ping(8) prepends an 8-byte timestamp before the pattern, so we skip
+     * that.
+     */
+    size_t ip_total = ntohs(p->ip.length);
+    size_t icmp_len = ip_total - sizeof(struct ip);
+    size_t ping_hdr = sizeof(struct ping);
+    /*
+     * ping(8) prepends a struct timeval to the ICMP data.
+     * On 64-bit systems, struct timeval is 16 bytes (two longs).
+     */
+    size_t timestamp_len = 16;
+
+    if (icmp_len > ping_hdr + timestamp_len) {
+        size_t payload_off = ping_hdr + timestamp_len;
+        size_t payload_len = icmp_len - payload_off;
+        uint8_t *payload = (uint8_t *)&p->ping + payload_off;
+
+        if (!verify_payload(payload, payload_len)) {
+            n_corrupted++;
+            puts("CORRUPT: packet ");
+            put_uint(n_verified + n_corrupted);
+            puts(" payload mismatch at byte\n");
+            return false;
+        }
+    }
+
+    n_verified++;
+
+    /* Build echo reply */
+    memcpy(p->ether.target, p->ether.source, HLEN_ETHER);
+    memcpy(p->ether.source, net_info.mac_address, HLEN_ETHER);
+    p->ip.id = 0;
+    p->ip.flags_offset = 0;
+    memcpy(p->ip.dst_ip, p->ip.src_ip, PLEN_IPV4);
+    memcpy(p->ip.src_ip, ipaddr, PLEN_IPV4);
+    p->ip.checksum = 0;
+    p->ip.checksum = checksum((uint16_t *)&p->ip, sizeof(struct ip));
+    p->ping.type = 0x00;
+    p->ping.checksum = 0;
+    p->ping.checksum =
+        checksum((uint16_t *)&p->ping, ntohs(p->ip.length) - sizeof(struct ip));
+
+    return true;
+}
+
+static void send_garp(void)
+{
+    struct arppkt p;
+    uint8_t zero[HLEN_ETHER] = {0};
+
+    memcpy(p.ether.source, net_info.mac_address, HLEN_ETHER);
+    memcpy(p.ether.target, macaddr_brd, HLEN_ETHER);
+    p.ether.type = htons(ETHERTYPE_ARP);
+    p.arp.htype = htons(1);
+    p.arp.ptype = htons(ETHERTYPE_IP);
+    p.arp.hlen = HLEN_ETHER;
+    p.arp.plen = PLEN_IPV4;
+    p.arp.op = htons(1);
+    memcpy(p.arp.sha, net_info.mac_address, HLEN_ETHER);
+    memcpy(p.arp.tha, zero, HLEN_ETHER);
+    memcpy(p.arp.spa, ipaddr, PLEN_IPV4);
+    memcpy(p.arp.tpa, ipaddr, PLEN_IPV4);
+
+    solo5_net_write(net_handle, (uint8_t *)&p, sizeof p);
+}
+
+static const solo5_time_t NSEC_PER_SEC = 1000000000ULL;
+
+#define TARGET_PINGS 10000
+
+int solo5_app_main(const struct solo5_start_info *si)
+{
+    (void)si;
+
+    puts("\n**** Solo5 test_net_ring: ioeventfd data integrity ****\n\n");
+
+    if (solo5_net_acquire("service0", &net_handle, &net_info) != SOLO5_R_OK) {
+        puts("Could not acquire 'service0' network\n");
+        puts("FAILURE\n");
+        return SOLO5_EXIT_FAILURE;
+    }
+
+    send_garp();
+
+    puts("Serving ping on 10.0.0.2, verifying payload pattern 0xdeadbeef\n");
+    puts("Target: ");
+    put_uint(TARGET_PINGS);
+    puts(" verified packets\n");
+
+    while (n_verified < TARGET_PINGS) {
+        solo5_handle_set_t ready_set = 0;
+        uint8_t buf[net_info.mtu + SOLO5_NET_HLEN];
+        size_t len;
+
+        solo5_yield(solo5_clock_monotonic() + NSEC_PER_SEC, &ready_set);
+        if (!(ready_set & (1U << net_handle)))
+            continue;
+
+        solo5_result_t result =
+            solo5_net_read(net_handle, buf, sizeof buf, &len);
+        if (result != SOLO5_R_OK)
+            continue;
+
+        struct ether *p = (struct ether *)buf;
+
+        if (memcmp(p->target, net_info.mac_address, HLEN_ETHER) &&
+            memcmp(p->target, macaddr_brd, HLEN_ETHER))
+            continue;
+
+        bool handled = false;
+        switch (htons(p->type)) {
+        case ETHERTYPE_ARP:
+            handled = handle_arp(buf);
+            break;
+        case ETHERTYPE_IP:
+            handled = handle_ip(buf);
+            break;
+        default:
+            break;
+        }
+
+        if (handled) {
+            if (solo5_net_write(net_handle, buf, len) != SOLO5_R_OK) {
+                puts("Write error\n");
+                puts("FAILURE\n");
+                return SOLO5_EXIT_FAILURE;
+            }
+        }
+
+        if (n_corrupted > 0) {
+            puts("Data corruption detected after ");
+            put_uint(n_verified);
+            puts(" good packets, ");
+            put_uint(n_corrupted);
+            puts(" corrupted\n");
+            puts("FAILURE\n");
+            return SOLO5_EXIT_FAILURE;
+        }
+    }
+
+    puts("Verified ");
+    put_uint(n_verified);
+    puts(" packets, 0 corrupted\n");
+    puts("SUCCESS\n");
+    return SOLO5_EXIT_SUCCESS;
+}

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -673,6 +673,23 @@ xen_expect_abort() {
   virtio_expect_success
 }
 
+@test "net_ring hvt" {
+  skip_unless_root
+  skip_unless_host_is Linux
+
+  ( sleep 1; ${TIMEOUT} 60s ping -fq -c 10000 -p deadbeef ${NET0_IP} ) &
+  hvt_run --net:service0=${NET0} -- test_net_ring/test_net_ring.hvt
+  expect_success
+}
+
+@test "net_ring spt" {
+  skip_unless_root
+
+  ( sleep 1; ${TIMEOUT} 60s ping -fq -c 10000 -p deadbeef ${NET0_IP} ) &
+  spt_run --net:service0=${NET0} -- test_net_ring/test_net_ring.spt
+  expect_success
+}
+
 @test "dumpcore hvt" {
   [ "${CONFIG_HOST_ARCH}" = "x86_64" ] || skip "not implemented for ${CONFIG_HOST_ARCH}"
   skip_unless_host_is Linux FreeBSD


### PR DESCRIPTION
Here is an initial attempt to optimise our unikernels with regard to hvt. To fully understand the original problem: every time we want to write an Ethernet frame, our execution path is as follows:
1) we prepare a value
2) we write using `out`; this is a VM-exit
3) we are in the tender’s address space and execute `read()`
3) we prepare the result
4) we return to the VM

What is **very** costly here is the VM-exit (`out`), which significantly degrades our performance if we run a ‘fair’ benchmark comparison with VirtIO.

## Overview

The idea behind this PR is to offer something very similar to what VirtIO can provide with Virtqueues. It therefore involves implementing queues that are shared between the host and the guest so that they can exchange information.
In this case, the guest sends “entries”, which are actions the host must perform (read from and write to a network interface), and the host sends confirmation of these actions along with the result. In our case, we are only interested in the result of the read operation. Initially, Solo5 would only return SOLO5_R_OK or fail when writing:

https://github.com/Solo5/solo5/blob/a333cbb20152ecfad9bfd4957aa7f8b237408600/tenders/hvt/hvt_module_net.c#L46-L70

To enable the guest to transmit information to the host, we must be mindful of certain barriers (as was the case with VirtIO, #630) and there may be instances where we wish to “kick” our host’s thread.

Indeed, our host may be in a state of waiting for entries (the unikernel has not sent any entries). In this case, the thread goes to sleep whilst reading a file descriptor. As regards KVM, this file descriptor is derived from ioeventfd (it is a file descriptor that can be associated with a specific memory address). As regards OpenBSD and FreeBSD, this file descriptor is one derived from pipe() (thanks to @haesbaert for giving me the tip already present in Miou).

If our thread is waiting, it updates a shared variable called needs_kick. If the unikernel sees this value set to 1, it performs a VM-exit to wake up the host thread. On KVM, this VM-exit is inexpensive as KVM handles it directly. On OpenBSD/FreeBSD, there will be a proper VM-exit which involves writing to the other end of our pipe().

As for the unikernel, since we have very little available in this space, I chose to statically allocate what is necessary for our “ring”. In this case, when a unikernel wishes to write, we need to “hold” its buffer. This buffer will only become available after our host thread has written it to the interface. Once again, we’re not interested in write confirmation. So we’ll simply attempt to write until the queue is full. The buffers are allocated via the .bss segment.

The ring is a bit special, however. It must exist for the guest but also for the host. The idea is to reserve an area just before the stack. This is why there are now guest_mem_size and mem_alloc_size. The first refers to what the unikernel can use and where the stack must start. The second refers to everything allocated for the guest (which includes what is needed for our ring). Thus, a unikernel requesting 512MB will only have 510MB (as the ring takes up 2MB). The ring is only allocated if a network interface is present.

Since the buffers are statically allocated, there is a scenario where the user might wish to configure the MTU to more than 2048 bytes (the maximum size of a buffer that can be written). In this case, we ‘fall back’ to the hypercall scenario and therefore perform a VM-exit. Furthermore, increasing the MTU will therefore tend to degrade performance.

## Benchmark

It should be noted first of all that the performance gain is specifically observable on Linux. I haven’t run any benchmarks on FreeBSD/OpenBSD, but I think there must still be a gain. Here is a benchmark using IPerf3 without that pull request:
```
Connecting to host 10.0.0.2, port 5201
[  6] local 10.0.0.1 port 36664 connected to 10.0.0.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  6]   0.00-1.00   sec  80.1 MBytes   671 Mbits/sec    0    178 KBytes       
[  6]   1.00-2.00   sec  86.0 MBytes   721 Mbits/sec    0    178 KBytes       
[  6]   2.00-3.00   sec  85.0 MBytes   713 Mbits/sec    0    178 KBytes       
[  6]   3.00-4.00   sec  82.2 MBytes   690 Mbits/sec    0    178 KBytes       
[  6]   4.00-5.00   sec  83.5 MBytes   700 Mbits/sec    0    178 KBytes       
[  6]   5.00-6.00   sec  84.9 MBytes   712 Mbits/sec    0    178 KBytes       
[  6]   6.00-7.00   sec  85.2 MBytes   715 Mbits/sec    0    178 KBytes       
[  6]   7.00-8.00   sec  80.5 MBytes   675 Mbits/sec    0    178 KBytes       
[  6]   8.00-9.00   sec  83.1 MBytes   697 Mbits/sec    0    178 KBytes       
[  6]   9.00-10.00  sec  85.6 MBytes   718 Mbits/sec    0    178 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  6]   0.00-10.00  sec   836 MBytes   701 Mbits/sec    0            sender
[  6]   0.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  receiver

iperf Done.
```

And here is the result with this PR:
```
Connecting to host 10.0.0.2, port 5201
[  6] local 10.0.0.1 port 46470 connected to 10.0.0.2 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  6]   0.00-1.00   sec   254 MBytes  2.13 Gbits/sec    0    178 KBytes       
[  6]   1.00-2.00   sec   261 MBytes  2.19 Gbits/sec    0    178 KBytes       
[  6]   2.00-3.00   sec   262 MBytes  2.20 Gbits/sec    0    178 KBytes       
[  6]   3.00-4.00   sec   258 MBytes  2.17 Gbits/sec    0    178 KBytes       
[  6]   4.00-5.00   sec   260 MBytes  2.18 Gbits/sec    0    178 KBytes       
[  6]   5.00-6.00   sec   252 MBytes  2.12 Gbits/sec    0    178 KBytes       
[  6]   6.00-7.00   sec   256 MBytes  2.14 Gbits/sec    0    178 KBytes       
[  6]   7.00-8.00   sec   263 MBytes  2.20 Gbits/sec    0    178 KBytes       
[  6]   8.00-9.00   sec   257 MBytes  2.16 Gbits/sec    0    178 KBytes       
[  6]   9.00-10.00  sec   242 MBytes  2.03 Gbits/sec    0    178 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  6]   0.00-10.00  sec  2.50 GBytes  2.15 Gbits/sec    0            sender
[  6]   0.00-10.00  sec  0.00 Bytes  0.00 bits/sec                  receiver

iperf Done.
```

As you can see, the performance gain is quite significant. It is based on our implementation of `mnet` and `mkernel`. The IPerf3 code is available [here](https://git.robur.coop/robur/iperf3). I haven’t carried out a comparison with `mirage-tcpip`, however (there may be issues relating to the scheduler, particularly between Miou/`mkernel` and `lwt`).

## Tests

A test has been added to verify the integrity of the data transmitted over the network. In theory, the test could work perfectly well without this PR (it simply sends a ping with data), but I wanted to check that, under high load, I wasn’t misinterpreting the indices and buffers.

## Improvements

The number of comments is inversely proportional to my confidence in the code. In this case, there are a lot of comments. I hope the code is sufficiently documented, but above all it needs to be tested. In short, it’s a major change, but I think it’s definitely worth it to close the performance gap between hvt and VirtIO or Xen.