### PR TITLE
Discard the unused .eh_frame unwind tables

### DIFF
--- a/bindings/solo5_hvt.lds
+++ b/bindings/solo5_hvt.lds
@@ -93,10 +93,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     } :rodata
-    .eh_frame :
-    {
-        *(.eh_frame)
-    }
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
@@ -154,6 +150,10 @@ SECTIONS {
        toolchain might generate to prevent any surprises in the final layout. */
     /DISCARD/ : {
         *(.note.gnu.*)
+        /* Nothing in a unikernel unwinds through DWARF; drop the unused
+           .eh_frame tables instead of mapping ~0.5 MiB into every image. */
+        *(.eh_frame)
+        *(.eh_frame_hdr)
     }
 
     _ltdata = _edata - _stdata;

--- a/bindings/solo5_muen.lds
+++ b/bindings/solo5_muen.lds
@@ -92,10 +92,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     } :rodata
-    .eh_frame :
-    {
-        *(.eh_frame)
-    }
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
@@ -153,6 +149,10 @@ SECTIONS {
        toolchain might generate to prevent any surprises in the final layout. */
     /DISCARD/ : {
         *(.note.gnu.*)
+        /* Nothing in a unikernel unwinds through DWARF; drop the unused
+           .eh_frame tables instead of mapping ~0.5 MiB into every image. */
+        *(.eh_frame)
+        *(.eh_frame_hdr)
     }
 
     _ltdata = SIZEOF(.tdata);

--- a/bindings/solo5_spt.lds
+++ b/bindings/solo5_spt.lds
@@ -91,10 +91,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     } :text
-    .eh_frame :
-    {
-        *(.eh_frame)
-    }
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
@@ -152,6 +148,10 @@ SECTIONS {
        toolchain might generate to prevent any surprises in the final layout. */
     /DISCARD/ : {
         *(.note.gnu.*)
+        /* Nothing in a unikernel unwinds through DWARF; drop the unused
+           .eh_frame tables instead of mapping ~0.5 MiB into every image. */
+        *(.eh_frame)
+        *(.eh_frame_hdr)
     }
 
     _ltdata = _edata - _stdata;

--- a/bindings/solo5_stub.lds
+++ b/bindings/solo5_stub.lds
@@ -91,10 +91,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     } :text
-    .eh_frame :
-    {
-        *(.eh_frame)
-    }
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
@@ -152,6 +148,10 @@ SECTIONS {
        toolchain might generate to prevent any surprises in the final layout. */
     /DISCARD/ : {
         *(.note.gnu.*)
+        /* Nothing in a unikernel unwinds through DWARF; drop the unused
+           .eh_frame tables instead of mapping ~0.5 MiB into every image. */
+        *(.eh_frame)
+        *(.eh_frame_hdr)
     }
 
     _ltdata = SIZEOF(.tdata);

--- a/bindings/solo5_virtio.lds
+++ b/bindings/solo5_virtio.lds
@@ -77,10 +77,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    .eh_frame :
-    {
-        *(.eh_frame)
-    }
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
@@ -153,6 +149,10 @@ SECTIONS {
        toolchain might generate to prevent any surprises in the final layout. */
     /DISCARD/ : {
         *(.note.gnu.*)
+        /* Nothing in a unikernel unwinds through DWARF; drop the unused
+           .eh_frame tables instead of mapping ~0.5 MiB into every image. */
+        *(.eh_frame)
+        *(.eh_frame_hdr)
     }
 
     _ltdata = _edata - _stdata;

--- a/bindings/solo5_xen.lds
+++ b/bindings/solo5_xen.lds
@@ -78,10 +78,6 @@ SECTIONS {
         *(.rodata)
         *(.rodata.*)
     }
-    .eh_frame :
-    {
-        *(.eh_frame)
-    }
 
     . = ALIGN(CONSTANT(MAXPAGESIZE));
     _erodata = .;
@@ -158,6 +154,10 @@ SECTIONS {
        toolchain might generate to prevent any surprises in the final layout. */
     /DISCARD/ : {
         *(.note.gnu.*)
+        /* Nothing in a unikernel unwinds through DWARF; drop the unused
+           .eh_frame tables instead of mapping ~0.5 MiB into every image. */
+        *(.eh_frame)
+        *(.eh_frame_hdr)
     }
 
     _ltdata = _edata - _stdata;


### PR DESCRIPTION
Every unikernel image maps `.eh_frame` and `.eh_frame_hdr`, but nothing in a Solo5 guest unwinds through them: the tenders don't, and the runtimes that target Solo5 (OCaml/MirageOS, freestanding C) either use their own unwinding or none at all. Because the sections are `SHF_ALLOC` they land in a `PT_LOAD` segment, so they are loaded into every image and `strip` cannot reclaim them.

This moves `.eh_frame`/`.eh_frame_hdr` to `/DISCARD/` in all six bindings' linker scripts, the same way the scripts already discard the GNU NOTEs. It removes about 0.5 MiB from every image: a hello-world unikernel drops from 1,2M to 600k, and larger images shrink by the same absolute amount.

A guest that genuinely relies on DWARF unwinding (C++ exceptions, Rust `panic=unwind`) would need these tables. If that is a use case worth keeping, I am happy to gate the discard behind an option instead.