### PR TITLE
Verify that we have, at least, GCC 10 to compile Solo5

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -262,15 +262,18 @@ HOST_CC_MACHINE=$(${HOST_CC} -dumpmachine)
     die "Could not run '${HOST_CC} -dumpmachine', is your compiler working?"
 echo "${prog_NAME}: Using ${HOST_CC} for host compiler (${HOST_CC_MACHINE})"
 
+cc_version=$(${HOST_CC} -dumpversion)
+cc_major=$(echo "$cc_version" | cut -d '.' -f 1)
+if [ -z "$cc_major" ]; then
+    die "Impossible to recognize the version of cc: ${cc_version}"
+fi
 if CC="${HOST_CC}" cc_is_gcc; then
-    gcc_version=$(${HOST_CC} --version | sed 1q)
-    major=$(echo "$gcc_version" | sed -n 's/.*(.*) \([0-9]\+\).*/\1/p')
-    if [ -z "$major" ]; then
-        die "Impossible to recognize the version of GCC: ${gcc_version}"
-    fi
-
-    if [ "$major" -lt 9 ]; then
+    if [ "$cc_major" -lt 9 ]; then
         die "GCC 9 (or later) is required"
+    fi
+else # cc is clang
+    if [ "$cc_major" -lt 10 ]; then
+        die "clang 10 (or later) is required"
     fi
 fi
 

--- a/configure.sh
+++ b/configure.sh
@@ -262,6 +262,18 @@ HOST_CC_MACHINE=$(${HOST_CC} -dumpmachine)
     die "Could not run '${HOST_CC} -dumpmachine', is your compiler working?"
 echo "${prog_NAME}: Using ${HOST_CC} for host compiler (${HOST_CC_MACHINE})"
 
+if CC="${HOST_CC}" cc_is_gcc; then
+    gcc_version=$(${HOST_CC} --version | sed 1q)
+    major=$(echo "$gcc_version" | sed -n 's/.*(.*) \([0-9]\+\).*/\1/p')
+    if [ -z "$major" ]; then
+        die "Impossible to recognize the version of GCC: ${gcc_version}"
+    fi
+
+    if [ "$major" -lt 10 ]; then
+        die "GCC 10 (or later) is required"
+    fi
+fi
+
 CONFIG_SPT_TENDER=
 CONFIG_HVT_TENDER=
 case ${HOST_CC_MACHINE} in

--- a/configure.sh
+++ b/configure.sh
@@ -269,8 +269,8 @@ if CC="${HOST_CC}" cc_is_gcc; then
         die "Impossible to recognize the version of GCC: ${gcc_version}"
     fi
 
-    if [ "$major" -lt 10 ]; then
-        die "GCC 10 (or later) is required"
+    if [ "$major" -lt 9 ]; then
+        die "GCC 9 (or later) is required"
     fi
 fi
 


### PR DESCRIPTION
Our `configure.sh` will fail if we don't have GCC 10. Spotted by #576 and #640 also. /cc @mneumann can you confirm that GCC 10 is available on DragonFly (and update your PR to install it instead of GCC 9)? We also should do the same for Clang (and verify that we have, at least, Clang 8) but we can do that later (and in another PR).