### PR TITLE
Apply HVT_DROP_PRIVILEGES=0 on solo5-hvt-debug's objects

### DIFF
--- a/tenders/GNUmakefile
+++ b/tenders/GNUmakefile
@@ -44,11 +44,18 @@ all_TARGETS += $(common_LIB)
 %.o: %.c %.d
 	$(HOSTCOMPILE.c)
 
+%.debug.o: %.c %.debug.d
+	$(HOSTCOMPILE.c)
+
 %.o: %.S %.d
 	$(HOSTCOMPILE.S)
 
+%.debug.o: %.debug.S %.debug.d
+	$(HOSTCOMPILE.S)
+
 %.d: ;
-.PRECIOUS: %.d
+%.debug.d: ;
+.PRECIOUS: %.d %.debug.d
 
 endif
 
@@ -83,15 +90,23 @@ else ifeq ($(CONFIG_HOST), OpenBSD)
     HOSTLDLIBS += -lpthread
 endif
 
+# NOTE(dinosaure): here, we construct solo5-hvt with *.o objects and
+# solo5-hvt-debug with *.debug.o objects. By this way, we are able to apply
+# certain rules only on solo5-hvt-debug's objects such as HVT_DROP_PRIVILEGES=0
+
 hvt_SRCS += $(patsubst %,hvt/hvt_module_%.c,$(hvt_MODULES))
+hvt_debug_SRCS := $(hvt_SRCS)
 hvt_debug_SRCS += $(patsubst %,hvt/hvt_module_%.c,$(hvt_debug_MODULES))
 hvt_OBJS := $(patsubst %.c,%.o,$(hvt_SRCS))
-hvt_debug_OBJS := $(patsubst %.c,%.o,$(hvt_debug_SRCS))
+hvt_debug_OBJS := $(patsubst %.c,%.debug.o,$(hvt_debug_SRCS))
+
+$(hvt_debug_OBJS): HOSTCFLAGS += -DHVT_DROP_PRIVILEGES=0
+hvt/solo5-hvt-debug: HOSTCFLAGS += -DHVT_DROP_PRIVILEGES=0
 
 hvt/solo5-hvt: $(hvt_OBJS) $(common_LIB)
 	$(HOSTLINK)
 
-hvt/solo5-hvt-debug: $(hvt_OBJS) $(hvt_debug_OBJS) $(common_LIB)
+hvt/solo5-hvt-debug: $(hvt_debug_OBJS) $(common_LIB)
 	$(HOSTLINK)
 
 endif # CONFIG_HVT_TENDER

--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -41,7 +41,7 @@
 /*
  * HVT_DROP_PRIVILEGES (1) enables the function hvt_drop_privileges
  * please see hvt_drop_privileges for more information
- * HCT_DROP_PRIVILEGES would be disabled in a debugging scenario
+ * HVT_DROP_PRIVILEGES would be disabled in a debugging scenario
  * where the hvt has to create/modify files outside it normal operating domain
  */
 #ifndef HVT_DROP_PRIVILEGES
@@ -136,7 +136,7 @@ void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
 int hvt_guest_mprotect(void *t_arg, uint64_t addr_start, uint64_t addr_end,
                        int prot);
 
-#if HVT_DROP_PRIVILEGES
+#if defined(HVT_DROP_PRIVILEGES) && HVT_DROP_PRIVILEGES == 1
 /*
  * Drop privileges. This function is called by the tender before entering the
  * VCPU loop, after guest memory has been set up and all host resources have

--- a/tenders/hvt/hvt_freebsd.c
+++ b/tenders/hvt/hvt_freebsd.c
@@ -192,7 +192,7 @@ struct hvt *hvt_init(size_t mem_size)
     return hvt;
 }
 
-#if HVT_DROP_PRIVILEGES
+#if defined(HVT_DROP_PRIVILEGES) && HVT_DROP_PRIVILEGES == 1
 void hvt_drop_privileges()
 {
 #if HVT_FREEBSD_ENABLE_CAPSICUM

--- a/tenders/hvt/hvt_kvm.c
+++ b/tenders/hvt/hvt_kvm.c
@@ -117,7 +117,7 @@ struct hvt *hvt_init(size_t mem_size)
     return hvt;
 }
 
-#if HVT_DROP_PRIVILEGES
+#if defined(HVT_DROP_PRIVILEGES) && HVT_DROP_PRIVILEGES == 1
 void hvt_drop_privileges()
 {
     /*

--- a/tenders/hvt/hvt_main.c
+++ b/tenders/hvt/hvt_main.c
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
 
     hvt_boot_info_init(hvt, gpa_kend, argc, argv, mft, mft_size);
 
-#if HVT_DROP_PRIVILEGES
+#if defined(HVT_DROP_PRIVILEGES) && HVT_DROP_PRIVILEGES == 1
     hvt_drop_privileges();
 #else
     warnx("WARNING: Tender is configured with HVT_DROP_PRIVILEGES=0. Not"

--- a/tenders/hvt/hvt_openbsd.c
+++ b/tenders/hvt/hvt_openbsd.c
@@ -153,7 +153,7 @@ struct hvt *hvt_init(size_t mem_size)
     return hvt;
 }
 
-#if HVT_DROP_PRIVILEGES
+#if defined(HVT_DROP_PRIVILEGES) && HVT_DROP_PRIVILEGES == 1
 void hvt_drop_privileges()
 {
     struct passwd *pw = getpwnam(VMD_USER);


### PR DESCRIPTION
The purpose of solo5-hvt-debug is only for debug and we don't need to drop privileges when we would like to run a HVT unikernel (solo5-hvt-debug interacts with multiple things if we take into account dumpcore and gdb). This commit splits the way to build solo5-hvt-debug and apply -DHVT_DROP_PRIVILEGES=0 on sources. By this way, only solo5-hvt drops privileges.