### PR TITLE
Port Solo5 to DragonFly BSD and nvmm

### DIFF
--- a/.github/workflows/dragonfly.yml
+++ b/.github/workflows/dragonfly.yml
@@ -16,8 +16,11 @@ jobs:
         with:
           usesh: true
           prepare: |
-            pkg install -y gmake git llvm18
+            pkg install -y gmake git llvm18 gcc9
           run: |
             git config --global --add safe.directory /home/runner/work/solo5/solo5
             env TARGET_LD=ld.lld18 TARGET_CC=clang18 ./configure.sh
+            gmake
+            gmake clean
+            env TARGET_CC=gcc9 ./configure.sh
             gmake

--- a/.github/workflows/dragonfly.yml
+++ b/.github/workflows/dragonfly.yml
@@ -1,0 +1,23 @@
+name: DragonFly
+on: [push, pull_request]
+jobs:
+  Build:
+    name: AMD64
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+    runs-on: ${{ matrix.operating-system }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: DragonFly action
+        id: test
+        uses: vmactions/dragonflybsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y gmake git llvm18
+          run: |
+            git config --global --add safe.directory /home/runner/work/solo5/solo5
+            env TARGET_LD=ld.lld18 TARGET_CC=clang18 ./configure.sh
+            gmake

--- a/configure.sh
+++ b/configure.sh
@@ -502,6 +502,14 @@ case ${CONFIG_HOST} in
     DragonFly)
         TARGET_LD="${TARGET_LD:-ld}"
         TARGET_OBJCOPY="${TARGET_OBJCOPY:-objcopy}"
+        TARGET_CC="${TARGET_CC:-cc}"
+        if CC="${TARGET_CC}" cc_is_gcc; then
+            major_version=$(echo __GNUC__ | ${TARGET_CC} -E -x c - | tail -n 1)
+            if [ "${major_version}" -lt 9 ]; then
+                err "gcc version ${major_version} of ${TARGET_CC} unsupported on DragonFly"
+                die "gcc 9+ or clang required on DragonFly"
+            fi
+        fi
         ;;
     *)
         die "Unsupported host system: ${CONFIG_HOST}"

--- a/configure.sh
+++ b/configure.sh
@@ -281,6 +281,10 @@ case ${HOST_CC_MACHINE} in
         CONFIG_HOST_ARCH=x86_64 CONFIG_HOST=FreeBSD
         CONFIG_HVT_TENDER=1
         ;;
+    x86_64-*dragonfly*)
+        CONFIG_HOST_ARCH=x86_64 CONFIG_HOST=DragonFly
+        CONFIG_HVT_TENDER=1
+        ;;
     amd64-*openbsd*)
         CONFIG_HOST_ARCH=x86_64 CONFIG_HOST=OpenBSD
         CONFIG_HVT_TENDER=1
@@ -494,6 +498,10 @@ case ${CONFIG_HOST} in
         TARGET_CC_LDFLAGS="-Wl,-nopie,--no-execute-only"
         TARGET_LD_LDFLAGS="-nopie --no-execute-only"
         TARGET_CC_CFLAGS="${TARGET_CC_CFLAGS} -fno-emulated-tls"
+        ;;
+    DragonFly)
+        TARGET_LD="${TARGET_LD:-ld}"
+        TARGET_OBJCOPY="${TARGET_OBJCOPY:-objcopy}"
         ;;
     *)
         die "Unsupported host system: ${CONFIG_HOST}"

--- a/docs/building.md
+++ b/docs/building.md
@@ -18,7 +18,7 @@ unikernel -- about building Solo5, and running Solo5-based unikernels.
 
 Solo5 itself has the following build dependencies:
 
