### PR TITLE
Use a clean GIT_VERSION value instead of generating one from a Git source tree which was updated (we deleted the -Werror)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,7 +51,7 @@ gen-version-h:
 
 distrib-gen-version-h:
 	@echo "GEN $(VERSION_H).distrib"
-	scripts/gen_version_h.sh $(VERSION_H).distrib
+	GIT_VERSION="$(GIT_VERSION)" scripts/gen_version_h.sh $(VERSION_H).distrib
 
 delete-werror:
 	sed -i -e 's/-Werror//g' Makefile.common

--- a/scripts/gen_version_h.sh
+++ b/scripts/gen_version_h.sh
@@ -22,8 +22,8 @@ if [ ! -d "./.git" -a ! -f "./.git" ]; then
 fi
 
 # Otherwise, use "git describe" to get the exact version of this tree, and
-# generate a version.h from it.
-GIT_VERSION="$(git -C . describe --dirty --tags --always)" ||
+# generate a version.h from it. Take a pre-set GIT_VERSION if it exists.
+GIT_VERSION="${GIT_VERSION:-$(git -C . describe --dirty --tags --always)}" ||
     die "Could not determine Git version"
 
 cat <<EOM >${VERSION_H}.tmp || die


### PR DESCRIPTION
In the release path, we take everything and delete the -Werror argument into the Makefile.common (which is tracked by Git). The GIT_VERSION results with a `-dirty` suffix. This patch permits to pass a clean GIT_VERSION regardless some changes.

/cc @hannesm

Noticed on the last release, `solo5-hvt` shows me `v0.11.0-dirty`.