### PR TITLE
Stamp version.h from $SOLO5_VERSION for tarball pins

### DIFF
--- a/opam/solo5-cross-aarch64.opam
+++ b/opam/solo5-cross-aarch64.opam
@@ -11,9 +11,9 @@ license: "ISC"
 dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [
   ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
-  [make "V=1"]
+  ["env" "SOLO5_VERSION=%{version}%" make "V=1"]
 ]
-install: [make "V=1" "install-toolchain"]
+install: ["env" "SOLO5_VERSION=%{version}%" make "V=1" "install-toolchain"]
 depends: [
   "conf-pkg-config" {build & os = "linux"}
   "conf-libseccomp" {build & os = "linux"}

--- a/opam/solo5.opam
+++ b/opam/solo5.opam
@@ -11,9 +11,9 @@ license: "ISC"
 dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [
   ["./configure.sh" "--prefix=%{prefix}%"]
-  [make "V=1"]
+  ["env" "SOLO5_VERSION=%{version}%" make "V=1"]
 ]
-install: [make "V=1" "install"]
+install: ["env" "SOLO5_VERSION=%{version}%" make "V=1" "install"]
 depends: [
   "conf-pkg-config" {build & os = "linux"}
   "conf-libseccomp" {build & os = "linux"}

--- a/scripts/gen_version_h.sh
+++ b/scripts/gen_version_h.sh
@@ -10,21 +10,22 @@ die ()
 [ $# -ne 1 ] && exit 1
 VERSION_H="$1"
 
-# If we are being run from a release tarball, then a version.h.distrib must
-# be present, and we always use that as our source of truth. Allow ./.git
-# to be a file to support git worktrees.
-if [ ! -d "./.git" -a ! -f "./.git" ]; then
-    if [ ! -f "${VERSION_H}.distrib" ]; then
-	die "${VERSION_H}.distrib: Not found, and we are not in a Git tree"
-    fi
+# Determine the version, in order of precedence:
+#   1. "git describe" in a real checkout (allow ./.git to be a file for worktrees)
+#   2. version.h.distrib shipped in a release tarball
+#   3. $SOLO5_VERSION for an exported snapshot (e.g. an opam tarball pin) that has
+#      neither a Git tree nor a version.h.distrib
+if [ -d "./.git" -o -f "./.git" ]; then
+    VERSION="$(git -C . describe --dirty --tags --always)" ||
+	die "Could not determine Git version"
+elif [ -f "${VERSION_H}.distrib" ]; then
     cp "${VERSION_H}.distrib" "${VERSION_H}" || die
     exit 0
+elif [ -n "${SOLO5_VERSION}" ]; then
+    VERSION="${SOLO5_VERSION}"
+else
+    die "not a Git tree, ${VERSION_H}.distrib not found, and SOLO5_VERSION unset"
 fi
-
-# Otherwise, use "git describe" to get the exact version of this tree, and
-# generate a version.h from it.
-GIT_VERSION="$(git -C . describe --dirty --tags --always)" ||
-    die "Could not determine Git version"
 
 cat <<EOM >${VERSION_H}.tmp || die
 /* Automatically generated, do not edit */
@@ -32,12 +33,12 @@ cat <<EOM >${VERSION_H}.tmp || die
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define SOLO5_VERSION "${GIT_VERSION}"
+#define SOLO5_VERSION "${VERSION}"
 
 #endif
 EOM
 
-# Only touch the target file if it does not exist yet or Git version differs.
+# Only touch the target file if it does not exist yet or the version differs.
 if [ -f ${VERSION_H} ] && diff -q ${VERSION_H} ${VERSION_H}.tmp >/dev/null; then
     rm ${VERSION_H}.tmp || die
 else


### PR DESCRIPTION
`gen_version_h.sh` needs a version string when `.git` is absent. Today the only fallback is `version.h.distrib`, shipped in a `make distrib` release tarball. An opam tarball pin (or any exported git snapshot, e.g. a GitHub codeload archive) has neither a Git tree nor a `version.h.distrib`, so the build fails at `gen_version_h.sh`.

This PR adds `$SOLO5_VERSION` as a third source, after `git describe` and `version.h.distrib`, and passes it from the opam files as `%{version}%`. So `opam pin add solo5 <tarball>` and an opam-repository release from a codeload archive both build without a Git tree.

The macOS cross-build PR #641 carries this as a temporary commit so its CI can tar-pin solo5; that commit drops once this lands.