-* a 64-bit Linux, FreeBSD or OpenBSD system (see also [Supported
+* a 64-bit Linux, FreeBSD, OpenBSD or DragonFly system (see also [Supported
   targets](#supported-targets) for further requirements),
 * a C11 compiler; recent versions of GCC and clang are supported,
 * GNU make,
@@ -73,6 +73,8 @@ Experimental:
 * _hvt_: OpenBSD vmm, using `solo5-hvt` as a _tender_, on the x86\_64
   architecture.  OpenBSD 6.4 or later is required, 6.7 or later is recommended
   for full W^X support.
+* _hvt_: DragonFly nvmm, using `solo5-hvt` as a _tender_, on the x86\_64
+  architecture.  DragonFly 6.4 or later is recommended.
 * _spt_: Linux systems on the x86\_64, ppc64le and aarch64 architectures, using
   `solo5-spt` as a _tender_. A Linux distribution with libseccomp >= 2.3.3 is
   required.
@@ -181,10 +183,10 @@ ifconfig tap100 inet 10.0.0.1 netmask 255.255.255.0
 In case your unikernel needs to access internet (which is not the case in this
 example), you may need to add "ip forwarding" and a NAT to your host system.
 
-## _hvt_: Running on Linux, FreeBSD and OpenBSD with hardware virtualization
+## _hvt_: Running on Linux, FreeBSD, OpenBSD and DragonFly with hardware virtualization
 
-The _hvt_ ("hardware virtualized tender") target supports Linux, FreeBSD and
-OpenBSD systems and uses hardware virtualization to isolate the guest
+The _hvt_ ("hardware virtualized tender") target supports Linux, FreeBSD,
+OpenBSD and DragonFly systems and uses hardware virtualization to isolate the guest
 unikernel.
 
 On Linux, the `solo5-hvt` _tender_ only requires access to `/dev/kvm` and
@@ -199,6 +201,8 @@ _tender_ in order to access the `vmm` APIs.
 On OpenBSD, the `solo5-hvt` _tender_ must be started as `root`, however it will
 drop privileges to the standard `_vmd` user and further use `pledge(2)` to
 lower its privileges.
+
+On DragonFly, the `solo5-hvt` _tender_ only requires `nvmm` group membership.
 
 To launch the unikernel, in `tests/test_net/` run:
 

--- a/tenders/GNUmakefile
+++ b/tenders/GNUmakefile
@@ -81,6 +81,10 @@ else ifeq ($(CONFIG_HOST), OpenBSD)
     hvt_SRCS += hvt/hvt_openbsd.c hvt/hvt_openbsd_$(CONFIG_HOST_ARCH).c
     all_TARGETS += hvt/solo5-hvt
     HOSTLDLIBS += -lpthread
+else ifeq ($(CONFIG_HOST), DragonFly)
+    hvt_SRCS += hvt/hvt_dragonfly.c hvt/hvt_dragonfly_$(CONFIG_HOST_ARCH).c
+    all_TARGETS += hvt/solo5-hvt
+    HOSTLDLIBS += -lpthread -lnvmm
 endif
 
 hvt_SRCS += $(patsubst %,hvt/hvt_module_%.c,$(hvt_MODULES))

--- a/tenders/common/tap_attach.c
+++ b/tenders/common/tap_attach.c
@@ -46,7 +46,7 @@
 #include <linux/ethtool.h>
 #include <linux/sockios.h>
 
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 
 #include <net/if.h>
 
@@ -161,7 +161,7 @@ int tap_attach(const char *ifname, int *mtu)
         return -1;
     }
 
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 
     /*
      * Avoid unused-but-set-variable warning on FreeBSD, where the tap device

--- a/tenders/hvt/hvt_boot_info.c
+++ b/tenders/hvt/hvt_boot_info.c
@@ -36,6 +36,8 @@
 #include "hvt_freebsd.h"
 #elif defined(__OpenBSD__)
 #include "hvt_openbsd.h"
+#elif defined(__DragonFly__)
+#include "hvt_dragonfly.h"
 #endif
 
 static void setup_cmdline(uint8_t *cmdline, int argc, char **argv)
@@ -99,7 +101,7 @@ void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
         int ring_active = 0;
 #if defined(__linux__)
         ring_active = hvb->has_ioeventfd && hvb->kick_net_efd != -1;
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
         ring_active = hvb->kick_net_pipe[0] != -1;
 #endif
         if (ring_active) {

--- a/tenders/hvt/hvt_core.c
+++ b/tenders/hvt/hvt_core.c
@@ -42,7 +42,7 @@
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
 
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 
 #include <sys/types.h>
 #include <sys/event.h>

--- a/tenders/hvt/hvt_dragonfly.c
+++ b/tenders/hvt/hvt_dragonfly.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * hvt_dragonfly.c: Architecture-independent part of DragonFly nvmm(4) backend
+ * implementation.
+ */
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define _WITH_DPRINTF
+#include <stdio.h>
+
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <nvmm.h>
+#include <sys/param.h>
+
+#include "hvt.h"
+#include "hvt_dragonfly.h"
+
+struct hvt *hvt_init(size_t mem_size)
+{
+    struct hvt *hvt = malloc(sizeof(struct hvt));
+    if (hvt == NULL)
+        err(EXIT_FAILURE, "malloc");
+    memset(hvt, 0, sizeof(struct hvt));
+
+    struct hvt_b *hvb = malloc(sizeof(struct hvt_b));
+    if (hvb == NULL)
+        err(EXIT_FAILURE, "malloc");
+    memset(hvb, 0, sizeof(struct hvt_b));
+
+    hvt->b = hvb;
+    hvb->kick_net_pipe[0] = -1;
+    hvb->kick_net_pipe[1] = -1;
+
+    if (nvmm_init() == -1)
+        err(EXIT_FAILURE, "unable to init nvmm");
+
+    if (nvmm_machine_create(&hvb->mach) == -1)
+        err(EXIT_FAILURE, "unable to create nvmm machine");
+
+    if (nvmm_vcpu_create(&hvb->mach, 0, &hvb->vcpu) == -1)
+        err(EXIT_FAILURE, "unable to create vcpu");
+
+    hvt->mem = mmap(NULL, mem_size, PROT_READ | PROT_WRITE,
+                    MAP_ANON | MAP_PRIVATE, -1, 0);
+    if (hvt->mem == MAP_FAILED)
+        err(EXIT_FAILURE, "unable to mmap");
+    hvt->guest_mem_size = mem_size;
+    hvt->mem_alloc_size = mem_size;
+
+    if (nvmm_hva_map(&hvb->mach, (uintptr_t)hvt->mem, mem_size) == -1)
+        err(EXIT_FAILURE, "unable to map HVA");
+
+    if (nvmm_gpa_map(&hvb->mach, (uintptr_t)hvt->mem, 0, mem_size,
+                     PROT_READ | PROT_WRITE | PROT_EXEC) == -1)
+        err(EXIT_FAILURE, "unable to map GPA");
+
+    return hvt;
+}
+
+#if HVT_DROP_PRIVILEGES
+void hvt_drop_privileges()
+{
+}
+#endif
+
+int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
+                       int prot)
+{
+    struct hvt *hvt = t_arg;
+
+    assert(addr_start <= hvt->guest_mem_size);
+    assert(addr_end <= hvt->guest_mem_size);
+    assert(addr_start < addr_end);
+
+    uint8_t *vaddr_start = hvt->mem + addr_start;
+    assert(vaddr_start >= hvt->mem);
+    size_t size = addr_end - addr_start;
+    assert(size > 0 && size <= hvt->guest_mem_size);
+
+    /*
+     * Host-side page protections:
+     *
+     * Ensure that guest-executable pages are not also executable but are
+     * readable in the host.
+     *
+     * Guest-side page protections:
+     *
+     * Manipulating guest-side (EPT) mappings is currently not supported by
+     * DragonFly nvmm, so there is nothing more we can do.
+     */
+    if (prot & PROT_EXEC) {
+        prot &= ~(PROT_EXEC);
+        prot |= PROT_READ;
+    }
+    return mprotect(vaddr_start, size, prot);
+}

--- a/tenders/hvt/hvt_dragonfly.h
+++ b/tenders/hvt/hvt_dragonfly.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * hvt_dragonfly.h: DragonFly nvmm(4) backend definitions.
+ */
+
+#ifndef HVT_HV_DRAGONFLY_H
+#define HVT_HV_DRAGONFLY_H
+
+#include <nvmm.h>
+#include <pthread.h>
+
+struct hvt_b {
+    struct nvmm_machine mach;
+    struct nvmm_vcpu vcpu;
+
+    /* Ring I/O (pipe-based notification) */
+    int kick_net_pipe[2];
+    pthread_t io_thread_net;
+    hvt_gpa_t net_ring_gpa;
+};
+
+#endif /* HVT_HV_DRAGONFLY_H */

--- a/tenders/hvt/hvt_dragonfly_x86_64.c
+++ b/tenders/hvt/hvt_dragonfly_x86_64.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * hvt_dragonfly_x86_64.c: x86_64 architecture-dependent part of DragonFly
+ * nvmm(4) backend implementation.
+ */
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <nvmm.h>
+
+#include "hvt.h"
+#include "hvt_dragonfly.h"
+#include "hvt_cpu_x86_64.h"
+
+static struct hvt *global_hvt;
+static int exitcode = 0;
+static int halted = 0;
+
+static void io_callback(struct nvmm_io *io)
+{
+    struct hvt_b *hvb = global_hvt->b;
+
+    if (io->port == HVT_RING_KICK_PIO_BASE && !io->in && io->size == 4) {
+        if (hvb->kick_net_pipe[1] != -1) {
+            uint8_t byte = 1;
+            write(hvb->kick_net_pipe[1], &byte, 1);
+        }
+        return;
+    }
+    if (io->in || io->size != 4)
+        errx(EXIT_FAILURE, "Invalid guest port access: port=0x%x", io->port);
+    if (io->port < HVT_HYPERCALL_PIO_BASE ||
+        io->port >= (HVT_HYPERCALL_PIO_BASE + HVT_HYPERCALL_MAX))
+        errx(EXIT_FAILURE, "Invalid guest port access: port=0x%x", io->port);
+
+    int nr = io->port - HVT_HYPERCALL_PIO_BASE;
+
+    hvt_gpa_t gpa = io->vcpu->state->gprs[NVMM_X64_GPR_RAX];
+
+    /* Guest has halted the CPU. */
+    if (nr == HVT_HYPERCALL_HALT) {
+        exitcode = hvt_core_hypercall_halt(global_hvt, gpa);
+        halted = 1;
+        return;
+    }
+
+    hvt_hypercall_fn_t fn = hvt_core_hypercalls[nr];
+    if (fn == NULL)
+        errx(EXIT_FAILURE, "Invalid guest hypercall: num=%d", nr);
+
+    fn(global_hvt, gpa);
+}
+
+static struct nvmm_assist_callbacks callbacks = {.io = io_callback,
+                                                 .mem = NULL};
+
+void hvt_mem_size(size_t *mem_size)
+{
+    hvt_x86_mem_size(mem_size);
+}
+
+void hvt_mem_size_roundup(size_t *mem_size)
+{
+    size_t mem = ((*mem_size + X86_GUEST_PAGE_SIZE - 1) / X86_GUEST_PAGE_SIZE) *
+                 X86_GUEST_PAGE_SIZE;
+    if (mem > X86_GUEST_MAX_MEM_SIZE)
+        mem = X86_GUEST_MAX_MEM_SIZE;
+    *mem_size = mem;
+}
+
+static void set_seg(struct nvmm_x64_state_seg *seg, const struct x86_sreg *sreg)
+{
+    seg->selector = sreg->selector * 8;
+    seg->attrib.type = sreg->type;
+    seg->attrib.s = sreg->s;
+    seg->attrib.dpl = sreg->dpl;
+    seg->attrib.p = sreg->p;
+    seg->attrib.avl = sreg->avl;
+    seg->attrib.l = sreg->l;
+    seg->attrib.def = sreg->db;
+    seg->attrib.g = sreg->g;
+    seg->attrib.rsvd = sreg->unusable;
+    seg->limit = sreg->limit;
+    seg->base = sreg->base;
+}
+
+void hvt_vcpu_init(struct hvt *hvt, hvt_gpa_t gpa_ep)
+{
+    struct hvt_b *hvb = hvt->b;
+    struct nvmm_vcpu *vcpu = &hvb->vcpu;
+
+    hvt_x86_setup_gdt(hvt->mem);
+    hvt_x86_setup_pagetables(hvt->mem, hvt->mem_alloc_size);
+
+    if (nvmm_vcpu_getstate(&hvb->mach, vcpu, NVMM_X64_STATE_ALL) == -1)
+        err(EXIT_FAILURE, "unable to get VCPU state");
+
+    vcpu->state->crs[NVMM_X64_CR_CR0] = X86_CR0_INIT;
+    vcpu->state->crs[NVMM_X64_CR_CR3] = X86_CR3_INIT;
+    vcpu->state->crs[NVMM_X64_CR_CR4] = X86_CR4_INIT;
+    vcpu->state->msrs[NVMM_X64_MSR_EFER] = X86_EFER_INIT;
+    vcpu->state->gprs[NVMM_X64_GPR_RIP] = gpa_ep;
+    vcpu->state->gprs[NVMM_X64_GPR_RFLAGS] = X86_RFLAGS_INIT;
+    vcpu->state->gprs[NVMM_X64_GPR_RSP] = hvt->guest_mem_size - 8;
+    vcpu->state->gprs[NVMM_X64_GPR_RDI] = X86_BOOT_INFO_BASE;
+
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_CS], &hvt_x86_sreg_code);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_SS], &hvt_x86_sreg_data);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_DS], &hvt_x86_sreg_data);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_ES], &hvt_x86_sreg_data);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_FS], &hvt_x86_sreg_data);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_GS], &hvt_x86_sreg_data);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_TR], &hvt_x86_sreg_tr);
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_LDT], &hvt_x86_sreg_unusable);
+
+    const struct x86_sreg hvt_x86_sreg_gdt = {.base = X86_GDT_BASE,
+                                              .limit = X86_GDTR_LIMIT};
+    set_seg(&vcpu->state->segs[NVMM_X64_SEG_GDT], &hvt_x86_sreg_gdt);
+
+    nvmm_vcpu_setstate(&hvb->mach, vcpu, NVMM_X64_STATE_ALL);
+
+    uint64_t cpu_cycle_freq;
+    size_t outsz = sizeof(cpu_cycle_freq);
+    int ret =
+        sysctlbyname("hw.tsc_frequency", &cpu_cycle_freq, &outsz, NULL, 0);
+    if (ret == -1)
+        err(EXIT_FAILURE, "sysctl(hw.tsc_frequency)");
+    int invariant_tsc = 0;
+    outsz = sizeof(invariant_tsc);
+    ret = sysctlbyname("hw.tsc_invariant", &invariant_tsc, &outsz, NULL, 0);
+    if (ret == -1)
+        err(EXIT_FAILURE, "sysctl(hw.tsc_invariant");
+    if (invariant_tsc != 1)
+        errx(EXIT_FAILURE, "Host TSC is not invariant, cannot continue");
+    hvt->cpu_cycle_freq = cpu_cycle_freq;
+
+    hvt->cpu_boot_info_base = X86_BOOT_INFO_BASE;
+
+    // we need a global here for use within io_callback().
+    global_hvt = hvt;
+
+    if (nvmm_vcpu_configure(&hvb->mach, &hvb->vcpu, NVMM_VCPU_CONF_CALLBACKS,
+                            &callbacks) == -1)
+        err(EXIT_FAILURE, "nvmm_vcpu_configure");
+}
+
+int hvt_vcpu_loop(struct hvt *hvt)
+{
+    struct hvt_b *hvb = hvt->b;
+    struct nvmm_machine *mach = &hvb->mach;
+    struct nvmm_vcpu *vcpu = &hvb->vcpu;
+    int ret;
+
+    while (1) {
+        if (nvmm_vcpu_run(mach, vcpu) == -1)
+            err(EXIT_FAILURE, "unable to run VCPU");
+
+        /* Process the exit reasons. */
+        switch (vcpu->exit->reason) {
+        case NVMM_VCPU_EXIT_NONE:
+            break;
+        case NVMM_VCPU_EXIT_HALTED:
+            return 0;
+        case NVMM_VCPU_EXIT_IO:
+            ret = nvmm_assist_io(mach, vcpu);
+            if (ret == -1)
+                err(EXIT_FAILURE, "nvmm_assist_io");
+            if (halted)
+                return (exitcode);
+            continue;
+        default:
+            errx(EXIT_FAILURE, "unknown exit reason: 0x%lx",
+                 vcpu->exit->reason);
+        }
+    }
+    return 0;
+}

