### PR TITLE
configure.sh: pass -no-pie to the compiler driver, not ld

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -498,11 +498,12 @@ case ${CONFIG_HOST} in
         # which leads to linkers warning if it is enabled but the input section
         # is subsequently discarded.
         # The '-no-pie' exists because some Linux distributions
-        # (e.g. Alpine >= 3.23) package a GCC which passes '-pie' to ld even 
-        # when '-static' is present.
+        # (e.g. Alpine >= 3.23) package a GCC which passes '-pie' to ld even
+        # when '-static' is present. It is a driver flag, so it must stay
+        # outside the '-Wl,' list.
         TARGET_LD="${TARGET_LD:-ld}"
         TARGET_OBJCOPY="${TARGET_OBJCOPY:-objcopy}"
-        TARGET_CC_LDFLAGS="-Wl,--build-id=none,-no-pie"
+        TARGET_CC_LDFLAGS="-Wl,--build-id=none -no-pie"
         ;;
     FreeBSD)
         TARGET_LD="${TARGET_LD:-ld.lld}"


### PR DESCRIPTION
Follow-up to #629. `-no-pie` is a gcc driver flag, but it went in inside the `-Wl,` list, so ld gets it instead. Recent ld happens to accept it. GNU ld 2.35 doesn't, and parses it as `-n -o -pie`, which writes every unikernel to a file called `-pie` while make still exits 0.

Tested on ppc64le with ld 2.35, where this takes the build from no unikernels at all to all 24, and they run.