### PR TITLE
remove dead per module seccomp hook from hvt on linux

### DIFF
--- a/tenders/hvt/hvt.h
+++ b/tenders/hvt/hvt.h
@@ -206,16 +206,6 @@ struct hvt_module_ops {
     int (*setup)(struct hvt *hvt, struct mft *mft);
     int (*handle_cmdarg)(char *cmdarg, struct mft *mft);
     const char *(*usage)(void);
-#if defined(__linux__)
-    /*
-     * Add module-specific syscalls to the seccomp allowlist. Called from
-     * hvt_seccomp_apply() before the BPF filter is exported, so that
-     * debug-only modules (only linked into solo5-hvt-debug) don't widen
-     * the production filter. (ctx) is a scmp_filter_ctx; typed as void *
-     * here so hvt.h doesn't pull in <seccomp.h>.
-     */
-    void (*install_seccomp_rules)(void *ctx);
-#endif
 };
 
 struct hvt_module {

--- a/tenders/hvt/hvt_module_dumpcore.c
+++ b/tenders/hvt/hvt_module_dumpcore.c
@@ -40,10 +40,6 @@
 #include <stdio.h>
 #include <sys/uio.h>
 
-#if defined(__linux__)
-#include <seccomp.h>
-#endif
-
 #include "hvt.h"
 
 #if defined(__linux__) && defined(__x86_64__)
@@ -280,35 +276,5 @@ static int setup(struct hvt *hvt, struct mft *mft)
     return 0;
 }
 
-#if defined(__linux__)
-/*
- * Syscalls only dumpcore needs (on abort, when writing the core file).
- * Stays out of the production solo5-hvt filter because the module is only
- * linked into solo5-hvt-debug.
- */
-static void install_seccomp_rules(void *ctx)
-{
-    static const int allow[] = {
-        SCMP_SYS(getpid), /* core filename */
-        SCMP_SYS(openat), /* create core file */
-        SCMP_SYS(close), /* close fds */
-        SCMP_SYS(writev), /* ELF header */
-        SCMP_SYS(lseek), /* section offset */
-        SCMP_SYS(brk), /* asprintf heap */
-        SCMP_SYS(mmap), /* malloc(mvec) */
-        SCMP_SYS(munmap), /* free(mvec) */
-        SCMP_SYS(mincore), /* find mapped pages */
-    };
-    for (size_t i = 0; i < sizeof(allow) / sizeof(allow[0]); i++) {
-        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, allow[i], 0);
-        if (rc != 0)
-            errx(1, "dumpcore: seccomp_rule_add() failed: %s", strerror(-rc));
-    }
-}
-
-DECLARE_MODULE(dumpcore, .setup = setup, .handle_cmdarg = handle_cmdarg,
-               .usage = usage, .install_seccomp_rules = install_seccomp_rules)
-#else
 DECLARE_MODULE(dumpcore, .setup = setup, .handle_cmdarg = handle_cmdarg,
                .usage = usage)
-#endif

--- a/tenders/hvt/hvt_seccomp_linux.c
+++ b/tenders/hvt/hvt_seccomp_linux.c
@@ -43,9 +43,6 @@
 
 #include "hvt.h"
 
-extern struct hvt_module __start_modules;
-extern struct hvt_module __stop_modules;
-
 static inline int _memfd_create(const char *name, unsigned int flags)
 {
     return syscall(__NR_memfd_create, name, flags);
@@ -60,9 +57,8 @@ void hvt_seccomp_apply(void)
     /*
      * Syscalls the run loop actually needs. Everything else gets SIGSYS.
      * No argument matching yet, per-fd checks would be a nice follow up.
-     * Modules add their own syscalls below via install_seccomp_rules, so
-     * debug-only modules (dumpcore, gdb) don't widen this binary's
-     * filter unless they're linked in.
+     * Only solo5-hvt reaches this: solo5-hvt-debug is built with
+     * HVT_DROP_PRIVILEGES=0, so gdb and dumpcore run unsandboxed.
      */
     static const int allow[] = {
         SCMP_SYS(ioctl), /* KVM_RUN on vcpufd */
@@ -90,11 +86,6 @@ void hvt_seccomp_apply(void)
         rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, allow[i], 0);
         if (rc != 0)
             errx(1, "seccomp_rule_add() failed: %s", strerror(-rc));
-    }
-
-    for (struct hvt_module *m = &__start_modules; m < &__stop_modules; m++) {
-        if (m->ops.install_seccomp_rules)
-            m->ops.install_seccomp_rules(ctx);
     }
 
     /* memfd install: clean libseccomp up before arming the filter. */


### PR DESCRIPTION
Was reading the v0.12.0 changelog and hit the solo5-hvt-debug fix, [#644](https://github.com/Solo5/solo5/pull/644),  the crash fix for my seccomp work in [#638](https://github.com/Solo5/solo5/pull/638). Turns out the fix left some of my old code behind: the per-module seccomp hook and dumpcore's rules that used it, both dead since debug stopped sandboxing entirely.

Cleaned it up. solo5-hvt itself untouched, still sandboxed, still builds/runs/tests fine.