--- a/tenders/hvt/hvt_dumpcore_dragonfly_x86_64.c
+++ b/tenders/hvt/hvt_dumpcore_dragonfly_x86_64.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * hvt_dumpcore_dragonfly_x86_64.c: Glue between the dumpcore module and
+ * DragonFly (x86_64).
+ */
+
+int hvt_dumpcore_supported()
+{
+    return -1;
+}
+
+size_t hvt_dumpcore_prstatus_size(void)
+{
+    /* Not supported yet */
+    return 0;
+}
+
+int hvt_dumpcore_write_prstatus(int fd, struct hvt *hvt, void *cookie)
+{
+    /* Not supported yet */
+    return -1;
+}

--- a/tenders/hvt/hvt_gdb_dragonfly_x86_64.c
+++ b/tenders/hvt/hvt_gdb_dragonfly_x86_64.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * hvt_gdb_dragonfly_x86_64.c: glue between the GDB server (at
+ * hvt_modules_gdb.c) and DragonFly's nvmm.
+ */
+
+#include "hvt.h"
+#include "hvt_gdb_x86_64.h"
+#include "hvt_gdb.h"
+
+int hvt_gdb_supported(void)
+{
+    return -1;
+}
+
+int hvt_gdb_read_registers(struct hvt *hvt, uint8_t *registers, size_t *len)
+{
+    return -1;
+}
+
+int hvt_gdb_write_registers(struct hvt *hvt, uint8_t *registers, size_t len)
+{
+    return -1;
+}
+
+int hvt_gdb_enable_ss(struct hvt *hvt)
+{
+    return -1;
+}
+
+int hvt_gdb_disable_ss(struct hvt *hvt)
+{
+    return -1;
+}
+
+int hvt_gdb_read_last_signal(struct hvt *hvt, int *signal)
+{
+    return -1;
+}
+
+int hvt_gdb_add_breakpoint(struct hvt *hvt, uint32_t type, hvt_gpa_t addr,
+                           size_t len)
+{
+    return -1;
+}
+
+int hvt_gdb_remove_breakpoint(struct hvt *hvt, uint32_t type, hvt_gpa_t addr,
+                              size_t len)
+{
+    return -1;
+}

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -67,6 +67,12 @@ typedef char *host_mvec_t;
 #define EM_HOST EM_X86_64
 typedef unsigned char *host_mvec_t;
 
