### PR TITLE
Roundup the memory area for our ringbuffer when we have, at least, one net device

### DIFF
--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -104,9 +104,10 @@ void hvt_net_reserve_ring(struct hvt *hvt, struct mft *mft);
 void hvt_mem_size_roundup(size_t *mem_size);
 
 /*
- * Returns the extra guest memory needed for the network ring buffer, or 0 if
- * no NET_BASIC device is attached in the manifest. Must be called after
- * command-line parsing has set the attached flags.
+ * Returns the extra guest memory needed for the network ring buffer, rounded
+ * up to the architecture page boundary, or 0 if no NET_BASIC device is
+ * attached in the manifest. The return value is roundup on the system page.
+ * Must be called after command-line parsing has set the attached flags.
  */
 size_t hvt_net_mem_overhead(struct mft *mft);
 

--- a/tenders/hvt/hvt_boot_info.c
+++ b/tenders/hvt/hvt_boot_info.c
@@ -107,11 +107,11 @@ void hvt_boot_info_init(struct hvt *hvt, hvt_gpa_t gpa_kend, int cmdline_argc,
         if (ring_active) {
             bi->host_features |= HVT_FEATURE_RING_IO;
             bi->net_ring = hvb->net_ring_gpa;
-            /*
-             * Exclude the ring area from usable guest memory so the
-             * guest's heap allocator does not grow on it.
-             */
-            bi->mem_size = hvb->net_ring_gpa;
+            /* [hvt_net_reserve_ring] sets [guest_mem_size] (and,
+             * [bi->mem_size]) if we have a net device for our ringbuffer. We
+             * ensure here that the memory given to the unikernel does not
+             * include our ringbuffer. */
+            assert(bi->mem_size == hvb->net_ring_gpa);
         }
     }
 }

--- a/tenders/hvt/hvt_module_net.c
+++ b/tenders/hvt/hvt_module_net.c
@@ -64,32 +64,38 @@ static hvt_gpa_t reserved_ring_gpa;
 size_t hvt_net_mem_overhead(struct mft *mft)
 {
     for (unsigned i = 0; i != mft->entries; i++) {
-        if (mft->e[i].type == MFT_DEV_NET_BASIC && mft->e[i].attached)
-            return sizeof(struct hvt_ring);
+        if (mft->e[i].type == MFT_DEV_NET_BASIC && mft->e[i].attached) {
+            size_t overhead = sizeof(struct hvt_ring);
+            hvt_mem_size_roundup(&overhead);
+            return overhead;
+        }
     }
     return 0;
 }
 
 void hvt_net_reserve_ring(struct hvt *hvt, struct mft *mft)
 {
-    /* A ring is allocated only if there is at least one network interface
-     * listed in the manifest. The ring is then used by all interfaces. */
-    for (unsigned i = 0; i != mft->entries; i++) {
-        if (mft->e[i].type == MFT_DEV_NET_BASIC && mft->e[i].attached) {
-            size_t ring_size = sizeof(struct hvt_ring);
-            hvt_gpa_t gpa_ring = (hvt->guest_mem_size - ring_size) & ~0xFFFULL;
+    size_t reserve = hvt_net_mem_overhead(mft);
 
-            if (gpa_ring < 0x200000) {
-                warnx("Not enough guest memory for ring allocation");
-                return;
-            }
+    if (reserve == 0) /* no net devices */
+        return;
 
-            memset(hvt->mem + gpa_ring, 0, ring_size);
-            reserved_ring_gpa = gpa_ring;
-            hvt->guest_mem_size = gpa_ring;
-            return;
-        }
+    if (hvt->guest_mem_size < 2 * reserve) {
+        warnx("Not enough guest memory for ring allocation");
+        return;
     }
+
+    hvt_gpa_t gpa_ring = hvt->guest_mem_size - reserve;
+
+    /* NOTE(dinosaure): here, we set [reserved_ring_gpa] (see [setup]) and we
+     * reduce the [guest_mem_size] so that there is a shared memory area between
+     * the unikernel and the tender, which acts as the ring buffer for our
+     * network interfaces. [reserved] **must be** page-aligned (this is a
+     * prerequisite for [rumprun]).
+     */
+    memset(hvt->mem + gpa_ring, 0, sizeof(struct hvt_ring));
+    reserved_ring_gpa = gpa_ring;
+    hvt->guest_mem_size = gpa_ring;
 }
 
 static void hypercall_net_write(struct hvt *hvt, hvt_gpa_t gpa)


### PR DESCRIPTION
It seems that the memory given to the unikernel must be page-aligned. We roundup the needed memory for our ringbuffer and, by this way, we ensure to give a page-aligned memory area to the unikernel. It seems that it's a requirement for rumprun.

It should fix #659 