### PR TITLE
Support cross-building aarch64 unikernels on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,19 @@
+name: macOS
+on: [push, pull_request]
+jobs:
+  Build:
+    name: ARM64
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: brew install llvm lld
+      - name: Build
+        run: |
+          export PATH="$(brew --prefix llvm)/bin:$PATH"
+          env TARGET_CC="clang -target aarch64-linux-gnu" \
+            TARGET_LD=ld.lld TARGET_OBJCOPY=llvm-objcopy \
+            ./configure.sh --prefix="$PWD/_install"
+          make V=1
+          make V=1 install

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,6 +32,9 @@ tests: bindings elftool
 .PHONY: build
 ifdef CONFIG_DISABLE_TOOLCHAIN
 build: elftool tenders
+else ifeq ($(CONFIG_HOST),Darwin)
+# macOS builds only the cross toolchain + bindings (tenders/elftool are Linux/BSD-only).
+build: toolchain bindings
 else
 build: $(SUBDIRS)
 endif
@@ -184,6 +187,8 @@ endif
 install: MAKECMDGOALS :=
 ifdef CONFIG_DISABLE_TOOLCHAIN
 install: install-tools install-tenders
+else ifeq ($(CONFIG_HOST),Darwin)
+install: install-headers install-toolchain
 else
 install: install-tools install-tenders install-headers install-toolchain
 endif

--- a/configure.sh
+++ b/configure.sh
@@ -313,6 +313,13 @@ case ${HOST_CC_MACHINE} in
             echo "#undef HAVE_VMM_H" >tenders/hvt/hvt_openbsd_config.h
         fi
         ;;
+    arm64-*darwin*|aarch64-*darwin*)
+        CONFIG_HOST_ARCH=aarch64 CONFIG_HOST=Darwin
+        [ -z "${TARGET_CC}" ] && \
+            die "macOS host requires an ELF cross toolchain: set TARGET_CC" \
+                "(e.g. TARGET_CC='clang -target aarch64-linux-gnu')," \
+                "TARGET_LD and TARGET_OBJCOPY"
+        ;;
     *)
         die "Unsupported host toolchain: ${HOST_CC_MACHINE}"
         ;;
@@ -525,6 +532,24 @@ case ${CONFIG_HOST} in
                 die "gcc 9+ or clang required on DragonFly"
             fi
         fi
+        ;;
+    Darwin)
+        # llvm-objcopy is keg-only / off PATH on macOS; pin its absolute path.
+        TARGET_LD="${TARGET_LD:-ld.lld}"
+        TARGET_OBJCOPY="${TARGET_OBJCOPY:-llvm-objcopy}"
+        if ! command -v "${TARGET_OBJCOPY}" >/dev/null 2>&1; then
+            for _llvmbin in \
+                "$(command -v brew >/dev/null 2>&1 && brew --prefix llvm 2>/dev/null)/bin" \
+                /opt/homebrew/opt/llvm/bin /usr/local/opt/llvm/bin \
+                /opt/local/libexec/llvm-*/bin; do
+                if [ -x "${_llvmbin}/${TARGET_OBJCOPY}" ]; then
+                    TARGET_OBJCOPY="${_llvmbin}/${TARGET_OBJCOPY}"
+                    break
+                fi
+            done
+            unset _llvmbin
+        fi
+        TARGET_CC_LDFLAGS="-Wl,--build-id=none,-no-pie"
         ;;
     *)
         die "Unsupported host system: ${CONFIG_HOST}"

--- a/opam/solo5-cross-aarch64.opam
+++ b/opam/solo5-cross-aarch64.opam
@@ -10,14 +10,18 @@ bug-reports: "https://github.com/solo5/solo5/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [
-  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"] {os != "macos"}
+  ["env" "TARGET_CC=clang -target aarch64-linux-gnu" "TARGET_LD=ld.lld" "TARGET_OBJCOPY=llvm-objcopy" "./configure.sh" "--prefix=%{prefix}%"] {os = "macos"}
   [make "V=1"]
 ]
-install: [make "V=1" "install-toolchain"]
+install: [
+  [make "V=1" "install-toolchain"]
+  [make "V=1" "install-headers"] {os = "macos"}
+]
 depends: [
   "conf-pkg-config" {build & os = "linux"}
   "conf-libseccomp" {build & os = "linux"}
-  "solo5" {= version}
+  "solo5" {= version & os != "macos"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}
@@ -25,10 +29,11 @@ depexts: [
   ["kernel-headers"] {os-distribution = "rhel"}
   ["linux-libc-dev"] {os-family = "debian"}
   ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+  ["llvm" "lld"] {os = "macos" & os-distribution = "homebrew"}
 ]
 available: [
-  (arch != "arm64") &
-  (os = "linux" & os-family = "debian")
+  ((arch != "arm64") & (os = "linux" & os-family = "debian"))
+  | (os = "macos" & arch = "arm64")
 ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """


### PR DESCRIPTION
I'd like to build aarch64 Solo5/MirageOS unikernels on an Apple Silicon Mac, instead of going through a Linux VM.

This adds a Darwin case to `configure.sh` that builds the target toolchain and bindings with clang, `ld.lld` and `llvm-objcopy`, so `solo5-cross-aarch64` installs on macos/arm64. It declares the `llvm` and `lld` depexts, and a CI job builds it on every push.

The toolchain is pure LLVM: no libgcc is bundled. The downstream unikernel link needs none. clang inlines the aarch64 atomics, and once ocaml-solo5's nolibc stopped pulling long double soft-float (mirage/ocaml-solo5#171), the toolchain wrapper stopped passing `-lgcc`. I verified it by building a full aarch64 cross-compiler and linking a unikernel on macOS with no libgcc present.

The rest of the stack:
- mirage/ocaml-solo5#171 builds the aarch64 cross-compiler on macOS
- mirage/ocaml-gmp#29 installs a relocatable `gmp.pc`
- mirage/ocaml-gmp#30 archives `libgmp.a` with the cross `ar`/`ranlib`
- ocaml/Zarith#173 honours the `OCAML*` environment variables in configure