+#elif defined(__DragonFly__) && defined(__x86_64__)
+
+#include "hvt_dumpcore_dragonfly_x86_64.c"
+#define EM_HOST EM_X86_64
+typedef unsigned char *host_mvec_t;
+
 #elif defined(__linux__) && defined(__aarch64__)
 
 #include "hvt_dumpcore_kvm_aarch64.c"

--- a/tenders/hvt/hvt_module_gdb.c
+++ b/tenders/hvt/hvt_module_gdb.c
@@ -61,6 +61,10 @@
 
 #include "hvt_gdb_openbsd_x86_64.c"
 
+#elif defined(__DragonFly__) && defined(__x86_64__)
+
+#include "hvt_gdb_dragonfly_x86_64.c"
+
 #elif defined(__linux__) && defined(__aarch64__)
 
 #include "hvt_gdb_kvm_aarch64.c"

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -52,6 +52,8 @@
 #include "hvt_freebsd.h"
 #elif defined(__OpenBSD__)
 #include "hvt_openbsd.h"
+#elif defined(__DragonFly__)
+#include "hvt_dragonfly.h"
 #endif
 
 static bool module_in_use;
@@ -354,7 +356,7 @@ static void kill_net_pthread(struct hvt *hvt, int status, void *cookie)
         close(hvb->kick_net_efd);
         hvb->kick_net_efd = -1;
     }
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
     if (hvb->kick_net_pipe[1] != -1) {
         uint8_t byte = 1;
         (void)!write(hvb->kick_net_pipe[1], &byte, 1);
@@ -491,7 +493,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
             goto skip_ring;
         }
         notify_fd = efd;
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
         if (pipe(hvb->kick_net_pipe) == -1) {
             warn("pipe() failed, falling back to hypercalls");
             goto skip_ring;
@@ -516,7 +518,7 @@ static int setup(struct hvt *hvt, struct mft *mft)
 #if defined(__linux__)
             close(hvb->kick_net_efd);
             hvb->kick_net_efd = -1;
-#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
             close(hvb->kick_net_pipe[0]);
             close(hvb->kick_net_pipe[1]);
             hvb->kick_net_pipe[0] = -1;

--- a/toolchain/gen-headers.sh
+++ b/toolchain/gen-headers.sh
@@ -69,7 +69,7 @@ if CC=${CONFIG_TARGET_CC} cc_is_clang; then
     case ${CONFIG_HOST} in
         # The BSDs don't ship some standard headers that we need in Clang's
         # resource directory. Appropriate these from the host system.
-        FreeBSD|OpenBSD)
+        FreeBSD|OpenBSD|DragonFly)
             SRCDIR=/usr/include
             SRCS="float.h stddef.h stdint.h stdbool.h stdarg.h"
             [ "${CONFIG_HOST}" = "FreeBSD" ] && \
@@ -82,6 +82,7 @@ if CC=${CONFIG_TARGET_CC} cc_is_clang; then
             DESTDIR="$(readlink -f ${DESTDIR})"
             Q=
             [ "${CONFIG_HOST}" = "FreeBSD" ] && Q="--quiet"
+            [ "${CONFIG_HOST}" = "DragonFly" ] && Q="--quiet"
             (cd ${SRCDIR} && cpio ${Q} -Lpdm ${DESTDIR} <${DEPS}) || \
                 die "Failure copying host headers"
             rm ${DEPS}


### PR DESCRIPTION
nvmm(4) is NetBSD's Virtual Machine Monitor which we ported to DragonFly BSD.

It should be trivial to port this further to NetBSD.

This only builds with clang (e.g. "pkg ins llvm18") and not with the gcc from base.

To build, I used:

    env TARGET_CC=clang18 TARGET_LD=ld.lld18 sh configure.sh
    gmake